### PR TITLE
Fix final main guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @duriantaco

--- a/.github/main-branch-ruleset.json
+++ b/.github/main-branch-ruleset.json
@@ -1,0 +1,50 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Fast checks",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -1165,7 +1165,13 @@ def _resolve_same_turn_harness_action(  # noqa: PLR0913 - explicit turn boundary
     """Replace a known no-op selection before it consumes the current turn."""
     selected = dict(selected_action)
     if selected.get("action") == "final":
-        if not _hard_final_requirement_unmet(state):
+        if not _final_is_premature(
+            action=selected,
+            state=state,
+            turn=turn,
+            max_turns=max_turns,
+            settings=settings,
+        ):
             return selected, None
         fallback = _deterministic_harness_fallback(
             state=state,
@@ -2478,13 +2484,6 @@ def _proof_objective_completion_met(
     return (
         not _has_open_assessment_tasks(state)
         and not _has_executable_live_primitive_route(state, settings=settings)
-    )
-
-
-def _hard_final_requirement_unmet(state: AgentState) -> bool:
-    return (
-        _proof_count_requirement_unmet(state)
-        or pending_closure_obligation(state) is not None
     )
 
 

--- a/packages/ravage/tests/test_ai_agent_memory.py
+++ b/packages/ravage/tests/test_ai_agent_memory.py
@@ -6,6 +6,7 @@ from io import StringIO
 from typing import TYPE_CHECKING
 
 from ai_agent_fixtures import BRIEF_YAML, ScriptedModelClient, VulnerableOpenApiHttpClient
+from ravage.agent_core import ai_agent
 from ravage.agent_core.ai_agent import (
     AIWebAgentSettings,
     ChatMessage,
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
+    import pytest
     from ravage.model_core.providers import ResolvedModelRoute
 
 
@@ -32,7 +34,10 @@ class _CostlyScriptedModelClient(ScriptedModelClient):
         return ModelReply(content=reply.content, cost_usd=1.0)
 
 
-def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(tmp_path: Path) -> None:
+def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     memory_db = tmp_path / "memory.db"
     store = MemoryStore(memory_db)
     try:
@@ -63,6 +68,7 @@ def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(tmp_path:
     model = ScriptedModelClient(
         [{"action": "final", "args": {"summary": "done"}, "rationale": "done"}]
     )
+    monkeypatch.setattr(ai_agent, "_deterministic_harness_fallback", lambda **_kwargs: None)
 
     run_ai_web_agent(
         brief_path=brief_path,
@@ -75,6 +81,7 @@ def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(tmp_path:
             stdout=StringIO(),
             memory=MemoryRunSettings(mode="read", db_path=memory_db, min_confidence=0.0),
             memory_explicit=True,
+            max_turns=1,
         ),
     )
 
@@ -89,8 +96,8 @@ def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(tmp_path:
     )
     assert finished["audit_path"] == str(tmp_path / "run.db")
     assert finished["flag_objective"] is False
-    assert finished["status"] == "completed"
-    assert finished["termination_reason"] == "agent_final"
+    assert finished["status"] == "incomplete"
+    assert finished["termination_reason"] == "max_turns_reached"
     assert "report_path" not in finished
 
     first_request_text = "\n".join(message.content for message in model.messages_seen[0])
@@ -123,7 +130,6 @@ def test_ai_web_memory_write_stores_reflection_candidates_after_confirmed_eviden
                 "args": {"path": "/search", "param": "q"},
                 "rationale": "confirmed",
             },
-            {"action": "final", "args": {"summary": "done"}, "rationale": "done"},
             {
                 "memories": [
                     {
@@ -166,6 +172,7 @@ def test_ai_web_memory_write_stores_reflection_candidates_after_confirmed_eviden
             stdout=StringIO(),
             memory=MemoryRunSettings(mode="write", db_path=memory_db, min_confidence=0.0),
             memory_explicit=True,
+            max_turns=3,
         ),
     )
 
@@ -214,7 +221,6 @@ def test_retrieved_memory_cannot_bypass_evidence_gate(tmp_path: Path) -> None:
                 "args": {"path": "/search", "param": "q"},
                 "rationale": "try from memory",
             },
-            {"action": "final", "args": {"summary": "done"}, "rationale": "done"},
         ]
     )
 
@@ -229,6 +235,7 @@ def test_retrieved_memory_cannot_bypass_evidence_gate(tmp_path: Path) -> None:
             stdout=StringIO(),
             memory=MemoryRunSettings(mode="read", db_path=memory_db, min_confidence=0.0),
             memory_explicit=True,
+            max_turns=1,
         ),
     )
 
@@ -284,7 +291,6 @@ def test_ai_web_memory_records_model_provenance(tmp_path: Path) -> None:
                 "args": {"path": "/search", "param": "q"},
                 "rationale": "confirmed",
             },
-            {"action": "final", "args": {"summary": "done"}, "rationale": "done"},
             {
                 "memories": [
                     {
@@ -322,6 +328,7 @@ def test_ai_web_memory_records_model_provenance(tmp_path: Path) -> None:
             stdout=StringIO(),
             memory=MemoryRunSettings(mode="learn", db_path=memory_db, min_confidence=0.0),
             memory_explicit=True,
+            max_turns=3,
         ),
     )
 

--- a/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
+++ b/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
@@ -46,6 +46,27 @@ def test_premature_final_uses_open_surface_route_in_the_same_turn() -> None:
     assert selected["task_id"] == "surface-map"
 
 
+def test_injected_model_final_uses_open_surface_route_in_the_same_turn() -> None:
+    state = AgentState(turn=3)
+    state.surface["flag_objective"] = False
+    state.tasks = [_task("surface-map", priority=100)]
+    proposed = {"action": "final", "summary": "stop"}
+
+    selected, reason = _resolve_same_turn_harness_action(
+        state=state,
+        proposed_action=proposed,
+        selected_action=proposed,
+        turn=3,
+        max_turns=40,
+        settings=AIWebAgentSettings(),
+    )
+
+    assert reason == "premature_final_required_work_fallback"
+    assert selected["action"] == "run_probe"
+    assert selected["probe"] == "surface_map"
+    assert selected["task_id"] == "surface-map"
+
+
 def test_locked_primitive_precedes_a_higher_priority_open_recon_task() -> None:
     state = AgentState(turn=4)
     state.surface["flag_objective"] = False
@@ -134,6 +155,26 @@ def test_live_tier_one_primitive_prevents_synthesized_final() -> None:
 
     assert selected == proposed
     assert reason is None
+
+
+def test_injected_model_final_cannot_skip_a_live_primitive_route() -> None:
+    state = AgentState(turn=5)
+    state.surface["flag_objective"] = False
+    state.tasks = [_task("api-behavior", priority=100, status="done")]
+    state.primitives["jwt_observed"] = 5
+    proposed = {"action": "final", "summary": "stop"}
+
+    selected, reason = _resolve_same_turn_harness_action(
+        state=state,
+        proposed_action=proposed,
+        selected_action=proposed,
+        turn=5,
+        max_turns=40,
+        settings=AIWebAgentSettings(),
+    )
+
+    assert selected["action"] != "final"
+    assert reason == "premature_final_required_work_guard"
 
 
 def test_auth_unavailable_live_route_does_not_cost_an_extra_model_turn() -> None:

--- a/packages/ravage/tests/test_harness_trace.py
+++ b/packages/ravage/tests/test_harness_trace.py
@@ -4,6 +4,7 @@ import json
 from typing import TYPE_CHECKING
 
 from ai_agent_fixtures import BRIEF_YAML, ScriptedModelClient
+from ravage.agent_core import ai_agent
 from ravage.agent_core.agent_state import AgentState
 from ravage.agent_core.ai_agent import AIWebAgentSettings, run_ai_web_agent
 from ravage.agent_core.harness_trace import (
@@ -19,6 +20,8 @@ from ravage.agent_core.semantic_routes import semantic_action_fingerprint, seman
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 
 def test_harness_trace_redacts_secret_shaped_action_values() -> None:
@@ -248,7 +251,12 @@ def test_attempt_ledger_round_trips_without_entering_baseline_prompt_memory() ->
     assert marker not in str(build_planner_memory(restored))
 
 
-def test_agent_persists_one_attempt_record_per_executed_turn(tmp_path: Path) -> None:
+def test_agent_persists_one_attempt_record_per_executed_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(ai_agent, "_seed_recon", lambda **_kwargs: None)
+    monkeypatch.setattr(ai_agent, "refresh_mission_board", lambda *_args, **_kwargs: None)
     brief_path = tmp_path / "brief.yaml"
     brief_path.write_text(BRIEF_YAML, encoding="utf-8")
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

  - prevent injected model clients from finalizing while assessment tasks or live evidence routes remain
  - add `.github/CODEOWNERS`
  - add the declarative `main` branch ruleset configuration