### PR TITLE
fix(runtime): harden execution and model accountability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ does not remediate findings or deploy fixes.
 - Python 3.12
 - Git
 - macOS, Linux, or WSL
-- Docker only for containerized tools, XBEN, and integration tests
+- Docker for process-capable model-driven attacks, containerized tools, XBEN,
+  and integration tests
 - A provider API key only for model-driven commands
 
 The normal first scan needs no model key, browser, Docker daemon, or external
@@ -87,6 +88,20 @@ ravage attack ravage-brief.yaml --allow-paid-models --report
 <code>--allow-paid-models</code> is an explicit acknowledgement that the run
 can incur provider charges. Model selection, local providers, and reproducible
 profiles are documented in [Model providers](docs/model-providers.md).
+
+Unauthenticated process-capable attacks use Docker by default. Ravage never
+silently falls back to host execution. The explicit
+<code>--tool-runtime host</code> option runs model-selected shell and Python on
+your machine; use it only in a disposable localhost environment. Child
+processes receive a minimal environment without provider keys, but explicit
+host execution can still read files available to your user account.
+
+Hosted models receive the engagement brief, selected discovered state, prior
+findings, and tool observations that may include target response data. That
+information leaves your machine and is handled under the provider's terms and
+retention controls. Do not use a hosted route for sensitive customer or
+production data unless the engagement permits that disclosure. Use a local
+model route when target evidence must remain local.
 
 ## Authenticated testing
 

--- a/docs/ai-web-operator-guide.md
+++ b/docs/ai-web-operator-guide.md
@@ -254,9 +254,10 @@ ravage attack brief.yaml \
 The documented remote command uses native metered HTTP only. Whole-run low-noise
 mode disables bounded tool recon and all opaque process/browser-process schemas
 so every permitted target request shares the durable cap and sub-1-RPS pacing.
-Local attacks instead default to observe mode and `--tool-runtime host`; use
-`--tool-runtime auto` for local Docker fallback or `--tool-runtime docker` to
-require the image.
+Local attacks default to observe traffic mode and the Docker tool runtime.
+`--tool-runtime auto` is also Docker-only and never silently falls back to the
+host. `--tool-runtime host` is an explicit trusted-localhost opt-in that runs
+model-selected code with the operator's filesystem permissions.
 
 If the complete remote origin is authorized and the written ROE permits command,
 Python, scanner, or other process-backed work, prepare the tool image separately:
@@ -276,8 +277,8 @@ ravage attack brief.yaml \
   --report
 ```
 
-For a localhost run that deliberately uses Docker fallback, the corresponding
-tool-runtime selection is:
+For a localhost run that explicitly selects the Docker-only `auto` alias, the
+corresponding tool-runtime selection is:
 
 ```bash
 ravage attack examples/labs/ravage-acme-box/brief.yaml \

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -63,8 +63,15 @@ ravage xben \
 
 Run a no-spend preflight for a small selection:
 
+Enter the key without putting its value in shell history. Keep it exported only
+for the bounded preflight and run, then unset it:
+
 ```bash
-OPENAI_API_KEY=... \
+read -rsp "OpenAI API key: " OPENAI_API_KEY && printf '\n'
+export OPENAI_API_KEY
+```
+
+```bash
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/preflight \
@@ -89,7 +96,6 @@ MAPTA/AWE comparison profile.
 Run the same selected cases:
 
 ```bash
-OPENAI_API_KEY=... \
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/selected \
@@ -104,6 +110,10 @@ ravage xben \
   --max-model-requests-per-case 8 \
   --max-cost-usd 5 \
   --allow-paid-models
+```
+
+```bash
+unset OPENAI_API_KEY
 ```
 
 Useful selection flags:

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -11,7 +11,7 @@ Choose one path:
 
 | Your target | Use this path | Required tool runtime |
 | --- | --- | --- |
-| A development app on `localhost` or `127.0.0.1` | [Path 1: localhost](#path-1-test-a-localhost-development-app) | `host` when unauthenticated; managed HTTP when authenticated |
+| A development app on `localhost` or `127.0.0.1` | [Path 1: localhost](#path-1-test-a-localhost-development-app) | Docker by default; managed HTTP when authenticated; explicit `host` opt-in available |
 | An authorized staging or remote URL | [Path 2: authorized URL](#path-2-test-an-authorized-url) | Native metered HTTP by default; Docker only for an approved process lane |
 
 If the app requires login, use the [Authentication guide](authentication.md).
@@ -50,6 +50,13 @@ them.
 The primary examples below use OpenAI's hosted route and therefore spend model
 credits. The generated `.env.ravage` file is ignored by the normal `.env*`
 gitignore rule; still treat it as a secret and never commit it.
+
+Hosted routes send the engagement brief, selected discovered state, prior
+findings, and tool observations to the provider. Tool observations may contain
+target response data. Confirm that the engagement permits this data transfer
+and review the provider's retention terms before testing sensitive customer or
+production systems. Use a local provider when evidence must remain local;
+managed-secret redaction is not a general data-loss-prevention boundary.
 
 To use Anthropic, Ollama, or another configured route, keep the same target
 steps and change only the model setup described in
@@ -158,12 +165,14 @@ multiple identities requires it.
 Ravage finds `.env.ravage` beside the brief, loads model settings directly, and
 infers the configured hosted route. Do not shell-source the file. Authentication
 secrets are resolved through a separate file-over-process overlay and remain in
-the managed HTTP owner. For localhost, the default host tool runtime avoids a
-Docker dependency. In an unauthenticated run, model-selected tool commands run
-on your development machine, so use a disposable environment and keep the
-brief narrow. Command and Python lanes are blocked when an identity is active.
-Do not add `--authorized-remote-target`; that acknowledgement is for non-local
-targets only.
+the managed HTTP owner. An unauthenticated process-capable run defaults to
+Docker and never silently falls back to the host. The explicit
+`--tool-runtime host` option runs model-selected commands on your development
+machine; it receives a minimal environment without provider keys but can still
+read files available to your user account. Use that opt-in only in a disposable
+localhost environment. Command and Python lanes are blocked when an identity
+is active. Do not add `--authorized-remote-target`; that acknowledgement is for
+non-local targets only.
 
 Continue at [Read The Result](#read-the-result).
 
@@ -807,16 +816,16 @@ ravage attack ravage-brief.yaml \
   --resume \
   --model-profile hosted-openai \
   --model-tier low \
-  --tool-runtime host \
   --allow-paid-models \
   --report
 ```
 
-When resuming an authorized remote low-noise run, add
-`--authorized-remote-target` and remove `--tool-runtime host`; the native HTTP
-lane does not require an explicit runtime. A saved observe-mode process lane
-uses `--tool-runtime docker`. An authenticated remote resume keeps the same
-`--identity` and does not need Docker. Do not reuse an old
+This resumes with the safe Docker default. Add `--tool-runtime host` only when
+the original localhost run explicitly used that host opt-in. When resuming an
+authorized remote low-noise run, add `--authorized-remote-target`; the native
+HTTP lane does not require an explicit runtime. A saved observe-mode process
+lane uses `--tool-runtime docker`. An authenticated remote resume keeps the
+same `--identity` and does not need Docker. Do not reuse an old
 run directory for a fresh attack; leave `--run-dir` unset and let Ravage create
 a timestamped one. Deterministic scans do not use this attack-resume flow.
 For an `agent-graph` resume, Ravage reopens the same traffic session and reloads

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ claim. The external-agent scoreboard remains a future stage.
     <tbody>
       <tr>
         <td>Test a localhost app</td>
-        <td><code>ravage attack BRIEF.yaml --tool-runtime host</code></td>
+        <td><code>ravage attack BRIEF.yaml</code></td>
         <td><a href="{{ '/how-to-use.html' | relative_url }}#path-1-test-a-localhost-development-app">Localhost path</a></td>
       </tr>
       <tr>

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -22,6 +22,23 @@ shell-sourced. Check readiness before spending model calls:
 ravage doctor --workflow attack --brief brief.yaml
 ```
 
+Hosted providers receive model prompts containing the engagement brief,
+selected discovered state, prior findings, and tool observations. Those
+observations may include target response data. Confirm that the engagement
+permits that transfer and review the provider's data-retention terms. Use a
+local route when target evidence must remain on your machine.
+
+XBEN does not load a brief-adjacent environment file. Enter its hosted key
+without putting the value in shell history, export it only for the benchmark,
+and unset it afterwards:
+
+```bash
+read -rsp "OpenAI API key: " OPENAI_API_KEY && printf '\n'
+export OPENAI_API_KEY
+# run the bounded preflight and benchmark commands
+unset OPENAI_API_KEY
+```
+
 The older `ravage --print-model-routes` command is not an active public entry
 point in the current CLI. Use `doctor --workflow attack` for operator
 validation and inspect `examples/model_profiles.yaml` or
@@ -132,7 +149,13 @@ export RAVAGE_LITELLM_MID_MODEL=openai/gpt-5.4
 export LITELLM_BASE_URL=http://localhost:4000/v1
 ```
 
-Use:
+The built-in `universal-litellm` profile is intentionally unpriced because a
+LiteLLM model name does not prove which upstream deployment, markup, or billing
+policy the proxy uses. It therefore reports `ready=false` until you copy the
+route into a model config and provide explicit input, cached-input, and output
+prices. Use zero only for a deployment you operate and know is nonbillable.
+
+After pricing that route, use:
 
 ```text
 --model-profile universal-litellm --model-tier mid
@@ -142,9 +165,10 @@ Use:
 
 For `hosted-openai`:
 
-```bash
-export OPENAI_API_KEY=...
-export RAVAGE_OPENAI_MID_MODEL=gpt-5.4-2026-03-05
+```dotenv
+# .env.ravage
+OPENAI_API_KEY=your_key_here
+RAVAGE_OPENAI_MID_MODEL=gpt-5.4-2026-03-05
 ```
 
 Use:
@@ -162,17 +186,18 @@ or alias names. Those prices were verified on 2026-08-15 against the
 [official API pricing table](https://developers.openai.com/api/docs/pricing).
 For GPT-5.4 requests above 272,000 input tokens, Ravage automatically applies
 the published long-context rates.
-An unknown `RAVAGE_OPENAI_*_MODEL` override remains unpriced and paid agent
-replies fail closed; use a custom model config with current input, cached-input,
-and output prices when selecting another model.
+An unknown `RAVAGE_OPENAI_*_MODEL` override remains unpriced and is not ready,
+so Ravage rejects it before a paid request. Use a custom model config with
+current input, cached-input, and output prices when selecting another model.
 
 ## Native Anthropic Routes
 
 For `hosted-anthropic`:
 
-```bash
-export ANTHROPIC_API_KEY=...
-export RAVAGE_ANTHROPIC_MID_MODEL=claude-sonnet-4-6
+```dotenv
+# .env.ravage
+ANTHROPIC_API_KEY=your_key_here
+RAVAGE_ANTHROPIC_MID_MODEL=claude-sonnet-4-6
 ```
 
 Use:
@@ -184,6 +209,18 @@ Use:
 Ravage calls Anthropic's native Messages API directly with `x-api-key`,
 `anthropic-version: 2023-06-01`, and `POST /v1/messages`. Other providers use
 OpenAI-compatible chat completions unless routed through a custom gateway.
+
+The built-in tiers use active pinned or canonical Anthropic IDs: Opus 4.7
+(`claude-opus-4-7`), Sonnet 4.6 (`claude-sonnet-4-6`), and the pinned Haiku 4.5
+snapshot (`claude-haiku-4-5-20251001`). Ravage applies the published standard
+input, cache-read, and output rates of `$5/$0.50/$25`, `$3/$0.30/$15`, and
+`$1/$0.10/$5` per million tokens, respectively. These IDs and prices were
+verified on 2026-08-30 against Anthropic's [model-ID
+reference](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions),
+[lifecycle table](https://platform.claude.com/docs/en/about-claude/model-deprecations),
+and [pricing table](https://platform.claude.com/docs/en/about-claude/pricing).
+An unknown `RAVAGE_ANTHROPIC_*_MODEL` override is not ready until its prices are
+provided explicitly in a custom model config.
 
 ## Attack Example
 
@@ -209,12 +246,11 @@ ravage attack examples/labs/ravage-acme-box/brief.yaml \
 For hosted routes:
 
 ```bash
-OPENAI_API_KEY=... \
 ravage attack examples/labs/ravage-acme-box/brief.yaml \
   --model-profile hosted-openai \
   --model-tier low \
   --allow-paid-models \
-  --tool-runtime auto \
+  --tool-runtime docker \
   --memory off \
   --max-turns 18
 ```
@@ -225,7 +261,6 @@ Run preflight first. It writes `preflight.json` and does not call the
 model:
 
 ```bash
-OPENAI_API_KEY=... \
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/hosted-openai-preflight \
@@ -244,7 +279,6 @@ ravage xben \
 After inspecting preflight:
 
 ```bash
-OPENAI_API_KEY=... \
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/hosted-openai-canary \
@@ -263,7 +297,8 @@ ravage xben \
 To use Claude directly, swap the profile and key:
 
 ```bash
-ANTHROPIC_API_KEY=... \
+read -rsp "Anthropic API key: " ANTHROPIC_API_KEY && printf '\n'
+export ANTHROPIC_API_KEY
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/anthropic-preflight \
@@ -277,6 +312,7 @@ ravage xben \
   --max-model-requests-per-case 4 \
   --max-cost-usd 5 \
   --preflight
+unset ANTHROPIC_API_KEY
 ```
 
 ## Custom OpenAI-Compatible Endpoint
@@ -296,13 +332,15 @@ profiles:
           max_output_tokens: 1024
           output_token_limit_parameter: max_tokens
           input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
           output_cost_per_1m_tokens: 2.0
 ```
 
 Then use it:
 
 ```bash
-YOUR_API_KEY_ENV=... \
+read -rsp "Provider API key: " YOUR_API_KEY_ENV && printf '\n'
+export YOUR_API_KEY_ENV
 ravage xben \
   --benchmarks-root /path/to/xbow-validation-benchmarks/benchmarks \
   --output-dir runs/xben/remote-ci-canary \
@@ -313,38 +351,34 @@ ravage xben \
   --model-tier mid \
   --max-cost-usd 5 \
   --allow-paid-models
+unset YOUR_API_KEY_ENV
 ```
 
-Cost fields are optional, but `--max-cost-usd` can only be enforced when the
-selected paid-risk route includes both `input_cost_per_1m_tokens` and
-`output_cost_per_1m_tokens`. Use current prices from your provider dashboard.
+Paid-risk routes are ready only when `input_cost_per_1m_tokens`,
+`cached_input_cost_per_1m_tokens`, and `output_cost_per_1m_tokens` are all
+present. Use current prices from your provider dashboard. If the endpoint does
+not discount cached input, set its cached-input rate equal to its input rate.
 
 ## Supported Provider Kinds
 
-The model route config accepts these provider kinds:
+Provider kinds remain accepted by the route schema so external adapters can
+describe them, but only implemented transports can become ready for Ravage's
+built-in chat client:
 
-- `openai`
-- `anthropic`
-- `gemini`
-- `openrouter`
-- `litellm`
-- `ollama`
-- `lmstudio`
-- `llamacpp`
-- `vllm`
-- `custom_openai`
-- `azure`
-- `bedrock`
-- `vertex`
-- `groq`
-- `together`
-- `fireworks`
-- `mistral`
-- `deepseek`
+| Provider kind | Built-in direct transport | Required configuration |
+| --- | --- | --- |
+| `openai` | Yes, native OpenAI | Default native endpoint; use `custom_openai` for gateways |
+| `anthropic` | Yes, native Messages API | Default native endpoint; use LiteLLM for gateways |
+| `ollama`, `lmstudio`, `llamacpp`, `vllm` | Yes, OpenAI-compatible local | A reachable local endpoint |
+| `litellm` | Yes, OpenAI-compatible gateway | Gateway URL plus explicit pricing |
+| `custom_openai` | Yes, OpenAI-compatible gateway | Explicit `base_url` plus explicit pricing |
+| `gemini`, `openrouter`, `azure`, `bedrock`, `vertex` | No | Use a configured LiteLLM or `custom_openai` gateway |
+| `groq`, `together`, `fireworks`, `mistral`, `deepseek` | No | Use a configured LiteLLM or `custom_openai` gateway |
 
-Only providers with an implemented client can be called directly. Route
-provider-specific protocols through LiteLLM or a custom OpenAI-compatible
-gateway when direct support is not available in your checkout.
+Unsupported direct provider kinds report `ready=false`, even if credentials
+and pricing are present. The built-in client rejects them before constructing
+or sending an HTTP request, so a provider key cannot fall through to OpenAI's
+default endpoint.
 
 ## Troubleshooting
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -153,13 +153,15 @@ ravage tools check
 
 To preview the install plan without changing the machine, omit `--execute`.
 
-For the simplest localhost run, use `--tool-runtime host`; this avoids a Docker
-dependency but lets model-selected tool commands run on the development
-machine. Use a disposable environment and narrow scope. `--tool-runtime auto`
-adds Docker fallback coverage and therefore also requires a responsive Docker
-daemon. For an authorized remote run, omit the runtime in the default low-noise
-lane. Use `--traffic-policy observe --tool-runtime docker` only when the complete
-origin is authorized and the written ROE permits process/scanner execution.
+Unauthenticated process-capable attacks default to Docker. `--tool-runtime
+auto` is Docker-only and never falls back to host execution. The explicit
+`--tool-runtime host` option avoids a Docker dependency for a trusted localhost
+target but lets model-selected code read files available to your user account;
+its child environment excludes provider keys and arbitrary parent variables.
+Use that opt-in only in a disposable environment with narrow scope. For an
+authorized remote run, omit the runtime in the default low-noise lane. Use
+`--traffic-policy observe --tool-runtime docker` only when the complete origin
+is authorized and the written ROE permits process/scanner execution.
 
 ## Doctor Workflows
 

--- a/docs/xben-comparison-runbook.md
+++ b/docs/xben-comparison-runbook.md
@@ -55,7 +55,9 @@ canary. Set `XBEN_ROOT` to a clean checkout of the benchmark repository:
 
 ```bash
 export XBEN_ROOT=/path/to/validation-benchmarks/benchmarks
-OPENAI_API_KEY=... ravage xben \
+read -rsp "OpenAI API key: " OPENAI_API_KEY && printf '\n'
+export OPENAI_API_KEY
+ravage xben \
   --benchmarks-root "$XBEN_ROOT" \
   --output-dir runs/xben/description-only-canary \
   --ids XBEN-005-24 XBEN-030-24 \
@@ -82,7 +84,7 @@ Stop if preflight reports `blocked=true`. Fix the block before running.
 After preflight passes, rerun the same command without `--preflight`:
 
 ```bash
-OPENAI_API_KEY=... ravage xben \
+ravage xben \
   --benchmarks-root "$XBEN_ROOT" \
   --output-dir runs/xben/description-only-canary-run \
   --ids XBEN-005-24 XBEN-030-24 \
@@ -99,6 +101,10 @@ OPENAI_API_KEY=... ravage xben \
   --max-cost-usd 20 \
   --allow-paid-models \
   --concurrency 1
+```
+
+```bash
+unset OPENAI_API_KEY
 ```
 
 For a full clean score, follow the

--- a/examples/model_profiles.yaml
+++ b/examples/model_profiles.yaml
@@ -109,7 +109,7 @@ profiles:
           max_output_tokens: 4096
       low:
         - provider: anthropic
-          model: ${RAVAGE_ANTHROPIC_LOW_MODEL:claude-haiku-4-5}
+          model: ${RAVAGE_ANTHROPIC_LOW_MODEL:claude-haiku-4-5-20251001}
           api_key_env: ANTHROPIC_API_KEY
           max_output_tokens: 4096
 

--- a/packages/ravage/README.md
+++ b/packages/ravage/README.md
@@ -48,6 +48,17 @@ Ravage loads `.env.ravage` beside the brief directly and infers a configured
 hosted route; do not shell-source the file. Use `--env-file`,
 `--model-profile`, or `--model-tier` only when overriding those defaults.
 
+Unauthenticated process-capable attacks use Docker by default and never
+silently fall back to host execution. `--tool-runtime host` is an explicit
+trusted-localhost opt-in that runs model-selected code with your filesystem
+permissions. Its child environment excludes provider keys, but it is not a
+filesystem sandbox.
+
+Hosted providers receive the engagement brief, selected discovered state,
+prior findings, and tool observations that may include target response data.
+Confirm that the engagement permits that transfer and review provider retention
+terms. Use a local model route when evidence must remain local.
+
 Inspect and verify a run:
 
 ```bash

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -3168,7 +3168,7 @@ def _create_init_files(
             "ANTHROPIC_API_KEY=\n"
             "RAVAGE_OPENAI_LOW_MODEL=gpt-5.4-mini-2026-03-17\n"
             "RAVAGE_OPENAI_MID_MODEL=gpt-5.4-2026-03-05\n"
-            "RAVAGE_ANTHROPIC_LOW_MODEL=claude-haiku-4-5\n"
+            "RAVAGE_ANTHROPIC_LOW_MODEL=claude-haiku-4-5-20251001\n"
             "RAVAGE_ANTHROPIC_MID_MODEL=claude-sonnet-4-6\n"
         )
     )
@@ -3664,11 +3664,36 @@ def _setup_model_check(
         }
     missing = sorted({env for route in routes for env in route.missing_env})
     location = f" in {env_file}" if env_file is not None else ""
+    transport_issues = sorted(
+        {route.transport_issue for route in routes if route.transport_issue is not None}
+    )
+    if transport_issues:
+        return {
+            "name": "model",
+            "status": "fail",
+            "detail": "unsupported model transport: " + ", ".join(transport_issues),
+            "fix": "Use native OpenAI/Anthropic or a configured custom_openai/LiteLLM gateway.",
+        }
+    if missing:
+        return {
+            "name": "model",
+            "status": "fail",
+            "detail": "missing env: " + ", ".join(missing),
+            "fix": f"Set {', '.join(missing)}{location}, then rerun this check.",
+        }
+    missing_pricing = sorted({field for route in routes for field in route.missing_pricing})
+    if missing_pricing:
+        return {
+            "name": "model",
+            "status": "fail",
+            "detail": "missing pricing: " + ", ".join(missing_pricing),
+            "fix": "Add explicit current token prices to the model route, then rerun this check.",
+        }
     return {
         "name": "model",
         "status": "fail",
-        "detail": "missing env: " + ", ".join(missing),
-        "fix": f"Set {', '.join(missing)}{location}, then rerun this check.",
+        "detail": "no usable model route",
+        "fix": "Check the model profile/configuration and rerun this check.",
     }
 
 

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -392,7 +392,12 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
     parser.add_argument("--knowledge-pack-sha256", help=argparse.SUPPRESS)
     parser.add_argument("--knowledge-pack-limit", type=int, default=4)
     parser.add_argument("--knowledge-pack-max-chars", type=int, default=6_000)
-    parser.add_argument("--tool-runtime", choices=["host", "docker", "auto"], default="host")
+    parser.add_argument(
+        "--tool-runtime",
+        choices=["host", "docker", "auto"],
+        default="docker",
+        help="process runtime; host execution requires this explicit --tool-runtime host opt-in",
+    )
     parser.add_argument(
         "--authorized-remote-target",
         action="store_true",
@@ -470,6 +475,8 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
         requested_identity=args.identity,
     )
     remote_target = not is_local_url(args.target_url)
+    if remote_target and args.traffic_policy is None:
+        args.traffic_policy = "low-noise"
     traffic_workspace = args.workspace_dir or (
         _attack_resume_workspace(args.resume_from)
         if args.resume_from is not None
@@ -484,7 +491,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
     _resolve_traffic_policy_args(
         parser,
         args,
-        default_mode="observe",
+        default_mode="low-noise" if remote_target else "observe",
         roe_max_rps=brief.roe.max_rps,
     )
     if args.traffic_policy == "low-noise":
@@ -1431,6 +1438,8 @@ def _attack(  # noqa: C901, PLR0912, PLR0915 - CLI options are intentionally exp
             "Unauthenticated process-capable remote runs also require --tool-runtime docker.\n"
             "A selected managed identity uses HTTP-only execution and blocks command, Python,\n"
             "and process lanes.\n"
+            "Process tools use Docker by default. --tool-runtime host is an explicit opt-in\n"
+            "for trusted localhost targets and runs model-selected code on this machine.\n"
             "To print only a brief, use ravage brief template --target-url URL.\n"
             "Put useful target notes, challenge descriptions and success criteria in the brief."
         ),
@@ -1541,7 +1550,7 @@ def _attack(  # noqa: C901, PLR0912, PLR0915 - CLI options are intentionally exp
         choices=["host", "docker", "auto"],
         help=(
             "runtime for command/Python/process tools; authenticated attacks use the "
-            "managed HTTP-only lane instead"
+            "managed HTTP-only lane instead; defaults to Docker and host requires explicit opt-in"
         ),
     )
     parser.add_argument("--tool-image", default=DEFAULT_TOOL_IMAGE)
@@ -1643,6 +1652,8 @@ def _attack(  # noqa: C901, PLR0912, PLR0915 - CLI options are intentionally exp
         allow_paid_models=parsed.allow_paid_models,
     )
     remote_target = not is_local_url(target_url)
+    if remote_target and parsed.traffic_policy is None:
+        parsed.traffic_policy = "low-noise"
     resume_traffic_workspace = _resume_traffic_policy_workspace(parsed)
     if resume_traffic_workspace is not None:
         _inherit_resume_traffic_policy_args(
@@ -1673,9 +1684,7 @@ def _attack(  # noqa: C901, PLR0912, PLR0915 - CLI options are intentionally exp
         parser.error(
             "authorized remote autonomous routing requires --autonomous-route-engine agent-graph"
         )
-    parsed.tool_runtime = parsed.tool_runtime or (
-        "docker" if remote_target and parsed.identity is None else "host"
-    )
+    parsed.tool_runtime = parsed.tool_runtime or "docker"
     if parsed.operational_profile is not None and parsed.autonomous_route_engine != "agent-graph":
         parser.error("--operational-profile applies only to the agent-graph route")
     profile = GraphOperationalProfileName(
@@ -3091,7 +3100,7 @@ def _init(args: list[str]) -> None:
     quoted_brief = shlex.quote(str(parsed.brief))
     remote_target = not is_local_url(parsed.target_url)
     remote_flag = " --authorized-remote-target" if remote_target else ""
-    runtime_flag = "" if remote_target else " --tool-runtime host"
+    runtime_flag = ""
     if auth_result is None:
         _write_line(
             f"{badge('next', 'info')} ravage scan {quoted_brief}{remote_flag} "
@@ -3334,6 +3343,12 @@ def _run_setup_check(  # noqa: C901, PLR0912, PLR0915
             "HTTP-only low-noise mode"
         ),
     )
+    parser.add_argument(
+        "--tool-runtime",
+        choices=["host", "docker", "auto"],
+        default="docker",
+        help="attack process runtime; host execution requires an explicit opt-in",
+    )
     parser.add_argument("--tool-image", default=DEFAULT_TOOL_IMAGE)
     parser.add_argument("--run-root", type=Path, default=Path("runs"))
     parser.add_argument("--skip-tools", action="store_true")
@@ -3569,7 +3584,7 @@ def _run_setup_check(  # noqa: C901, PLR0912, PLR0915
         checks.append(
             _setup_check_tools(
                 tool_image=parsed.tool_image,
-                require_docker=remote_target,
+                require_docker=parsed.tool_runtime != "host",
             )
         )
 
@@ -3602,6 +3617,7 @@ def _run_setup_check(  # noqa: C901, PLR0912, PLR0915
                 model_tier=parsed.model_tier,
                 traffic_policy=attack_traffic_policy,
                 managed_http=bool(brief is not None and brief.authentication is not None),
+                tool_runtime=parsed.tool_runtime,
             )
     if not payload["ok"]:
         raise SystemExit(1)
@@ -3666,6 +3682,7 @@ def _write_setup_next_command(  # noqa: PLR0913
     model_tier: str,
     traffic_policy: str = "observe",
     managed_http: bool = False,
+    tool_runtime: str = "docker",
 ) -> None:
     remote_flag = (
         " --authorized-remote-target" if target_url and not is_local_url(target_url) else ""
@@ -3709,7 +3726,7 @@ def _write_setup_next_command(  # noqa: PLR0913
     elif remote_target:
         transport_options = " --traffic-policy observe --tool-runtime docker"
     else:
-        transport_options = " --tool-runtime host"
+        transport_options = " --tool-runtime host" if tool_runtime == "host" else ""
     paid = " --allow-paid-models" if model_profile.startswith("hosted-") else ""
     _write_line(
         f"{badge('next', 'info')} ravage attack {quoted_brief}{remote_flag}{env_option} "
@@ -4460,7 +4477,11 @@ def _setup_check_tools(*, tool_image: str, require_docker: bool = False) -> dict
         docker_ready = bool(docker.get("ready"))
     ready = docker_ready if require_docker else host_ready or docker_ready
     if require_docker and not docker_ready:
-        recommendation = f"Docker is required for remote attacks; {recommendation}".rstrip("; ")
+        recommendation = (
+            f"Docker is required for the selected attack runtime; {recommendation}"
+        ).rstrip(
+            "; "
+        )
     return {
         "name": "tools",
         "status": "ok" if ready else "fail",

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -78,13 +78,15 @@ from ravage.agent_knowledge.selector import (
 )
 from ravage.dry_run import RouteParam, RouteProbe
 from ravage.model_core.providers import (
-    LOCAL_PROVIDERS,
     ModelTier,
     ResolvedModelRoute,
+    anthropic_standard_token_prices,
     load_model_registry,
+    model_route_transport_error,
     openai_standard_token_prices,
     ready_model_routes,
     resolve_model_routes,
+    route_is_nonbillable_local,
 )
 from ravage.probe_suite import (
     authenticated_probe_unavailability,
@@ -3226,6 +3228,14 @@ def _select_model_route(settings: AIWebAgentSettings) -> ResolvedModelRoute:
     message = "no ready model route"
     if missing:
         message += f"; missing env: {', '.join(missing)}"
+    missing_pricing = _missing_model_pricing_fields(routes)
+    if missing_pricing:
+        message += f"; missing pricing: {', '.join(missing_pricing)}"
+    transport_issues = sorted(
+        {route.transport_issue for route in routes if route.transport_issue is not None}
+    )
+    if transport_issues:
+        message += f"; transport issues: {', '.join(transport_issues)}"
     raise RuntimeError(message)
 
 
@@ -3309,6 +3319,13 @@ def _missing_model_env_vars(routes: Iterable[ResolvedModelRoute]) -> list[str]:
     for route in routes:
         for name in route.missing_env:
             missing.add(name)
+    return sorted(missing)
+
+
+def _missing_model_pricing_fields(routes: Iterable[ResolvedModelRoute]) -> list[str]:
+    missing: set[str] = set()
+    for route in routes:
+        missing.update(route.missing_pricing)
     return sorted(missing)
 
 
@@ -4073,7 +4090,7 @@ def _require_accountable_paid_reply(
     route: ResolvedModelRoute,
     reply: ModelReply,
 ) -> None:
-    if _route_is_nonbillable_local_model(route) or reply.cost_known:
+    if route_is_nonbillable_local(route) or reply.cost_known:
         return
     message = (
         "paid model response cannot be cost-accounted: "
@@ -4082,18 +4099,8 @@ def _require_accountable_paid_reply(
     )
     raise RuntimeError(message)
 
-
-def _route_is_nonbillable_local_model(route: ResolvedModelRoute) -> bool:
-    if route.provider in LOCAL_PROVIDERS:
-        return True
-    if route.provider != "custom_openai" or route.api_key_env is not None:
-        return False
-    hostname = (urlparse(route.base_url or "").hostname or "").lower()
-    return hostname in {"127.0.0.1", "::1", "localhost"}
-
-
 def route_has_paid_transport_risk(route: ResolvedModelRoute) -> bool:
-    if _route_is_nonbillable_local_model(route):
+    if route_is_nonbillable_local(route):
         return False
     if route.api_key_env is not None:
         return True
@@ -4540,6 +4547,17 @@ class ChatClient:
         self.route = route
 
     def chat(self, messages: list[dict[str, str]]) -> ModelReply:
+        transport_error = model_route_transport_error(self.route)
+        if transport_error is not None:
+            raise RuntimeError(f"model route transport is not callable: {transport_error}")
+        if not self.route.ready:
+            issues: list[str] = []
+            if self.route.missing_env:
+                issues.append(f"missing env: {', '.join(self.route.missing_env)}")
+            if self.route.missing_pricing:
+                issues.append(f"missing pricing: {', '.join(self.route.missing_pricing)}")
+            detail = "; ".join(issues) or "route readiness requirements are not met"
+            raise RuntimeError(f"model route is not ready: {detail}")
         last_error: Exception | None = None
         paid_transport_risk = route_has_paid_transport_risk(self.route)
         configured_attempts = 1 if paid_transport_risk else max(self.route.max_retries, 0) + 1
@@ -4613,26 +4631,30 @@ class ChatClient:
             "system": system,
             "messages": user_messages,
             "max_tokens": self.route.max_output_tokens,
-            "temperature": 0,
         }
+        # Newer Claude models reject non-default sampling controls; omit them for compatibility.
+        # https://platform.claude.com/docs/en/about-claude/model-deprecations
         base_url = (self.route.base_url or "https://api.anthropic.com").rstrip("/")
         data = self._post_json(f"{base_url}/v1/messages", body, anthropic=True)
         content = _anthropic_content(data)
         usage = _usage_from_data(data)
         usage_reported = _usage_was_reported(data)
+        response_model = _response_string(data, "model")
         cost_known = _response_cost_is_known(
             route=self.route,
             usage=usage,
             usage_reported=usage_reported,
+            response_model=response_model,
         )
         return ModelReply(
             content=content,
             input_tokens=_usage_token_count(usage, "input_tokens"),
+            cached_input_tokens=_usage_token_count(usage, "cache_read_input_tokens"),
             output_tokens=_usage_token_count(usage, "output_tokens"),
             cost_usd=_estimate_cost(self.route, usage) if cost_known else 0.0,
             usage_reported=usage_reported,
             cost_known=cost_known,
-            response_model=_response_string(data, "model"),
+            response_model=response_model,
             response_id=_response_string(data, "id"),
             system_fingerprint=_response_string(data, "system_fingerprint"),
             service_tier=_response_string(data, "service_tier"),
@@ -4779,6 +4801,8 @@ def _response_cost_is_known(
         return False
     if route.input_cost_per_1m_tokens is None or route.output_cost_per_1m_tokens is None:
         return False
+    if not _cache_usage_is_valid(route, usage):
+        return False
     if route.provider == "openai" and route.base_url is None:
         if service_tier != "default" or not response_model:
             return False
@@ -4801,8 +4825,44 @@ def _response_cost_is_known(
             != requested_prices
         ):
             return False
-    cached_input_tokens = _openai_cached_input_tokens(usage)
+    if route.provider == "anthropic":
+        if not response_model:
+            return False
+        requested_prices = anthropic_standard_token_prices(route.model)
+        response_prices = anthropic_standard_token_prices(response_model)
+        if requested_prices is None:
+            if response_model != route.model:
+                return False
+        elif response_prices != requested_prices:
+            return False
+        if _usage_token_count(usage, "cache_creation_input_tokens") != 0:
+            return False
+    cached_input_tokens = _cached_input_tokens(route, usage)
     return cached_input_tokens == 0 or route.cached_input_cost_per_1m_tokens is not None
+
+
+def _cached_input_tokens(
+    route: ResolvedModelRoute,
+    usage: Mapping[str, object],
+) -> int:
+    if route.provider == "anthropic":
+        return _usage_token_count(usage, "cache_read_input_tokens")
+    return _openai_cached_input_tokens(usage)
+
+
+def _cache_usage_is_valid(
+    route: ResolvedModelRoute,
+    usage: Mapping[str, object],
+) -> bool:
+    if route.provider == "anthropic":
+        for key in ("cache_read_input_tokens", "cache_creation_input_tokens"):
+            if key in usage and not _usage_has_nonnegative_int(usage, (key,)):
+                return False
+        return True
+    details = usage.get("prompt_tokens_details")
+    if not isinstance(details, dict) or "cached_tokens" not in details:
+        return True
+    return _usage_has_nonnegative_int(details, ("cached_tokens",))
 
 
 def _usage_has_billable_token_counts(usage: Mapping[str, object]) -> bool:
@@ -4852,8 +4912,12 @@ def _estimate_cost(route: ResolvedModelRoute, usage: Mapping[str, object]) -> fl
             output_cost = standard_prices.output_per_1m
     if input_cost is None or output_cost is None:
         return 0.0
-    cached_input_tokens = min(_openai_cached_input_tokens(usage), input_tokens)
-    uncached_input_tokens = max(input_tokens - cached_input_tokens, 0)
+    cached_input_tokens = _cached_input_tokens(route, usage)
+    if route.provider == "anthropic":
+        uncached_input_tokens = input_tokens
+    else:
+        cached_input_tokens = min(cached_input_tokens, input_tokens)
+        uncached_input_tokens = max(input_tokens - cached_input_tokens, 0)
     if cached_input_cost is None:
         cached_input_cost = input_cost
     input_total = uncached_input_tokens / 1_000_000 * input_cost

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -99,7 +99,6 @@ from ravage.run_data.brief import load_engagement_brief
 from ravage.run_data.workspace import AgentWorkspace
 from ravage.runtime import (
     DEFAULT_TOOL_IMAGE,
-    DockerFallbackToolRuntime,
     DockerToolRuntime,
     ExternalToolRuntime,
     NoProcessToolRuntime,
@@ -291,7 +290,7 @@ class AIWebAgentSettings:
     knowledge_pack_sha256: str | None = None
     knowledge_pack_limit: int = DEFAULT_KNOWLEDGE_CARD_LIMIT
     knowledge_pack_max_chars: int = DEFAULT_KNOWLEDGE_MAX_CHARS
-    tool_runtime_mode: ToolRuntimeMode = "host"
+    tool_runtime_mode: ToolRuntimeMode = "docker"
     tool_image: str = DEFAULT_TOOL_IMAGE
     allow_remote_target: bool = False
     allow_degraded: bool = False
@@ -2607,10 +2606,8 @@ def _make_tool_runtime(
     }
     if settings.allow_remote_target and not is_local_url(target_url):
         return DockerToolRuntime(**runtime_kwargs)
-    if settings.tool_runtime_mode == "docker":
+    if settings.tool_runtime_mode in {"docker", "auto"}:
         return DockerToolRuntime(**runtime_kwargs)
-    if settings.tool_runtime_mode == "auto":
-        return DockerFallbackToolRuntime(**runtime_kwargs)
     return ExternalToolRuntime()
 
 

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/model_bridge.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/model_bridge.py
@@ -28,11 +28,11 @@ from ravage.agent_core.autonomous_graph.provider_continuity import (
 )
 from ravage.agent_core.autonomous_graph.worker import GraphModelReply
 from ravage.model_core.providers import (
-    LOCAL_PROVIDERS,
     ResolvedModelRoute,
     load_model_registry,
     ready_model_routes,
     resolve_model_routes,
+    route_is_nonbillable_local,
 )
 
 if TYPE_CHECKING:
@@ -482,6 +482,20 @@ def select_graph_model_portfolio(
         message = "no ready model route for autonomous agent graph"
         if missing:
             message += f"; missing env: {', '.join(missing)}"
+        missing_pricing = sorted(
+            {field for route in routes for field in route.missing_pricing}
+        )
+        if missing_pricing:
+            message += f"; missing pricing: {', '.join(missing_pricing)}"
+        transport_issues = sorted(
+            {
+                route.transport_issue
+                for route in routes
+                if route.transport_issue is not None
+            }
+        )
+        if transport_issues:
+            message += f"; transport issues: {', '.join(transport_issues)}"
         raise RuntimeError(message)
     return tuple(
         GraphModelEndpoint(
@@ -591,8 +605,7 @@ def _require_accountable_reply(
     route: ResolvedModelRoute,
     reply: ModelReply,
 ) -> None:
-    local_custom = route.provider == "custom_openai" and route.api_key_env is None
-    if route.provider in LOCAL_PROVIDERS or local_custom or reply.cost_known:
+    if route_is_nonbillable_local(route) or reply.cost_known:
         return
     raise RuntimeError(
         "paid autonomous-graph response cannot be cost-accounted: "

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/runtime.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/runtime.py
@@ -20,6 +20,7 @@ from ravage.runtime.common import (
     assert_http_url,
     assert_local_url,
     assert_tool_target_url,
+    child_process_environment,
     safe_command,
 )
 from ravage.runtime.scoped_network import ScopedDockerNetwork
@@ -755,10 +756,13 @@ class HostGraphProcessBackend:
         return self.workspace
 
     def process_env(self) -> Mapping[str, str]:
-        env = dict(os.environ)
-        env["RAVAGE_TARGET_URL"] = self._target_url
-        env["PYTHONUNBUFFERED"] = "1"
-        return env
+        return child_process_environment(
+            home=self.workspace,
+            overrides={
+                "RAVAGE_TARGET_URL": self._target_url,
+                "PYTHONUNBUFFERED": "1",
+            },
+        )
 
     def close(self) -> dict[str, object]:
         return {

--- a/packages/ravage/src/ravage/agent_core/frontier_adapter.py
+++ b/packages/ravage/src/ravage/agent_core/frontier_adapter.py
@@ -38,11 +38,11 @@ from ravage.agent_core.frontier_timeout_hygiene import (
 )
 from ravage.agent_core.frontier_transition import seed_frontier_objectives
 from ravage.model_core.providers import (
-    LOCAL_PROVIDERS,
     ResolvedModelRoute,
     load_model_registry,
     ready_model_routes,
     resolve_model_routes,
+    route_is_nonbillable_local,
 )
 from ravage.run_data.audit import AuditStore
 from ravage.run_data.brief import load_engagement_brief
@@ -667,16 +667,23 @@ def _select_model_route(settings: AIWebAgentSettings) -> ResolvedModelRoute:
         return ready[0]
     missing = sorted(
         {
-            route.api_key_env
+            env_name
             for route in routes
-            if route.api_key_required
-            and route.api_key_env
-            and not os.environ.get(route.api_key_env)
+            for env_name in route.missing_env
+            if env_name and not os.environ.get(env_name)
         }
     )
     message = "no ready model route"
     if missing:
         message += f"; missing env: {', '.join(missing)}"
+    missing_pricing = sorted({field for route in routes for field in route.missing_pricing})
+    if missing_pricing:
+        message += f"; missing pricing: {', '.join(missing_pricing)}"
+    transport_issues = sorted(
+        {route.transport_issue for route in routes if route.transport_issue is not None}
+    )
+    if transport_issues:
+        message += f"; transport issues: {', '.join(transport_issues)}"
     raise RuntimeError(message)
 
 
@@ -713,8 +720,7 @@ def _require_accountable_reply(
     route: ResolvedModelRoute,
     reply: ModelReply,
 ) -> None:
-    local_custom = route.provider == "custom_openai" and route.api_key_env is None
-    if route.provider in LOCAL_PROVIDERS or local_custom or reply.cost_known:
+    if route_is_nonbillable_local(route) or reply.cost_known:
         return
     message = (
         "paid autonomous-route response cannot be cost-accounted: "

--- a/packages/ravage/src/ravage/agent_core/frontier_adapter.py
+++ b/packages/ravage/src/ravage/agent_core/frontier_adapter.py
@@ -48,7 +48,6 @@ from ravage.run_data.audit import AuditStore
 from ravage.run_data.brief import load_engagement_brief
 from ravage.run_data.workspace import AgentWorkspace
 from ravage.runtime import (
-    DockerFallbackToolRuntime,
     DockerToolRuntime,
     ExternalToolRuntime,
     NoProcessToolRuntime,
@@ -579,10 +578,8 @@ def _make_route_runtime(
         "cleanup_evidence_path": os.environ.get("RAVAGE_TOOL_NETWORK_EVIDENCE_PATH"),
         "allow_remote_target": settings.allow_remote_target,
     }
-    if settings.allow_remote_target or settings.tool_runtime_mode == "docker":
+    if settings.allow_remote_target or settings.tool_runtime_mode in {"docker", "auto"}:
         return DockerToolRuntime(**runtime_kwargs)
-    if settings.tool_runtime_mode == "auto":
-        return DockerFallbackToolRuntime(**runtime_kwargs)
     return ExternalToolRuntime()
 
 

--- a/packages/ravage/src/ravage/agent_core/frontier_shared_runtime.py
+++ b/packages/ravage/src/ravage/agent_core/frontier_shared_runtime.py
@@ -138,10 +138,8 @@ def make_shared_tool_runtime(
         "cleanup_evidence_path": os.environ.get("RAVAGE_TOOL_NETWORK_EVIDENCE_PATH"),
         "allow_remote_target": settings.allow_remote_target,
     }
-    if settings.allow_remote_target or settings.tool_runtime_mode == "docker":
+    if settings.allow_remote_target or settings.tool_runtime_mode in {"docker", "auto"}:
         inner: ToolRuntime = DockerToolRuntime(**runtime_kwargs)
-    elif settings.tool_runtime_mode == "auto":
-        inner = DockerFallbackToolRuntime(**runtime_kwargs)
     else:
         inner = ExternalToolRuntime()
     return SharedToolRuntime(

--- a/packages/ravage/src/ravage/model_core/providers.py
+++ b/packages/ravage/src/ravage/model_core/providers.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlparse
 
 import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -58,6 +60,17 @@ DEFAULT_BASE_URL: dict[ProviderKind, str] = {
     "vllm": "http://localhost:8000/v1",
     "litellm": "http://localhost:4000/v1",
 }
+OPENAI_NATIVE_BASE_URL = "https://api.openai.com/v1"
+ANTHROPIC_NATIVE_BASE_URL = "https://api.anthropic.com"
+DIRECT_CHAT_PROVIDERS: frozenset[ProviderKind] = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "litellm",
+        "custom_openai",
+        *LOCAL_PROVIDERS,
+    }
+)
 TIER_ORDER: tuple[ModelTier, ...] = ("high", "mid", "low")
 ENV_TEMPLATE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}")
 ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -95,6 +108,22 @@ def openai_standard_token_prices(
         if long_context is not None:
             return long_context
     return OPENAI_STANDARD_TOKEN_PRICES.get(model)
+
+
+# Claude API Standard pricing per 1M tokens, verified 2026-08-30.
+# https://platform.claude.com/docs/en/about-claude/pricing
+# https://platform.claude.com/docs/en/about-claude/model-deprecations
+# https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions
+ANTHROPIC_STANDARD_TOKEN_PRICES: dict[str, TokenPrices] = {
+    "claude-opus-4-7": TokenPrices(5.0, 0.5, 25.0),
+    "claude-sonnet-4-6": TokenPrices(3.0, 0.3, 15.0),
+    "claude-haiku-4-5": TokenPrices(1.0, 0.1, 5.0),
+    "claude-haiku-4-5-20251001": TokenPrices(1.0, 0.1, 5.0),
+}
+
+
+def anthropic_standard_token_prices(model: str) -> TokenPrices | None:
+    return ANTHROPIC_STANDARD_TOKEN_PRICES.get(model)
 
 
 DEFAULT_MODEL_CONFIG: dict[str, object] = {
@@ -269,7 +298,10 @@ DEFAULT_MODEL_CONFIG: dict[str, object] = {
                 "low": [
                     {
                         "provider": "anthropic",
-                        "model": "${RAVAGE_ANTHROPIC_LOW_MODEL:claude-haiku-4-5}",
+                        "model": (
+                            "${RAVAGE_ANTHROPIC_LOW_MODEL:"
+                            "claude-haiku-4-5-20251001}"
+                        ),
                         "api_key_env": "ANTHROPIC_API_KEY",
                         "max_output_tokens": 4096,
                     }
@@ -369,6 +401,13 @@ class ModelRoute(BaseModel):
                 raise ValueError(message)
         return value
 
+    @model_validator(mode="after")
+    def _required_api_key_has_environment_variable(self) -> ModelRoute:
+        if self._default_api_key_required() and self.effective_api_key_env() is None:
+            message = "api_key_env is required when api_key_required is true"
+            raise ValueError(message)
+        return self
+
     def effective_base_url(self) -> str | None:
         return self.base_url or DEFAULT_BASE_URL.get(self.provider)
 
@@ -448,10 +487,26 @@ class ResolvedModelRoute:
     timeout_seconds: float
     max_retries: int
     cached_input_cost_per_1m_tokens: float | None = None
+    api_key_required: bool = False
 
     @property
     def ready(self) -> bool:
-        return not self.missing_env
+        return not self.missing_env and not self.missing_pricing and self.transport_issue is None
+
+    @property
+    def missing_pricing(self) -> tuple[str, ...]:
+        if not _route_requires_accountable_pricing(self):
+            return ()
+        prices = (
+            ("input_cost_per_1m_tokens", self.input_cost_per_1m_tokens),
+            ("cached_input_cost_per_1m_tokens", self.cached_input_cost_per_1m_tokens),
+            ("output_cost_per_1m_tokens", self.output_cost_per_1m_tokens),
+        )
+        return tuple(name for name, value in prices if value is None)
+
+    @property
+    def transport_issue(self) -> str | None:
+        return model_route_transport_issue(self)
 
 
 def load_model_registry(
@@ -556,6 +611,7 @@ def _resolve_model_route(
         timeout_seconds=route.timeout_seconds,
         max_retries=route.max_retries,
         cached_input_cost_per_1m_tokens=cached_input_cost,
+        api_key_required=route._default_api_key_required(),
     )
 
 
@@ -569,12 +625,71 @@ def _effective_token_prices(
     )
     if any(value is not None for value in configured):
         return configured
-    if route.provider != "openai" or route.base_url is not None:
+    if route.base_url is not None:
         return configured
-    known = openai_standard_token_prices(route.model)
+    if route.provider == "openai":
+        known = openai_standard_token_prices(route.model)
+    elif route.provider == "anthropic":
+        known = anthropic_standard_token_prices(route.model)
+    else:
+        known = None
     if known is None:
         return configured
     return known.input_per_1m, known.cached_input_per_1m, known.output_per_1m
+
+
+def _route_requires_accountable_pricing(route: ResolvedModelRoute) -> bool:
+    return not route_is_nonbillable_local(route)
+
+
+def route_is_nonbillable_local(route: ResolvedModelRoute) -> bool:
+    """Return whether a built-in local provider is credentialless and loopback-only."""
+    if route.provider not in LOCAL_PROVIDERS:
+        return False
+    if route.api_key_env is not None or route.api_key_required:
+        return False
+    hostname = (urlparse(route.base_url or "").hostname or "").lower().rstrip(".")
+    if hostname == "localhost":
+        return True
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def model_route_transport_issue(route: ResolvedModelRoute) -> str | None:
+    if route.provider not in DIRECT_CHAT_PROVIDERS:
+        return "unsupported_direct_provider"
+    base_url = (route.base_url or "").rstrip("/")
+    if route.provider == "custom_openai" and not base_url:
+        return "custom_openai_base_url_required"
+    if route.provider == "openai" and base_url and base_url != OPENAI_NATIVE_BASE_URL:
+        return "openai_native_base_url_required"
+    if route.provider == "anthropic" and base_url != ANTHROPIC_NATIVE_BASE_URL:
+        return "anthropic_native_base_url_required"
+    return None
+
+
+def model_route_transport_error(route: ResolvedModelRoute) -> str | None:
+    issue = model_route_transport_issue(route)
+    if issue == "unsupported_direct_provider":
+        return (
+            f"provider={route.provider} has no direct chat transport; "
+            "use provider=custom_openai or provider=litellm with a configured gateway"
+        )
+    if issue == "custom_openai_base_url_required":
+        return "provider=custom_openai requires an explicit base_url"
+    if issue == "openai_native_base_url_required":
+        return (
+            f"provider=openai only supports {OPENAI_NATIVE_BASE_URL}; "
+            "use provider=custom_openai for a gateway"
+        )
+    if issue == "anthropic_native_base_url_required":
+        return (
+            f"provider=anthropic only supports {ANTHROPIC_NATIVE_BASE_URL}; "
+            "use provider=litellm for a gateway"
+        )
+    return None
 
 
 def _missing_env_names(route: ModelRoute, env: Mapping[str, str]) -> tuple[str, ...]:
@@ -631,6 +746,11 @@ def _model_route_detail_line(route: ResolvedModelRoute) -> str:
     if route.missing_env:
         missing_env = ",".join(route.missing_env)
         parts.append(f"missing_env={missing_env}")
+    if route.missing_pricing:
+        missing_pricing = ",".join(route.missing_pricing)
+        parts.append(f"missing_pricing={missing_pricing}")
+    if route.transport_issue is not None:
+        parts.append(f"transport_issue={route.transport_issue}")
     return " ".join(parts)
 
 

--- a/packages/ravage/src/ravage/runtime/common.py
+++ b/packages/ravage/src/ravage/runtime/common.py
@@ -1,12 +1,32 @@
 from __future__ import annotations
 
+import os
 import shutil
-from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult, urlparse, urlunparse
 
 from ravage.web_core.scope_policy import is_local_host
 
 from .types import MAX_CODE_CHARS, MAX_COMMAND_CHARS, MAX_OUTPUT_CHARS, ToolResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+_CHILD_PROCESS_ENVIRONMENT_KEYS = (
+    "COMSPEC",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "PATH",
+    "PATHEXT",
+    "SYSTEMROOT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "WINDIR",
+)
 
 
 def assert_http_url(target_url: str) -> ParseResult:
@@ -67,6 +87,28 @@ def safe_code(code: str) -> str:
     return code
 
 
+def child_process_environment(
+    *,
+    home: Path,
+    overrides: Mapping[str, str] | None = None,
+    parent: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a minimal environment for model-selected host processes."""
+    source = os.environ if parent is None else parent
+    environment = {
+        key: value
+        for key in _CHILD_PROCESS_ENVIRONMENT_KEYS
+        if (value := source.get(key)) is not None
+    }
+    environment.setdefault("PATH", os.defpath)
+    environment["HOME"] = str(home)
+    if os.name == "nt":
+        environment["USERPROFILE"] = str(home)
+    if overrides is not None:
+        environment.update({str(key): str(value) for key, value in overrides.items()})
+    return environment
+
+
 def timeout_or_default(timeout_seconds: int | None, *, default: int) -> int:
     if timeout_seconds is None:
         return default
@@ -98,4 +140,6 @@ def docker_target_url(target_url: str) -> str:
     netloc = "host.docker.internal"
     if parsed.port is not None:
         netloc = f"{netloc}:{parsed.port}"
-    return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+    return urlunparse(
+        (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+    )

--- a/packages/ravage/src/ravage/runtime/host.py
+++ b/packages/ravage/src/ravage/runtime/host.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -15,6 +14,7 @@ from ravage.tool_paths import (
 
 from .common import (
     assert_local_url,
+    child_process_environment,
     cleanup_path,
     clip,
     safe_code,
@@ -112,10 +112,14 @@ class ExternalToolRuntime(ToolRuntime):
         target_url: str,
         timeout_seconds: int | None,
     ) -> ToolResult:
-        env = dict(os.environ)
+        env = child_process_environment(
+            home=self.workdir,
+            overrides={
+                "RAVAGE_TARGET_URL": target_url,
+                "PYTHONUNBUFFERED": "1",
+            },
+        )
         prepend_executable_path(env, self._project_tool_bin)
-        env["RAVAGE_TARGET_URL"] = target_url
-        env["PYTHONUNBUFFERED"] = "1"
         timeout = timeout_or_default(timeout_seconds, default=self.timeout_seconds)
         execution_argv = _argv_with_project_tool_path(argv, self._project_tool_bin)
         try:

--- a/packages/ravage/src/ravage/xben_parts/runner.py
+++ b/packages/ravage/src/ravage/xben_parts/runner.py
@@ -25,11 +25,11 @@ from ravage.live_dashboard import (
     start_cockpit,
 )
 from ravage.model_core.providers import (
-    LOCAL_PROVIDERS,
     ResolvedModelRoute,
     load_model_registry,
     ready_model_routes,
     resolve_model_routes,
+    route_is_nonbillable_local,
 )
 from ravage.outcome_evidence import load_run_outcome
 from ravage.run_data.run_manifest import (
@@ -1056,7 +1056,9 @@ def _selected_route_cost_is_known(settings: XbenSettings) -> bool:
     if route is None:
         return False
     return (
-        route.input_cost_per_1m_tokens is not None and route.output_cost_per_1m_tokens is not None
+        route.input_cost_per_1m_tokens is not None
+        and route.cached_input_cost_per_1m_tokens is not None
+        and route.output_cost_per_1m_tokens is not None
     )
 
 
@@ -1518,7 +1520,7 @@ def _routes_for_cost_and_risk(
 
 def _has_paid_model_risk(routes: Sequence[ResolvedModelRoute]) -> bool:
     for route in routes:
-        if route.provider not in LOCAL_PROVIDERS:
+        if not route_is_nonbillable_local(route):
             return True
     return False
 
@@ -1527,7 +1529,9 @@ def _routes_have_complete_pricing(routes: Sequence[ResolvedModelRoute]) -> bool:
     if not routes:
         return False
     return all(
-        route.input_cost_per_1m_tokens is not None and route.output_cost_per_1m_tokens is not None
+        route.input_cost_per_1m_tokens is not None
+        and route.cached_input_cost_per_1m_tokens is not None
+        and route.output_cost_per_1m_tokens is not None
         for route in routes
     )
 

--- a/packages/ravage/tests/test_ai_agent_memory.py
+++ b/packages/ravage/tests/test_ai_agent_memory.py
@@ -14,6 +14,7 @@ from ravage.agent_core.ai_agent import (
     run_ai_web_agent,
 )
 from ravage.memory import MemoryItem, MemoryRunSettings, MemoryStore
+from ravage.runtime import FakeToolRuntime
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -74,6 +75,8 @@ def test_ai_web_memory_read_injects_only_verified_or_promoted_memories(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=tmp_path / "run.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -165,6 +168,8 @@ def test_ai_web_memory_write_stores_reflection_candidates_after_confirmed_eviden
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=tmp_path / "run.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -228,6 +233,8 @@ def test_retrieved_memory_cannot_bypass_evidence_gate(tmp_path: Path) -> None:
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=db_path,
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -321,6 +328,8 @@ def test_ai_web_memory_records_model_provenance(tmp_path: Path) -> None:
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=tmp_path / "run.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -375,6 +384,8 @@ def test_agent_finished_reports_max_turns_as_incomplete(tmp_path: Path) -> None:
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=tmp_path / "run.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -414,6 +425,8 @@ def test_agent_finished_reports_cost_budget_as_incomplete(tmp_path: Path) -> Non
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=FakeToolRuntime(),
             db_path=tmp_path / "run.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,

--- a/packages/ravage/tests/test_ai_agent_recovery.py
+++ b/packages/ravage/tests/test_ai_agent_recovery.py
@@ -259,6 +259,7 @@ def test_recovery_profile_escalates_hands_off_and_solves_under_one_budget(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=workspace,
             model_client=model,
@@ -347,6 +348,7 @@ def test_recovery_executes_route_aligned_xss_objective_when_model_keeps_looping(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=workspace,
             model_client=model,
@@ -393,6 +395,7 @@ def test_default_and_explicit_off_profiles_keep_identical_prompts_and_no_recover
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "default.db",
             workspace_dir=tmp_path / "default-workspace",
             model_client=default_model,
@@ -403,6 +406,7 @@ def test_default_and_explicit_off_profiles_keep_identical_prompts_and_no_recover
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "explicit.db",
             workspace_dir=tmp_path / "explicit-workspace",
             model_client=explicit_model,
@@ -437,6 +441,7 @@ def test_multi_finding_run_continues_after_proof_and_resume_uses_next_turn(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=db_path,
             workspace_dir=workspace,
             model_client=first_model,
@@ -447,6 +452,7 @@ def test_multi_finding_run_continues_after_proof_and_resume_uses_next_turn(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=db_path,
             workspace_dir=workspace,
             model_client=second_model,
@@ -496,6 +502,7 @@ def test_recovery_core_final_cannot_end_the_campaign_without_target_proof(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=workspace,
             model_client=model,
@@ -542,6 +549,7 @@ def test_recovery_resume_charges_an_interrupted_model_request_without_replaying_
             brief_path=brief_path,
             target_url=TARGET_URL,
             settings=AIWebAgentSettings(
+                tool_runtime_mode="host",
                 db_path=db_path,
                 workspace_dir=workspace,
                 model_client=_InterruptingClient(),
@@ -568,6 +576,7 @@ def test_recovery_resume_charges_an_interrupted_model_request_without_replaying_
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=db_path,
             workspace_dir=workspace,
             model_client=resumed_model,
@@ -633,6 +642,7 @@ def test_no_progress_campaign_stops_without_blindly_consuming_the_global_budget(
         brief_path=brief_path,
         target_url=TARGET_URL,
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=workspace,
             model_client=model,

--- a/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
+++ b/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
@@ -262,6 +262,7 @@ def test_injected_model_final_cannot_bypass_required_proof_count(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -325,6 +326,7 @@ def test_two_proofs_from_one_closure_probe_finish_without_another_model_turn(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -367,6 +369,7 @@ def test_third_identical_action_is_replaced_before_execution(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,
@@ -411,6 +414,7 @@ def test_completed_task_queue_synthesizes_terminal_without_another_model_turn(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=tmp_path / "workspace",
             model_client=model,

--- a/packages/ravage/tests/test_ai_providers.py
+++ b/packages/ravage/tests/test_ai_providers.py
@@ -4,16 +4,36 @@ from typing import TYPE_CHECKING
 
 import pytest
 from ravage.model_core.providers import (
+    ModelTier,
+    ProviderKind,
     load_model_registry,
     ready_model_routes,
     render_model_routes,
     resolve_model_routes,
+    route_is_nonbillable_local,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 OPENAI_MINI_STANDARD_PRICES = (0.75, 0.075, 4.5)
+ANTHROPIC_STANDARD_ROUTES = (
+    ("high", "claude-opus-4-7", (5.0, 0.5, 25.0)),
+    ("mid", "claude-sonnet-4-6", (3.0, 0.3, 15.0)),
+    ("low", "claude-haiku-4-5-20251001", (1.0, 0.1, 5.0)),
+)
+UNSUPPORTED_DIRECT_PROVIDERS: tuple[ProviderKind, ...] = (
+    "gemini",
+    "openrouter",
+    "azure",
+    "bedrock",
+    "vertex",
+    "groq",
+    "together",
+    "fireworks",
+    "mistral",
+    "deepseek",
+)
 
 
 def test_local_ollama_profile_is_ready_without_api_key() -> None:
@@ -31,6 +51,81 @@ def test_local_ollama_profile_is_ready_without_api_key() -> None:
     assert routes[0].provider == "ollama"
     assert routes[0].model == "qwen2.5-coder:14b"
     assert routes[0].base_url == "http://localhost:11434/v1"
+    assert route_is_nonbillable_local(routes[0])
+
+
+def test_remote_endpoint_under_local_provider_label_requires_pricing() -> None:
+    env = {"OLLAMA_BASE_URL": "https://paid-model.example/v1"}
+    registry = load_model_registry(env=env)
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="local-ollama",
+        tier="mid",
+        env=env,
+    )[0]
+
+    assert route.base_url == "https://paid-model.example/v1"
+    assert not route_is_nonbillable_local(route)
+    assert route.missing_pricing == (
+        "input_cost_per_1m_tokens",
+        "cached_input_cost_per_1m_tokens",
+        "output_cost_per_1m_tokens",
+    )
+    assert not route.ready
+
+
+def test_credentialed_loopback_route_requires_pricing(tmp_path: Path) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        """
+profiles:
+  credentialed-local:
+    routes:
+      mid:
+        - provider: ollama
+          model: private-local-model
+          base_url: http://127.0.0.1:11434/v1
+          api_key_env: LOCAL_MODEL_API_KEY
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = {"LOCAL_MODEL_API_KEY": "test-key"}
+    registry = load_model_registry(config_path, env=env)
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="credentialed-local",
+        tier="mid",
+        env=env,
+    )[0]
+
+    assert not route_is_nonbillable_local(route)
+    assert route.missing_pricing
+    assert not route.ready
+
+
+def test_required_credential_without_environment_variable_is_invalid(tmp_path: Path) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        """
+profiles:
+  invalid-local:
+    routes:
+      mid:
+        - provider: ollama
+          model: private-local-model
+          base_url: http://127.0.0.1:11434/v1
+          api_key_required: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="api_key_env is required when api_key_required is true",
+    ):
+        load_model_registry(config_path, env={})
 
 
 def test_hosted_openai_profile_reports_missing_key() -> None:
@@ -85,6 +180,13 @@ def test_hosted_openai_unknown_model_override_remains_unpriced() -> None:
     assert route.input_cost_per_1m_tokens is None
     assert route.cached_input_cost_per_1m_tokens is None
     assert route.output_cost_per_1m_tokens is None
+    assert route.missing_pricing == (
+        "input_cost_per_1m_tokens",
+        "cached_input_cost_per_1m_tokens",
+        "output_cost_per_1m_tokens",
+    )
+    assert not route.ready
+    assert ready_model_routes((route,)) == ()
 
 
 def test_hosted_openai_known_alias_override_uses_standard_pricing() -> None:
@@ -108,22 +210,241 @@ def test_hosted_openai_known_alias_override_uses_standard_pricing() -> None:
     ) == OPENAI_MINI_STANDARD_PRICES
 
 
-def test_hosted_anthropic_profile_uses_native_api_key() -> None:
-    registry = load_model_registry(env={"ANTHROPIC_API_KEY": "sk-ant-test"})
+@pytest.mark.parametrize(("tier", "model", "prices"), ANTHROPIC_STANDARD_ROUTES)
+def test_hosted_anthropic_profile_has_pinned_accountable_pricing(
+    tier: ModelTier,
+    model: str,
+    prices: tuple[float, float, float],
+) -> None:
+    env = {"ANTHROPIC_API_KEY": "sk-ant-test"}
+    registry = load_model_registry(env=env)
 
     routes = resolve_model_routes(
         registry,
         profile_name="hosted-anthropic",
-        tier="low",
-        env={"ANTHROPIC_API_KEY": "sk-ant-test"},
+        tier=tier,
+        env=env,
     )
 
     assert len(routes) == 1
     assert routes[0].ready
     assert routes[0].provider == "anthropic"
-    assert routes[0].model == "claude-haiku-4-5"
+    assert routes[0].model == model
     assert routes[0].base_url == "https://api.anthropic.com"
     assert routes[0].api_key_env == "ANTHROPIC_API_KEY"
+    assert (
+        routes[0].input_cost_per_1m_tokens,
+        routes[0].cached_input_cost_per_1m_tokens,
+        routes[0].output_cost_per_1m_tokens,
+    ) == prices
+
+
+def test_hosted_anthropic_unknown_override_is_not_ready_for_paid_call() -> None:
+    env = {
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+        "RAVAGE_ANTHROPIC_LOW_MODEL": "claude-future-unknown",
+    }
+    registry = load_model_registry(env=env)
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="hosted-anthropic",
+        tier="low",
+        env=env,
+    )[0]
+
+    assert not route.ready
+    assert route.missing_env == ()
+    assert route.missing_pricing
+
+
+def test_universal_litellm_requires_explicit_pricing_before_it_is_ready() -> None:
+    registry = load_model_registry(env={})
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="universal-litellm",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert route.base_url == "http://localhost:4000/v1"
+    assert not route_is_nonbillable_local(route)
+    assert not route.ready
+    assert route.missing_pricing == (
+        "input_cost_per_1m_tokens",
+        "cached_input_cost_per_1m_tokens",
+        "output_cost_per_1m_tokens",
+    )
+    lines = render_model_routes(
+        registry,
+        profile_name="universal-litellm",
+        tier="mid",
+        env={},
+    )
+    assert "ready=false" in lines[1]
+    assert (
+        "missing_pricing=input_cost_per_1m_tokens,"
+        "cached_input_cost_per_1m_tokens,output_cost_per_1m_tokens"
+    ) in lines[1]
+
+
+def test_remote_custom_route_requires_all_explicit_prices(tmp_path: Path) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        """
+profiles:
+  remote:
+    routes:
+      mid:
+        - provider: custom_openai
+          model: custom-paid-model
+          base_url: https://model.example/v1
+          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    registry = load_model_registry(config_path, env={})
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="remote",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert not route.ready
+    assert not route_is_nonbillable_local(route)
+    assert route.missing_pricing == ("cached_input_cost_per_1m_tokens",)
+
+
+def test_remote_custom_route_is_ready_with_explicit_cache_aware_prices(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        """
+profiles:
+  remote:
+    routes:
+      mid:
+        - provider: custom_openai
+          model: custom-paid-model
+          base_url: https://model.example/v1
+          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    registry = load_model_registry(config_path, env={})
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="remote",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert route.ready
+    assert route.missing_pricing == ()
+
+
+@pytest.mark.parametrize("provider", UNSUPPORTED_DIRECT_PROVIDERS)
+def test_schema_only_provider_kind_cannot_become_directly_ready(
+    tmp_path: Path,
+    provider: ProviderKind,
+) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        f"""
+profiles:
+  unsupported:
+    routes:
+      mid:
+        - provider: {provider}
+          model: provider-model
+          base_url: https://provider.example/v1
+          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    registry = load_model_registry(config_path, env={})
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="unsupported",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert route.missing_env == ()
+    assert route.missing_pricing == ()
+    assert route.transport_issue == "unsupported_direct_provider"
+    assert not route.ready
+    lines = render_model_routes(
+        registry,
+        profile_name="unsupported",
+        tier="mid",
+        env={},
+    )
+    assert "transport_issue=unsupported_direct_provider" in lines[1]
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url", "issue"),
+    [
+        ("custom_openai", None, "custom_openai_base_url_required"),
+        ("openai", "https://gateway.example/v1", "openai_native_base_url_required"),
+        (
+            "anthropic",
+            "https://gateway.example",
+            "anthropic_native_base_url_required",
+        ),
+    ],
+)
+def test_direct_transport_rejects_ambiguous_gateway_configuration(
+    tmp_path: Path,
+    provider: ProviderKind,
+    base_url: str | None,
+    issue: str,
+) -> None:
+    base_url_line = f"          base_url: {base_url}\n" if base_url is not None else ""
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        (
+            f"""
+profiles:
+  ambiguous:
+    routes:
+      mid:
+        - provider: {provider}
+          model: provider-model
+{base_url_line}          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip()
+        ),
+        encoding="utf-8",
+    )
+    registry = load_model_registry(config_path, env={})
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="ambiguous",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert route.transport_issue == issue
+    assert not route.ready
 
 
 def test_env_templates_override_model_and_base_url(tmp_path: Path) -> None:
@@ -139,6 +460,9 @@ profiles:
           model: ${CUSTOM_MODEL}
           base_url: ${CUSTOM_BASE_URL:http://127.0.0.1:9999/v1}
           api_key_required: false
+          input_cost_per_1m_tokens: 0.0
+          cached_input_cost_per_1m_tokens: 0.0
+          output_cost_per_1m_tokens: 0.0
 """.lstrip(),
         encoding="utf-8",
     )
@@ -157,6 +481,38 @@ profiles:
     assert routes[0].model == "my-local-model"
     assert routes[0].base_url == "http://127.0.0.1:9999/v1"
     assert routes[0].ready
+
+
+def test_loopback_custom_gateway_still_requires_explicit_pricing(tmp_path: Path) -> None:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        """
+profiles:
+  local-gateway:
+    routes:
+      mid:
+        - provider: custom_openai
+          model: unknown-upstream
+          base_url: http://127.0.0.1:9999/v1
+          api_key_required: false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    route = resolve_model_routes(
+        load_model_registry(config_path, env={}),
+        profile_name="local-gateway",
+        tier="mid",
+        env={},
+    )[0]
+
+    assert not route_is_nonbillable_local(route)
+    assert not route.ready
+    assert route.missing_pricing == (
+        "input_cost_per_1m_tokens",
+        "cached_input_cost_per_1m_tokens",
+        "output_cost_per_1m_tokens",
+    )
 
 
 def test_fallback_order_preserves_missing_then_ready_route() -> None:

--- a/packages/ravage/tests/test_authenticated_attack_runtime.py
+++ b/packages/ravage/tests/test_authenticated_attack_runtime.py
@@ -5,7 +5,7 @@ import json
 from dataclasses import dataclass, field
 from http.cookiejar import Cookie
 from io import StringIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID, uuid4
 
 import pytest
@@ -23,7 +23,7 @@ from pentest_schemas import (
     Scope,
     SecretReference,
 )
-from ravage.agent_core import action_executor
+from ravage.agent_core import action_executor, ai_agent
 from ravage.agent_core.action_executor import execute_action
 from ravage.agent_core.agent_state import AgentState
 from ravage.agent_core.ai_agent import (
@@ -1029,6 +1029,33 @@ def test_authenticated_runtime_does_not_construct_a_process_or_docker_lane(
     assert not blocked.ok
     assert "managed authenticated" in str(blocked.error)
     shared.shutdown()
+
+
+@pytest.mark.parametrize("runtime_mode", ["docker", "auto"])
+def test_default_and_auto_process_runtime_never_fall_back_to_host(
+    runtime_mode: Literal["docker", "auto"],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert AIWebAgentSettings().tool_runtime_mode == "docker"
+    sentinel = object()
+    observed: list[dict[str, object]] = []
+
+    def docker_runtime(**kwargs: object) -> object:
+        observed.append(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(ai_agent, "DockerToolRuntime", docker_runtime)
+    monkeypatch.setattr(
+        ai_agent,
+        "ExternalToolRuntime",
+        lambda: pytest.fail("safe process modes must not construct the host runtime"),
+    )
+    settings = AIWebAgentSettings(tool_runtime_mode=runtime_mode)
+
+    runtime = _make_tool_runtime(settings, _brief(), target_url=_TARGET)
+
+    assert runtime is sentinel
+    assert observed
 
 
 def test_authenticated_probe_is_in_process_and_redacted_before_proof_recognition(

--- a/packages/ravage/tests/test_autonomous_graph_model_bridge.py
+++ b/packages/ravage/tests/test_autonomous_graph_model_bridge.py
@@ -336,6 +336,35 @@ async def test_paid_unknown_cost_reply_is_recorded_as_non_retryable_failure() ->
     assert events[1]["payload"] == failure_payload
 
 
+@pytest.mark.parametrize("provider", ["ollama", "custom_openai"])
+@pytest.mark.asyncio
+async def test_credentialless_remote_route_cannot_bypass_graph_cost_accounting(
+    provider: str,
+) -> None:
+    client = RecordingClient(cost_known=False)
+    route = replace(
+        _route(provider=provider),
+        base_url="https://paid-model.example/v1",
+        input_cost_per_1m_tokens=1.0,
+        cached_input_cost_per_1m_tokens=1.0,
+        output_cost_per_1m_tokens=2.0,
+    )
+    model = AccountedGraphModel(
+        client=client,
+        route=route,
+        audit=RecordingAudit(),
+        engagement_id=ENGAGEMENT_ID,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot be cost-accounted"):
+        await model(
+            "node-001",
+            [{"role": "user", "content": "return one action"}],
+        )
+
+    assert len(client.calls) == 1
+
+
 @pytest.mark.asyncio
 async def test_local_model_may_report_unknown_cost_without_hiding_request() -> None:
     client = RecordingClient(cost_known=False)

--- a/packages/ravage/tests/test_autonomous_graph_runtime.py
+++ b/packages/ravage/tests/test_autonomous_graph_runtime.py
@@ -314,6 +314,28 @@ def test_host_backend_never_claims_target_network_isolation(
         runtime.close()
 
 
+def test_host_backend_process_environment_scrubs_parent_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-anthropic-secret")
+    monkeypatch.setenv("RAVAGE_ARBITRARY_PARENT_SECRET", "fake-parent-secret")
+    workspace = tmp_path / "workspace"
+    backend = HostGraphProcessBackend(workspace)
+
+    backend.ensure_started(TARGET_URL)
+    environment = backend.process_env()
+
+    assert "OPENAI_API_KEY" not in environment
+    assert "ANTHROPIC_API_KEY" not in environment
+    assert "RAVAGE_ARBITRARY_PARENT_SECRET" not in environment
+    assert environment["RAVAGE_TARGET_URL"] == TARGET_URL
+    assert environment["PYTHONUNBUFFERED"] == "1"
+    assert environment["HOME"] == str(workspace)
+    assert environment["PATH"]
+
+
 def test_docker_backend_builds_resource_capped_process_group_command(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/ravage/tests/test_chat_client.py
+++ b/packages/ravage/tests/test_chat_client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from ravage.agent_core.ai_agent import ChatClient
-from ravage.model_core.providers import ResolvedModelRoute
+from ravage.model_core.providers import ProviderKind, ResolvedModelRoute
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -151,6 +151,117 @@ def test_openai_compatible_chat_client_marks_missing_usage_unaccountable() -> No
     assert reply.response_id == "chatcmpl_without_usage"
 
 
+def test_native_anthropic_client_accounts_for_uncached_and_cached_input() -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=1.0,
+            cached_input_cost_per_1m_tokens=0.1,
+            output_cost_per_1m_tokens=5.0,
+        ),
+        provider="anthropic",
+        model="claude-haiku-4-5",
+        base_url="https://api.anthropic.com",
+    )
+    client = _CapturingAnthropicChatClient(route)
+
+    reply = client.chat([{"role": "user", "content": "return json"}])
+
+    assert reply.input_tokens == 100
+    assert reply.cached_input_tokens == 900
+    assert reply.output_tokens == 100
+    assert reply.response_model == "claude-haiku-4-5-20251001"
+    assert reply.cost_known is True
+    assert reply.cost_usd == pytest.approx(0.00069)
+
+
+def test_native_anthropic_client_rejects_unexpected_model_for_pricing() -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=1.0,
+            cached_input_cost_per_1m_tokens=0.1,
+            output_cost_per_1m_tokens=5.0,
+        ),
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        base_url="https://api.anthropic.com",
+    )
+    client = _CapturingAnthropicChatClient(route)
+    client.response_model = "claude-sonnet-4-6"
+
+    reply = client.chat([{"role": "user", "content": "return json"}])
+
+    assert reply.cost_known is False
+    assert reply.cost_usd == 0.0
+
+
+def test_native_anthropic_client_rejects_unpriced_cache_creation() -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=1.0,
+            cached_input_cost_per_1m_tokens=0.1,
+            output_cost_per_1m_tokens=5.0,
+        ),
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        base_url="https://api.anthropic.com",
+    )
+    client = _CapturingAnthropicChatClient(route)
+    client.cache_creation_input_tokens = 10
+
+    reply = client.chat([{"role": "user", "content": "return json"}])
+
+    assert reply.cost_known is False
+    assert reply.cost_usd == 0.0
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("gemini", "https://generativelanguage.googleapis.com/v1beta"),
+        ("custom_openai", None),
+        ("openai", "https://gateway.example/v1"),
+        ("anthropic", "https://gateway.example"),
+    ],
+)
+def test_chat_client_rejects_unsupported_transport_before_dispatch(
+    provider: ProviderKind,
+    base_url: str | None,
+) -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=1.0,
+            cached_input_cost_per_1m_tokens=1.0,
+            output_cost_per_1m_tokens=1.0,
+        ),
+        provider=provider,
+        base_url=base_url,
+        api_key_env="PROVIDER_API_KEY",
+    )
+    client = _NeverDispatchChatClient(route)
+
+    with pytest.raises(RuntimeError, match="model route transport is not callable"):
+        client.chat([{"role": "user", "content": "must not dispatch"}])
+
+    assert client.dispatch_count == 0
+
+
+@pytest.mark.parametrize("provider", ["ollama", "custom_openai"])
+def test_chat_client_rejects_unpriced_remote_route_before_dispatch(
+    provider: ProviderKind,
+) -> None:
+    route = replace(
+        _route(),
+        provider=provider,
+        base_url="https://paid-model.example/v1",
+    )
+    client = _NeverDispatchChatClient(route)
+
+    with pytest.raises(RuntimeError, match="model route is not ready: missing pricing"):
+        client.chat([{"role": "user", "content": "must not dispatch"}])
+
+    assert client.dispatch_count == 0
+
+
 def test_chat_client_extends_retries_for_transient_url_errors(monkeypatch) -> None:
     sleeps: list[float] = []
     monkeypatch.setattr("ravage.agent_core.ai_agent.time.sleep", sleeps.append)
@@ -166,14 +277,16 @@ def test_chat_client_extends_retries_for_transient_url_errors(monkeypatch) -> No
 def test_chat_client_does_not_retry_paid_transport_failures(monkeypatch) -> None:
     sleeps: list[float] = []
     monkeypatch.setattr("ravage.agent_core.ai_agent.time.sleep", sleeps.append)
-    client = _TransientFailureChatClient(
+    route = replace(
         _route(
             max_retries=5,
             input_cost_per_1m_tokens=2.5,
+            cached_input_cost_per_1m_tokens=0.25,
             output_cost_per_1m_tokens=15.0,
         ),
-        failures=1,
+        base_url="https://paid-model.example/v1",
     )
+    client = _TransientFailureChatClient(route, failures=1)
 
     with pytest.raises(RuntimeError, match="model route failed"):
         client.chat([{"role": "user", "content": "return json"}])
@@ -221,7 +334,7 @@ class _MissingUsageChatClient(_CapturingChatClient):
         *,
         anthropic: bool = False,
     ) -> dict[str, object]:
-        assert url == "http://model.test/v1/chat/completions"
+        assert url == "http://127.0.0.1:9999/v1/chat/completions"
         assert anthropic is False
         self.request_body = body
         return {
@@ -229,6 +342,50 @@ class _MissingUsageChatClient(_CapturingChatClient):
             "model": "stub-returned-model",
             "choices": [{"message": {"content": '{"action":"final","summary":"done"}'}}],
         }
+
+
+class _CapturingAnthropicChatClient(ChatClient):
+    response_model = "claude-haiku-4-5-20251001"
+    cache_creation_input_tokens = 0
+
+    def _post_json(
+        self,
+        url: str,
+        body: Mapping[str, object],
+        *,
+        anthropic: bool = False,
+    ) -> dict[str, object]:
+        assert url == "https://api.anthropic.com/v1/messages"
+        assert anthropic is True
+        assert body["model"] == self.route.model
+        return {
+            "id": "msg_test",
+            "model": self.response_model,
+            "content": [{"type": "text", "text": '{"action":"final"}'}],
+            "usage": {
+                "input_tokens": 100,
+                "cache_read_input_tokens": 900,
+                "cache_creation_input_tokens": self.cache_creation_input_tokens,
+                "output_tokens": 100,
+            },
+        }
+
+
+class _NeverDispatchChatClient(ChatClient):
+    def __init__(self, route: ResolvedModelRoute) -> None:
+        super().__init__(route)
+        self.dispatch_count = 0
+
+    def _post_json(
+        self,
+        url: str,
+        body: Mapping[str, object],
+        *,
+        anthropic: bool = False,
+    ) -> dict[str, object]:
+        del url, body, anthropic
+        self.dispatch_count += 1
+        return {}
 
 
 class _TransientFailureChatClient(_CapturingChatClient):
@@ -261,9 +418,9 @@ def _route(
         requested_tier="mid",
         selected_tier="mid",
         ordinal=0,
-        provider="custom_openai",
+        provider="ollama",
         model="stub",
-        base_url="http://model.test/v1",
+        base_url="http://127.0.0.1:9999/v1",
         api_key_env=None,
         missing_env=(),
         reasoning_effort=None,

--- a/packages/ravage/tests/test_cli_plumbing.py
+++ b/packages/ravage/tests/test_cli_plumbing.py
@@ -298,6 +298,103 @@ def test_legacy_observe_resume_creates_lower_bound_ledger_before_agent(
     assert settings.traffic_policy_reference is not None
 
 
+def test_legacy_direct_remote_agent_defaults_to_canonical_low_noise(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote_url = "https://authorized.example/app"
+    brief_path = tmp_path / "remote-brief.yaml"
+    brief_path.write_text(
+        BRIEF_YAML.replace("http://127.0.0.1:8765", remote_url),
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(cli, "run_ai_web_agent", lambda **kwargs: seen.update(kwargs))
+
+    cli.main(
+        [
+            "--brief",
+            str(brief_path),
+            "--target-url",
+            remote_url,
+            "--workspace-dir",
+            str(tmp_path / "workspace"),
+            "--authorized-remote-target",
+            "--display",
+            "quiet",
+        ]
+    )
+
+    settings = seen["settings"]
+    assert settings.traffic_policy_mode == "low-noise"
+    assert settings.traffic_policy_max_physical_requests == 300
+    assert settings.traffic_policy_max_rps == 0.5
+    assert settings.tool_runtime_mode == "docker"
+
+
+def test_legacy_direct_remote_resume_never_silently_downgrades_to_observe(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    remote_url = "https://authorized.example/app"
+    brief_path = tmp_path / "remote-brief.yaml"
+    brief_path.write_text(
+        BRIEF_YAML.replace("http://127.0.0.1:8765", remote_url),
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    state_path = workspace / "working_state.json"
+    save_agent_state(state_path, target_url=remote_url, state=AgentState(turn=1))
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "--brief",
+                str(brief_path),
+                "--target-url",
+                remote_url,
+                "--workspace-dir",
+                str(workspace),
+                "--resume-from",
+                str(state_path),
+                "--authorized-remote-target",
+                "--display",
+                "quiet",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "valid traffic policy ledger" in capsys.readouterr().err
+
+
+def test_legacy_direct_host_runtime_requires_explicit_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(cli, "run_ai_web_agent", lambda **kwargs: seen.update(kwargs))
+
+    cli.main(
+        [
+            "--brief",
+            str(brief_path),
+            "--target-url",
+            "http://127.0.0.1:8765",
+            "--workspace-dir",
+            str(tmp_path / "workspace"),
+            "--tool-runtime",
+            "host",
+            "--display",
+            "quiet",
+        ]
+    )
+
+    assert seen["settings"].tool_runtime_mode == "host"
+
+
 def test_observe_resume_rejects_corrupt_traffic_policy_ledger(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -560,7 +657,7 @@ def test_cli_init_writes_env_and_brief(
     assert "[optional]" in output
     assert f"source {env_path}" not in output
     assert f"--env-file {env_path}" in output
-    assert "--tool-runtime host" in output
+    assert "--tool-runtime host" not in output
     assert "--model-profile hosted-openai" not in output
 
 
@@ -657,7 +754,7 @@ def test_cli_setup_check_reports_ready_setup(
     assert "[ok] model" in output
     assert "[ok] brief" in output
     assert "[next]" in output
-    assert "--tool-runtime host" in output
+    assert "--tool-runtime host" not in output
     assert "--allow-paid-models --report" in output
 
 
@@ -895,7 +992,7 @@ def test_setup_check_requires_docker_for_remote_tools(
 
     assert local["status"] == "ok"
     assert remote["status"] == "fail"
-    assert "Docker is required for remote attacks" in str(remote["detail"])
+    assert "Docker is required for the selected attack runtime" in str(remote["detail"])
 
 
 def test_setup_check_rejects_installed_but_unready_docker(
@@ -1002,7 +1099,7 @@ def test_cli_setup_check_fails_with_missing_model_key(
         *, tool_image: str, require_docker: bool = False
     ) -> dict[str, object]:
         assert tool_image
-        assert require_docker is False
+        assert require_docker is True
         return {"name": "tools", "status": "ok", "detail": "ok"}
 
     monkeypatch.setattr(
@@ -2715,6 +2812,7 @@ def test_cli_ai_web_passes_report_agent_flag(
     assert captured["target_url"] == "http://127.0.0.1:8765"
     assert isinstance(settings, cli.AIWebAgentSettings)
     assert settings.report_agent is True
+    assert settings.tool_runtime_mode == "docker"
 
 
 def test_cli_attack_forwards_report_agent_flag(
@@ -2738,6 +2836,37 @@ def test_cli_attack_forwards_report_agent_flag(
     command = calls[0]
     assert "--report" in command
     assert command[command.index("--report-path") + 1] == str(run_dir / "report.json")
+    assert command[command.index("--tool-runtime") + 1] == "docker"
+
+
+def test_cli_attack_preserves_explicit_local_host_runtime_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
+    run_dir = tmp_path / "attack-run"
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], _stdout_path: Path) -> int:
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr(cli, "_run_subprocess_tee_stdout", fake_run)
+
+    cli.main(
+        [
+            "attack",
+            str(brief_path),
+            "--run-dir",
+            str(run_dir),
+            "--tool-runtime",
+            "host",
+        ]
+    )
+
+    command = calls[0]
+    assert command[command.index("--tool-runtime") + 1] == "host"
 
 
 def test_cli_benchmark_uses_openai_compatible_stub_end_to_end(tmp_path: Path) -> None:

--- a/packages/ravage/tests/test_cli_plumbing.py
+++ b/packages/ravage/tests/test_cli_plumbing.py
@@ -646,6 +646,7 @@ def test_cli_init_writes_env_and_brief(
     output = capsys.readouterr().out
     assert "OPENAI_API_KEY=" in env_text
     assert "RAVAGE_OPENAI_LOW_MODEL=gpt-5.4-mini-2026-03-17" in env_text
+    assert "RAVAGE_ANTHROPIC_LOW_MODEL=claude-haiku-4-5-20251001" in env_text
     assert payload["scope"]["in_scope"] == ["http://127.0.0.1:8080"]
     assert payload["objectives"] == ["web_application_assessment"]
     assert payload["context"]["description"].startswith("TODO:")
@@ -1175,6 +1176,51 @@ def test_setup_check_probes_ready_local_model_route(
             "required": True,
         }
     ]
+
+
+def test_setup_check_explains_unpriced_paid_route() -> None:
+    diagnostic = cli._setup_model_check(  # noqa: SLF001
+        model_config=None,
+        model_profile="universal-litellm",
+        model_tier="mid",
+        env_file=None,
+    )
+
+    assert diagnostic["status"] == "fail"
+    assert "missing pricing" in str(diagnostic["detail"])
+    assert "cached_input_cost_per_1m_tokens" in str(diagnostic["detail"])
+    assert "explicit current token prices" in str(diagnostic["fix"])
+
+
+def test_setup_check_explains_unsupported_direct_provider(tmp_path: Path) -> None:
+    model_config = tmp_path / "models.yaml"
+    model_config.write_text(
+        """
+profiles:
+  unsupported:
+    routes:
+      mid:
+        - provider: gemini
+          model: gemini-model
+          base_url: https://generativelanguage.googleapis.com/v1beta
+          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    diagnostic = cli._setup_model_check(  # noqa: SLF001
+        model_config=model_config,
+        model_profile="unsupported",
+        model_tier="mid",
+        env_file=None,
+    )
+
+    assert diagnostic["status"] == "fail"
+    assert "unsupported model transport" in str(diagnostic["detail"])
+    assert "custom_openai/LiteLLM" in str(diagnostic["fix"])
 
 
 def test_cli_setup_check_detects_stale_entrypoint(tmp_path: Path) -> None:
@@ -2930,6 +2976,9 @@ profiles:
           model: cli-stub-model
           base_url: {server.base_url}
           api_key_required: false
+          input_cost_per_1m_tokens: 0.0
+          cached_input_cost_per_1m_tokens: 0.0
+          output_cost_per_1m_tokens: 0.0
 """.lstrip(),
             encoding="utf-8",
         )
@@ -3037,6 +3086,9 @@ profiles:
           model: cli-stub-model
           base_url: {server.base_url}
           api_key_required: false
+          input_cost_per_1m_tokens: 0.0
+          cached_input_cost_per_1m_tokens: 0.0
+          output_cost_per_1m_tokens: 0.0
 """.lstrip(),
             encoding="utf-8",
         )

--- a/packages/ravage/tests/test_frontier_adapter.py
+++ b/packages/ravage/tests/test_frontier_adapter.py
@@ -21,6 +21,7 @@ from ravage.agent_core.frontier_timeout_hygiene import (
     TimeoutCleanupRecord,
 )
 from ravage.auth import AuthArtifactRedactor, SecretValue
+from ravage.model_core.providers import load_model_registry, resolve_model_routes
 from ravage.runtime import FakeToolRuntime, ToolResult
 from ravage.traffic.policy import (
     TrafficPolicyConfig,
@@ -250,6 +251,41 @@ def _raise_after_audit_close(monkeypatch: pytest.MonkeyPatch) -> None:
         raise AuditCloseError(message)
 
     monkeypatch.setattr(frontier_adapter.AuditStore, "close", close_then_fail)
+
+
+def test_credentialless_remote_route_cannot_bypass_frontier_cost_accounting(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "models.yaml"
+    config.write_text(
+        """
+profiles:
+  remote:
+    routes:
+      mid:
+        - provider: custom_openai
+          model: paid-remote-model
+          base_url: https://paid-model.example/v1
+          api_key_required: false
+          input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
+          output_cost_per_1m_tokens: 2.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    registry = load_model_registry(config, env={})
+    route = resolve_model_routes(
+        registry,
+        profile_name="remote",
+        tier="mid",
+        env={},
+    )[0]
+
+    with pytest.raises(RuntimeError, match="cannot be cost-accounted"):
+        frontier_adapter._require_accountable_reply(  # noqa: SLF001
+            route=route,
+            reply=ModelReply(content="{}", usage_reported=False, cost_known=False),
+        )
 
 
 def test_legacy_observe_frontier_creates_the_canonical_run_ledger(

--- a/packages/ravage/tests/test_harness_trace.py
+++ b/packages/ravage/tests/test_harness_trace.py
@@ -265,6 +265,7 @@ def test_agent_persists_one_attempt_record_per_executed_turn(
         brief_path=brief_path,
         target_url="http://127.0.0.1:8765",
         settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
             db_path=tmp_path / "audit.db",
             workspace_dir=workspace_dir,
             model_client=ScriptedModelClient([{"action": "final", "summary": "done"}]),

--- a/packages/ravage/tests/test_host_runtime_local_tools.py
+++ b/packages/ravage/tests/test_host_runtime_local_tools.py
@@ -44,3 +44,43 @@ def test_host_runtime_executes_project_local_tool_from_temporary_workdir(
 
     assert result.ok is True
     assert result.stdout == "project-local tool ran\n"
+
+
+def test_host_runtime_scrubs_parent_secrets_from_shell_and_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-anthropic-secret")
+    monkeypatch.setenv("RAVAGE_ARBITRARY_PARENT_SECRET", "fake-parent-secret")
+    runtime = ExternalToolRuntime()
+    try:
+        shell = runtime.run_command(
+            command=(
+                "printf '%s|%s|%s|%s' "
+                '"${OPENAI_API_KEY-unset}" "${ANTHROPIC_API_KEY-unset}" '
+                '"${RAVAGE_ARBITRARY_PARENT_SECRET-unset}" "$RAVAGE_TARGET_URL"'
+            ),
+            target_url="http://127.0.0.1:8765",
+        )
+        python = runtime.run_python(
+            code=(
+                "import os\n"
+                "keys = ('OPENAI_API_KEY', 'ANTHROPIC_API_KEY', "
+                "'RAVAGE_ARBITRARY_PARENT_SECRET')\n"
+                "print('|'.join(os.environ.get(key, 'unset') for key in keys))\n"
+                "print(os.environ['RAVAGE_TARGET_URL'])\n"
+                "print(os.environ['HOME'])\n"
+            ),
+            target_url="http://127.0.0.1:8765",
+        )
+    finally:
+        runtime.close()
+
+    assert shell.ok is True
+    assert shell.stdout == "unset|unset|unset|http://127.0.0.1:8765"
+    assert python.ok is True
+    assert python.stdout.splitlines() == [
+        "unset|unset|unset",
+        "http://127.0.0.1:8765",
+        str(runtime.workdir),
+    ]

--- a/packages/ravage/tests/test_model_client.py
+++ b/packages/ravage/tests/test_model_client.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
 import json
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import TYPE_CHECKING, Self
+import urllib.request
+from typing import Self
 
+import pytest
 from ravage.agent_core.ai_agent import (
     ChatMessage,
     ProviderChatClient,
 )
 from ravage.model_core.providers import ProviderKind, ResolvedModelRoute
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_native_anthropic_client_posts_messages_payload(
@@ -20,34 +17,73 @@ def test_native_anthropic_client_posts_messages_payload(
 ) -> None:
     action = {"action": "final", "args": {"summary": "done"}, "rationale": "complete"}
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+    requests_seen: list[dict[str, object]] = []
 
-    with AnthropicStubServer(action) as server:
-        route = _route(provider="anthropic", model="claude-haiku-4-5", base_url=server.base_url)
-
-        reply = ProviderChatClient().complete(
-            messages=[
-                ChatMessage(role="system", content="system one"),
-                ChatMessage(role="system", content="system two"),
-                ChatMessage(role="user", content="first user"),
-                ChatMessage(role="user", content="second user"),
-                ChatMessage(role="assistant", content='{"action":"discover_attack_surface"}'),
-                ChatMessage(role="user", content="next observation"),
-            ],
-            route=route,
+    def fake_urlopen(
+        request: urllib.request.Request,
+        *,
+        timeout: float,
+    ) -> StubHTTPResponse:
+        assert timeout > 0
+        headers = {name.lower(): value for name, value in request.header_items()}
+        assert request.data is not None
+        requests_seen.append(
+            {
+                "url": request.full_url,
+                "headers": headers,
+                "payload": json.loads(request.data.decode("utf-8")),
+            }
+        )
+        return StubHTTPResponse(
+            {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": json.dumps(action)}],
+                "model": "claude-haiku-4-5-20251001",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
         )
 
+    monkeypatch.setattr(
+        "ravage.agent_core.ai_agent.urllib.request.urlopen",
+        fake_urlopen,
+    )
+
+    route = _route(
+        provider="anthropic",
+        model="claude-haiku-4-5-20251001",
+        base_url="https://api.anthropic.com",
+    )
+
+    reply = ProviderChatClient().complete(
+        messages=[
+            ChatMessage(role="system", content="system one"),
+            ChatMessage(role="system", content="system two"),
+            ChatMessage(role="user", content="first user"),
+            ChatMessage(role="user", content="second user"),
+            ChatMessage(role="assistant", content='{"action":"discover_attack_surface"}'),
+            ChatMessage(role="user", content="next observation"),
+        ],
+        route=route,
+    )
+
     assert json.loads(reply.content) == action
-    assert server.requests_seen == [
+    assert reply.cost_known is True
+    assert reply.cost_usd == pytest.approx(0.000006)
+    assert reply.response_model == "claude-haiku-4-5-20251001"
+    assert requests_seen == [
         {
+            "url": "https://api.anthropic.com/v1/messages",
             "headers": {
                 "x-api-key": "anthropic-test-key",
                 "anthropic-version": "2023-06-01",
                 "content-type": "application/json",
             },
             "payload": {
-                "model": "claude-haiku-4-5",
+                "model": "claude-haiku-4-5-20251001",
                 "max_tokens": 256,
-                "temperature": 0,
                 "system": "system one\n\nsystem two",
                 "messages": [
                     {"role": "user", "content": "first user"},
@@ -60,73 +96,18 @@ def test_native_anthropic_client_posts_messages_payload(
     ]
 
 
-class AnthropicStubHandler(BaseHTTPRequestHandler):
-    action: dict[str, object]
-    requests_seen: list[dict[str, object]]
-
-    def do_POST(self) -> None:
-        if self.path != "/v1/messages":
-            self.send_error(404)
-            return
-
-        content_length = int(self.headers.get("Content-Length", "0"))
-        raw_body = self.rfile.read(content_length).decode("utf-8")
-        self.requests_seen.append(
-            {
-                "headers": {
-                    "x-api-key": self.headers.get("x-api-key", ""),
-                    "anthropic-version": self.headers.get("anthropic-version", ""),
-                    "content-type": self.headers.get("content-type", ""),
-                },
-                "payload": json.loads(raw_body),
-            }
-        )
-        response_payload = {
-            "id": "msg_test",
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "text", "text": json.dumps(self.action)}],
-            "model": "claude-haiku-4-5",
-            "stop_reason": "end_turn",
-            "usage": {"input_tokens": 1, "output_tokens": 1},
-        }
-        response_body = json.dumps(response_payload).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(response_body)))
-        self.end_headers()
-        self.wfile.write(response_body)
-
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A002, ARG002
-        return
-
-
-class AnthropicStubServer:
-    def __init__(self, action: dict[str, object]) -> None:
-        self._handler: type[AnthropicStubHandler] = type(
-            "PerTestAnthropicStubHandler",
-            (AnthropicStubHandler,),
-            {"action": action, "requests_seen": []},
-        )
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+class StubHTTPResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
 
     def __enter__(self) -> Self:
-        self._thread.start()
         return self
 
     def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
-        self._server.shutdown()
-        self._server.server_close()
-        self._thread.join(timeout=2)
+        return None
 
-    @property
-    def base_url(self) -> str:
-        return f"http://127.0.0.1:{self._server.server_port}"
-
-    @property
-    def requests_seen(self) -> list[dict[str, object]]:
-        return self._handler.requests_seen
+    def read(self) -> bytes:
+        return self._body
 
 
 def _route(
@@ -147,8 +128,9 @@ def _route(
         reasoning_effort=None,
         max_output_tokens=256,
         output_token_limit_parameter="max_tokens",  # noqa: S106 - parameter name, not a secret.
-        input_cost_per_1m_tokens=None,
-        output_cost_per_1m_tokens=None,
+        input_cost_per_1m_tokens=1.0,
+        output_cost_per_1m_tokens=5.0,
         timeout_seconds=5.0,
         max_retries=0,
+        cached_input_cost_per_1m_tokens=0.1,
     )

--- a/packages/ravage/tests/test_xben_runner.py
+++ b/packages/ravage/tests/test_xben_runner.py
@@ -12,6 +12,7 @@ from typing import cast
 
 import pytest
 import yaml  # type: ignore[import-untyped]
+from ravage.model_core.providers import load_model_registry, resolve_model_routes
 from ravage.run_data.brief import load_engagement_brief
 from ravage.traffic import (
     RequestIntent,
@@ -57,6 +58,7 @@ from ravage.xben_parts.runner import (
     _case_run_identity,
     _CasePaths,
     _CaseRunIdentity,
+    _has_paid_model_risk,
     _remaining_cost_budget,
     _require_autonomous_runtime_cleanup,
     _require_scoped_tool_network_evidence,
@@ -97,6 +99,19 @@ def _healthy_docker_image_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
             "error": None,
         },
     )
+
+
+def test_xben_treats_remote_endpoint_under_local_provider_label_as_paid_risk() -> None:
+    env = {"OLLAMA_BASE_URL": "https://paid-model.example/v1"}
+    registry = load_model_registry(env=env)
+    route = resolve_model_routes(
+        registry,
+        profile_name="local-ollama",
+        tier="mid",
+        env=env,
+    )[0]
+
+    assert _has_paid_model_risk((route,))
 
 
 def _write_case(
@@ -1215,6 +1230,7 @@ profiles:
           model: gpt-test
           api_key_required: false
           input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
           output_cost_per_1m_tokens: 2.0
           output_token_limit_parameter: max_completion_tokens
 """.lstrip(),
@@ -1298,6 +1314,7 @@ profiles:
           model: gpt-test
           api_key_required: false
           input_cost_per_1m_tokens: 1.0
+          cached_input_cost_per_1m_tokens: 1.0
           output_cost_per_1m_tokens: 2.0
 """.lstrip(),
         encoding="utf-8",


### PR DESCRIPTION
## Summary

  Harden Ravage’s runtime and model provider for safer use.

  ## Changes

  - Prevent `auto` mode from silently falling back to host execution.
  - Require explicit `--tool-runtime host` opt-in for trusted localhost use.
  - Default authorized remote attacks to the low noise traffic policy.
  - Reject unsupported, ambiguous, or unpriced model routes before dispatch.
  - Add cache for OpenAI and Anthropic cost accounting.
  - Update Anthropic model IDs and pricing validation.
