### PR TITLE
fix(scan): improve deterministic detection and reporting reliability

### DIFF
--- a/docs/ai-web-operator-guide.md
+++ b/docs/ai-web-operator-guide.md
@@ -134,6 +134,12 @@ ravage scan examples/labs/ravage-acme-box/brief.yaml \
 Use `--all-probes` to run the full deterministic catalog, or repeat `--probe`
 for a focused run. Inspect available probes with:
 
+`--all-probes` is intentionally broad and can generate thousands of bounded
+requests across the catalog even while respecting the brief's rate limit. Use
+it on disposable local or staging targets. For an authorized remote target,
+start with `surface_map` and add only the probes justified by the rules of
+engagement.
+
 ```bash
 ravage scan --help
 ravage tools list

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -55,7 +55,8 @@ and skips unavailable probes during the default or `--all-probes` selection. If
 you explicitly name an incompatible probe with `--probe`, Ravage fails closed
 before dispatch instead of silently changing its identity policy. The attack
 example assumes a paid model route; omit `--allow-paid-models` when using a
-local model.
+local model. The full catalog can generate thousands of bounded requests, so
+use focused probes unless the target and rules of engagement allow that breadth.
 
 Use `--identity user` explicitly in saved commands and automation. The public
 `ravage attack` wrapper selects the identity automatically when the brief has

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -618,7 +618,9 @@ ravage scan ravage-brief.yaml \
 Useful scan options include `--probe NAME`, `--all-probes`,
 `--timeout-seconds N`, `--report`, and `--json`. Treat probe output as evidence
 signals unless the resulting record has passed a formal confirmation gate; a
-count alone is not proof of a vulnerability.
+count alone is not proof of a vulnerability. `--all-probes` can generate
+thousands of bounded requests across the catalog; reserve it for disposable
+local or staging targets, and use focused probes for remote engagements.
 
 ### Optional: capture, inspect, and replay browser traffic
 

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -26,14 +26,16 @@ from uuid import UUID, uuid4
 import yaml  # type: ignore[import-untyped]
 
 from ravage import authbench, cli_tool_check, cli_tools, package_version
+from ravage.agent_core.action_executor import (
+    record_probe_result,
+    record_verified_probe_findings,
+)
 from ravage.agent_core.agent_state import (
     AgentState,
     load_agent_state,
-    merge_signals,
     resolve_agent_state_path,
     save_agent_state,
 )
-from ravage.agent_core.agent_strategy import observation_digest
 from ravage.agent_core.ai_agent import (
     AIWebAgentSettings,
     route_has_paid_transport_risk,
@@ -46,7 +48,7 @@ from ravage.agent_core.autonomous_route_selection import (
     AUTONOMOUS_ROUTE_ENGINES,
     run_selected_autonomous_route,
 )
-from ravage.agent_core.observation_analysis import extract_signals
+from ravage.agent_core.surface_graph import SurfaceGraphState
 from ravage.agent_knowledge import describe_knowledge_pack
 from ravage.agent_knowledge.cli import handle_skills_command
 from ravage.auth import (
@@ -187,6 +189,8 @@ _MAX_RESULT_IDENTIFIER_CHARS = 64
 _MAX_SCAN_PROOF_SCAN_CHARS = 8_000_000
 _MAX_SCAN_PROOF_VALUE_CHARS = 650_000
 _MAX_SCAN_PROOF_NODES = 20_000
+_MAX_SCAN_OBSERVATION_CHARS = 10_000
+_MAX_SCAN_TRANSCRIPT_CHARS = 80_000
 
 _TOP_LEVEL_COMMANDS = (
     "attack",
@@ -2538,7 +2542,10 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             "scope manifest could not be initialized"
         )
     audit = AuditStore(db_path, scope=brief.scope)
-    state = AgentState(summary="deterministic scan")
+    surface_graph = SurfaceGraphState.for_target(target_url)
+    state = AgentState(summary="deterministic scan", surface_graph=surface_graph)
+    state.surface["target_url"] = target_url
+    state.surface["origin"] = surface_graph.target_origin
     state.surface["scope_in_scope"] = list(brief.scope.in_scope)
     state.surface["scope_out_of_scope"] = list(brief.scope.out_of_scope)
     state.surface["scope_max_rps"] = brief.roe.max_rps
@@ -2569,7 +2576,8 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     )
     workspace.record_event(kind="scan_started", payload=start_payload)
 
-    findings_count = 0
+    probe_observations_count = 0
+    confirmed_findings_count = 0
     observed_request_count = 0
     observed_http_response_count = 0
     transport_errors: list[str] = []
@@ -2664,7 +2672,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                 error = str(request.get("error") or "").strip()
                 if error and error not in transport_errors:
                     transport_errors.append(error)
-            findings_count += len(result.findings)
+            probe_observations_count += len(result.findings)
             raw_payload = {
                 "probe": probe,
                 "ok": result.ok,
@@ -2684,14 +2692,39 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             payload = _require_scan_payload(artifact_redactor.redact(raw_payload))
             text = json.dumps(payload, indent=2, sort_keys=True)
             safe_summary = artifact_redactor.redact_text(result.summary)
+            action_id = f"scan-{index:03d}-{probe}"
+            session_mode = (
+                f"identity:{parsed.identity}" if use_authenticated_session else "anonymous"
+            )
+            probe_result = record_probe_result(
+                text,
+                ok=result.ok,
+                kind="tool_run_probe",
+                state=state,
+                workspace=workspace,
+                audit=audit,
+                engagement_id=brief.engagement_id,
+                proof_recognition_enabled=False,
+                action_id=action_id,
+                repeat_count=1,
+                timed_out=False,
+                max_observation_chars=_MAX_SCAN_OBSERVATION_CHARS,
+                max_transcript_chars=_MAX_SCAN_TRANSCRIPT_CHARS,
+                session_mode=session_mode,
+                authentication=auth_owner,
+            )
+            scan_payload = dict(payload)
+            scan_payload["action_id"] = action_id
+            scan_payload["source_observation_id"] = str(
+                state.last_observation.get("observation_id") or ""
+            )
             audit.record(
                 engagement_id=brief.engagement_id,
                 actor="tool",
                 action="scan_probe",
-                payload=payload,
+                payload=scan_payload,
             )
-            workspace.record_event(kind="scan_probe", payload=payload)
-            workspace.record_transcript(role="tool", content=text)
+            workspace.record_event(kind="scan_probe", payload=scan_payload)
             state.turn = index
             state.actions.append(
                 {
@@ -2701,8 +2734,17 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                     "summary": safe_summary,
                 }
             )
-            state.last_observation = observation_digest(text)
-            merge_signals(state, extract_signals(text))
+            record_verified_probe_findings(
+                probe=probe,
+                probe_text=text,
+                result=probe_result,
+                target_url=target_url,
+                state=state,
+                workspace=workspace,
+                audit=audit,
+                engagement_id=brief.engagement_id,
+                action_id=action_id,
+            )
             _capture_scan_proofs(
                 recognized_proofs,
                 state=state,
@@ -2726,6 +2768,10 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             observed_responses=observed_http_response_count,
             transport_errors=transport_errors,
             redactor=artifact_redactor,
+        )
+        confirmed_findings_count = audit.count_findings(
+            status="confirmed",
+            engagement_id=brief.engagement_id,
         )
     except BaseException as exc:
         failure_payload: dict[str, object] = {
@@ -2804,7 +2850,8 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         "identity": parsed.identity or "",
         "probes_run": len(selected_probes),
         "skipped_authenticated_probes": skipped_authenticated_probes,
-        "findings_count": findings_count,
+        "probe_observations_count": probe_observations_count,
+        "confirmed_findings_count": confirmed_findings_count,
         "traffic_requests": traffic_requests,
         "traffic_contracts": traffic_contracts,
         "traffic_recorder_errors": traffic_recorder_errors,

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -235,6 +235,38 @@ DEFAULT_SCAN_PROBES = (
     "browser_boundary",
 )
 
+_SCAN_DISCOVERY_PROBES = (
+    "surface_map",
+    "secret_sweep",
+    "direct_exposure",
+    "api_behavior",
+    "browser_boundary",
+)
+
+_SCAN_PROBE_DEPENDENCIES: dict[str, tuple[str, ...]] = {
+    "browser_boundary": ("surface_map",),
+    "captcha_form_state": ("stateful_session",),
+    "cms_exposure": ("direct_exposure",),
+    "cookie_deserialization": ("stateful_session",),
+    "csrf_session": ("stateful_session",),
+    "dom_execution": ("xss_context", "xss_filter_constraint"),
+    "file_read_extract": ("file_fetch_parser",),
+    "filtered_query_bypass": ("sqli_differential",),
+    "graphql_exploit": ("api_behavior",),
+    "idor_boundary": ("api_behavior", "stateful_session"),
+    "jwt_exploit": ("api_behavior", "stateful_session"),
+    "preg_match_subject": ("sqli_differential",),
+    "reflection_value_boundary": ("input_reflection",),
+    "sqli_auth_transition": ("sqli_exploit",),
+    "sqli_exploit": ("data_query", "sqli_differential"),
+    "ssti_deferred_context_closure": ("ssti_fingerprint",),
+    "ssti_fingerprint": ("server_rendering",),
+    "werkzeug_console": ("direct_exposure",),
+    "xss_context": ("input_reflection",),
+    "xss_filter_constraint": ("xss_context",),
+    "xxe_boundary": ("file_fetch_parser",),
+}
+
 BRIEF_DESCRIPTION_TODO = (
     "TODO: describe the target, challenge text, rules, credentials, and win condition."
 )
@@ -4299,13 +4331,43 @@ def _attack_resume_workspace(resume_from: Path) -> Path:
 
 
 def _selected_scan_probes(requested: list[str], *, all_probes: bool) -> list[str]:
-    known = {item["name"] for item in available_probes()}
-    selected = sorted(known) if all_probes else list(requested or DEFAULT_SCAN_PROBES)
+    catalog = [item["name"] for item in available_probes()]
+    known = set(catalog)
+    selected = (
+        _dependency_ordered_scan_probes(catalog)
+        if all_probes
+        else list(requested or DEFAULT_SCAN_PROBES)
+    )
     unknown = [probe for probe in selected if probe not in known]
     if unknown:
         choices = ", ".join(sorted(known))
         message = f"unknown probe(s): {', '.join(unknown)}; choices: {choices}"
         raise SystemExit(message)
+    return selected
+
+
+def _dependency_ordered_scan_probes(catalog: list[str]) -> list[str]:
+    """Return a stable breadth-before-depth order for the complete probe catalog."""
+    known = set(catalog)
+    pending = list(catalog)
+    selected: list[str] = []
+    completed: set[str] = set()
+    while pending:
+        for index, probe in enumerate(pending):
+            dependencies = set(_SCAN_PROBE_DEPENDENCIES.get(probe, ()))
+            if probe not in _SCAN_DISCOVERY_PROBES:
+                dependencies.update(item for item in _SCAN_DISCOVERY_PROBES if item in known)
+            if all(
+                dependency not in known or dependency in completed
+                for dependency in dependencies
+            ):
+                selected.append(probe)
+                completed.add(probe)
+                pending.pop(index)
+                break
+        else:
+            unresolved = ", ".join(pending)
+            raise RuntimeError(f"cyclic deterministic scan probe dependencies: {unresolved}")
     return selected
 
 

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -2402,8 +2402,9 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         prog="ravage scan",
         description="Run deterministic built-in probes without model calls.",
         epilog=(
-            "Use --all-probes for the full in-tree probe catalog, or repeat "
-            "--probe for a focused run."
+            "Use --all-probes for the broad, high-traffic in-tree catalog; it may "
+            "generate thousands of bounded requests. Repeat --probe for a focused "
+            "run, especially against authorized remote targets."
         ),
     )
     parser.add_argument(
@@ -2430,7 +2431,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     parser.add_argument(
         "--all-probes",
         action="store_true",
-        help="run every built-in deterministic probe",
+        help="run the broad catalog; may generate thousands of bounded requests",
     )
     parser.add_argument(
         "--list-probes",

--- a/packages/ravage/src/ravage/agent_core/action_executor.py
+++ b/packages/ravage/src/ravage/agent_core/action_executor.py
@@ -319,7 +319,7 @@ def execute_action(  # noqa: PLR0913
                     traffic_policy.to_reference() if traffic_policy is not None else None
                 ),
             )
-        result = _record_probe_result(
+        result = record_probe_result(
             probe_result.text,
             ok=probe_result.ok,
             kind="tool_run_probe",
@@ -336,7 +336,7 @@ def execute_action(  # noqa: PLR0913
             session_mode=session_mode,
             authentication=authentication,
         )
-        return _record_verified_probe_finding(
+        return record_verified_probe_findings(
             probe=probe,
             probe_text=probe_result.text,
             result=result,
@@ -433,7 +433,7 @@ def execute_action(  # noqa: PLR0913
             )
             validation_payload["session_mode"] = session_mode
             validation_text = json.dumps(validation_payload, indent=2, sort_keys=True)
-        result = _record_probe_result(
+        result = record_probe_result(
             validation_text,
             ok=validation_result.ok,
             kind="tool_validate_poc",
@@ -942,7 +942,7 @@ def _record_validated_finding(  # noqa: PLR0913
     )
 
 
-def _record_verified_probe_finding(  # noqa: C901, PLR0912, PLR0913
+def record_verified_probe_findings(  # noqa: C901, PLR0912, PLR0913
     *,
     probe: str,
     probe_text: str,
@@ -1056,6 +1056,12 @@ def _record_verified_probe_finding(  # noqa: C901, PLR0912, PLR0913
             engagement_id=engagement_id,
         )
     return current
+
+
+# Compatibility alias for existing internal consumers. New deterministic
+# runners should use the public shared recorder above instead of creating a
+# second finding-promotion path.
+_record_verified_probe_finding = record_verified_probe_findings
 
 
 def _raw_probe_finding(
@@ -2315,7 +2321,7 @@ def _tool_proof_text(result: ToolResult) -> str:
     return "\n".join(parts)
 
 
-def _record_probe_result(  # noqa: PLR0913
+def record_probe_result(  # noqa: PLR0913
     text: str,
     *,
     ok: bool,
@@ -2408,6 +2414,12 @@ def _record_probe_result(  # noqa: PLR0913
         evidence_observation=text,
         session_mode=session_mode,
     )
+
+
+# Compatibility alias for focused tests and older internal imports. Keeping a
+# single implementation makes probe provenance identical across agent and scan
+# entry points.
+_record_probe_result = record_probe_result
 
 
 def _ingest_probe_surface_graph(

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/action_executor.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/action_executor.py
@@ -14,10 +14,10 @@ from ravage.agent_core.action_executor import (
     _decode_probe_runner_payload,
     _probe_failure_text,
     _probe_wall_timeout,
-    _record_probe_result,
-    _record_verified_probe_finding,
     _timeout,
     execute_action,
+    record_probe_result,
+    record_verified_probe_findings,
 )
 from ravage.agent_core.autonomous_graph.effort_policy import (
     GRAPH_ROUTE_TARGET_REQUEST_LIMIT,
@@ -115,7 +115,7 @@ def execute_graph_action(
             traffic_policy.to_reference() if traffic_policy is not None else None
         ),
     )
-    result = _record_probe_result(
+    result = record_probe_result(
         probe_result.text,
         ok=probe_result.ok,
         kind="tool_run_probe",
@@ -130,7 +130,7 @@ def execute_graph_action(
         max_observation_chars=max_observation_chars,
         max_transcript_chars=max_transcript_chars,
     )
-    return _record_verified_probe_finding(
+    return record_verified_probe_findings(
         probe=probe,
         probe_text=probe_result.text,
         result=result,

--- a/packages/ravage/src/ravage/agent_core/observation_analysis.py
+++ b/packages/ravage/src/ravage/agent_core/observation_analysis.py
@@ -144,7 +144,10 @@ def _collect_javascript_endpoint_signals(signals: dict[str, list[str]], text: st
 
 
 def _collect_plain_url_signals(signals: dict[str, list[str]], text: str) -> None:
-    pattern = r"https?://[^\s'\"<>]+|/[A-Za-z0-9._~:/?#@!$&()*+,;=%-]+"
+    pattern = (
+        r"https?://[^\s'\"<>]+|"
+        r"(?<![A-Za-z0-9._-])/[A-Za-z0-9._~:/?#@!$&()*+,;=%-]+"
+    )
     for match in re.finditer(pattern, text):
         _record_plain_url(signals, match.group(0))
 

--- a/packages/ravage/src/ravage/deterministic_agents/xss.py
+++ b/packages/ravage/src/ravage/deterministic_agents/xss.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import json
 import re
-from typing import Callable, cast
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
 
-from ravage.agent_core.agent_state import AgentState
-from ravage.web_core.http_probe import ProbeResponse, ProbeSession, form_defaults, inject_query_param
+from ravage.deterministic_agents.xss_payloads import (
+    _XSS_PROOF_TOKENS,
+    _dom_exec_payloads,
+)
 from ravage.probe_suite_parts.result import ProbeRunResult
 from ravage.probe_suite_parts.support import (
+    _absolute_same_origin_url,
     _dedupe,
     _form_input_names,
     _form_targets,
@@ -18,12 +22,17 @@ from ravage.probe_suite_parts.support import (
     _parameter_targets,
     _string_items,
 )
-from ravage.web_core.proof_recognizer import recognize_proofs
 from ravage.runtime.browser import BrowserObservation, BrowserStatus
-from ravage.deterministic_agents.xss_payloads import (
-    _XSS_PROOF_TOKENS,
-    _dom_exec_payloads,
+from ravage.web_core.http_probe import (
+    ProbeResponse,
+    ProbeSession,
+    form_defaults,
+    inject_query_param,
 )
+from ravage.web_core.proof_recognizer import recognize_proofs
+
+if TYPE_CHECKING:
+    from ravage.agent_core.agent_state import AgentState
 
 
 _DOM_EXEC_NAV_BUDGET = 16
@@ -105,9 +114,12 @@ def _run_dom_execution_targets(
     render_request_fn: RenderRequestFn | None,
     run: _DomExecutionRun,
 ) -> ProbeRunResult | None:
-    for target in _dom_targets(state):
+    for candidate in _dom_targets(state):
         if run.budget <= 0:
             break
+        target = _scoped_dom_target(session, candidate)
+        if target is None:
+            continue
         name = str(target.get("name") or "")
         base = str(target.get("url") or "")
         if not name or not base:
@@ -128,6 +140,31 @@ def _run_dom_execution_targets(
         if run.findings:
             break
     return None
+
+
+def _scoped_dom_target(
+    session: ProbeSession,
+    target: dict[str, object],
+) -> dict[str, object] | None:
+    raw_page_url = str(target.get("page_url") or "")
+    page_url = _absolute_same_origin_url(raw_page_url, base_url=session.target_url)
+    if raw_page_url and (not page_url or not session.in_scope(page_url)):
+        return None
+    base_url = page_url or session.target_url
+    url = _absolute_same_origin_url(target.get("url"), base_url=base_url)
+    if not url or not session.in_scope(url):
+        return None
+    scoped = dict(target)
+    scoped["url"] = url
+    scoped["page_url"] = page_url
+    raw_form = target.get("form")
+    if isinstance(raw_form, dict):
+        form = dict(raw_form)
+        form["action"] = url
+        if scoped["page_url"]:
+            form["page"] = scoped["page_url"]
+        scoped["form"] = form
+    return scoped
 
 
 def _run_dom_execution_target(

--- a/packages/ravage/src/ravage/probe_suite_parts/support.py
+++ b/packages/ravage/src/ravage/probe_suite_parts/support.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import secrets
 from typing import cast
-from urllib.parse import unquote_plus, urlsplit, urlunsplit
+from urllib.parse import unquote_plus, urljoin, urlsplit, urlunsplit
 
 from ravage.agent_core.agent_state import AgentState
 from ravage.web_core.http_probe import ProbeResponse, ProbeSession
@@ -568,6 +568,27 @@ def _url_in_scope(url: str, origin: str) -> bool:
     if not action_parts.scheme and not action_parts.netloc:
         return True
     return (action_parts.scheme, action_parts.netloc) == (origin_parts.scheme, origin_parts.netloc)
+
+
+def _absolute_same_origin_url(value: object, *, base_url: str) -> str:
+    """Resolve one observed URL while rejecting malformed or cross-origin targets."""
+    text = str(value or "").strip()
+    if not text or not base_url:
+        return ""
+    try:
+        absolute = urljoin(base_url, text)
+    except ValueError:
+        return ""
+    cleaned = _clean_signal_endpoint(absolute, origin=base_url)
+    if not cleaned or not _url_in_scope(cleaned, base_url):
+        return ""
+    try:
+        parsed = urlsplit(cleaned)
+    except ValueError:
+        return ""
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        return ""
+    return cleaned
 
 
 def _url_looks_static_oauth_redirect(url: str) -> bool:

--- a/packages/ravage/src/ravage/report.py
+++ b/packages/ravage/src/ravage/report.py
@@ -8,6 +8,7 @@ import stat
 from datetime import UTC, datetime
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, Self, cast
+from urllib.parse import urlsplit
 
 from ravage.finding_evidence import confirmed_finding_evidence_failures
 from ravage.hosting_layer import HOSTING_LAYER_EVENT_KIND, run_configured_hosting_layer_agent
@@ -21,6 +22,7 @@ from ravage.traffic.manifest import (
 )
 from ravage.traffic.policy import TrafficPolicyError, load_traffic_policy_snapshot
 from ravage.traffic.provenance import TrafficProvenanceError, load_traffic_provenance
+from ravage.traffic.redaction import REDACTED_URL, sanitize_url
 from ravage.traffic.store import TrafficStore, TrafficStoreError
 
 if TYPE_CHECKING:
@@ -328,7 +330,7 @@ def build_pentest_report(  # noqa: PLR0913
     generated_at = datetime.now(UTC).isoformat()
     target = target_url or _target_from_events(events) or (manifest.target_url if manifest else "")
     agent_http_evidence = _agent_http_evidence_summary(workspace_dir)
-    traffic_accounting = _traffic_accounting_summary(workspace_dir)
+    traffic_accounting = _traffic_accounting_summary(workspace_dir, events=events)
     report = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
@@ -441,16 +443,7 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
     ]
     lines.extend(f"- {item}" for item in _list(report.get("methodology")))
     lines.extend(["", "## Reconnaissance", ""])
-    recon = _dict(report.get("reconnaissance"))
-    lines.extend(
-        [
-            f"- Pages observed: {recon.get('page_count', 0)}",
-            f"- Forms observed: {recon.get('form_count', 0)}",
-            f"- Query parameters observed: {_join(_list(recon.get('query_parameter_names')))}",
-            f"- Interesting markers: {_join(_list(recon.get('interesting_markers')))}",
-            "",
-        ]
-    )
+    lines.extend(_recon_markdown(_dict(report.get("reconnaissance"))))
     hosting = _dict(report.get("hosting_layer"))
     if bool(hosting.get("enabled")):
         lines.extend(_hosting_layer_markdown(hosting))
@@ -524,6 +517,36 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
     return "\n".join(lines)
 
 
+def _recon_markdown(recon: dict[str, Any]) -> list[str]:
+    lines = [
+        f"- Pages observed: {recon.get('page_count', 0)}",
+        f"- Forms observed: {recon.get('form_count', 0)}",
+        f"- Query parameters observed: {_join(_list(recon.get('query_parameter_names')))}",
+        f"- Interesting markers: {_join(_list(recon.get('interesting_markers')))}",
+    ]
+    recon_sources = _list(recon.get("source_kinds"))
+    if recon_sources:
+        lines.append(f"- Evidence sources: {_join(recon_sources)}")
+    surface_requests = recon.get("surface_request_count")
+    surface_responses = recon.get("surface_response_count")
+    if (
+        isinstance(surface_requests, int)
+        and surface_requests > 0
+        and isinstance(surface_responses, int)
+    ):
+        lines.append(
+            f"- Surface-map HTTP responses: {surface_responses}/{surface_requests} requests"
+        )
+    status_counts = _dict(recon.get("surface_status_counts"))
+    if status_counts:
+        status_summary = ", ".join(f"{status}={count}" for status, count in status_counts.items())
+        lines.append(f"- Surface-map status counts: {status_summary}")
+    finding_types = _list(recon.get("surface_finding_types"))
+    if finding_types:
+        lines.append(f"- Surface-map signals: {_join(finding_types)}")
+    return [*lines, ""]
+
+
 def redact_sensitive(value: str) -> str:
     redacted = _PROOF_RE.sub(lambda match: _mask_proof(match.group(0)), str(value))
     for pattern in _SECRET_PATTERNS:
@@ -531,9 +554,19 @@ def redact_sensitive(value: str) -> str:
     return redacted
 
 
-def _traffic_accounting_summary(workspace_dir: Path) -> dict[str, object]:
+def _traffic_accounting_summary(
+    workspace_dir: Path,
+    *,
+    events: list[dict[str, Any]],
+) -> dict[str, object]:
     ledger_path = workspace_dir / "traffic-policy.json"
     if not ledger_path.exists():
+        scan_accounting = _scan_traffic_accounting_summary(
+            workspace_dir,
+            events=events,
+        )
+        if scan_accounting is not None:
+            return scan_accounting
         return {
             "status": "unavailable",
             "provenance": "traffic_policy_ledger_missing",
@@ -551,9 +584,7 @@ def _traffic_accounting_summary(workspace_dir: Path) -> dict[str, object]:
         None
         if limit is None
         else max(
-            limit
-            - snapshot.physical_request_count
-            - snapshot.reservation_count,
+            limit - snapshot.physical_request_count - snapshot.reservation_count,
             0,
         )
     )
@@ -579,6 +610,52 @@ def _traffic_accounting_summary(workspace_dir: Path) -> dict[str, object]:
     }
 
 
+def _scan_traffic_accounting_summary(
+    workspace_dir: Path,
+    *,
+    events: list[dict[str, Any]],
+) -> dict[str, object] | None:
+    if not any(event.get("kind") == "scan_probe" for event in events):
+        return None
+    try:
+        traffic_workspace = resolve_workspace(workspace_dir)
+    except TrafficRunError as exc:
+        if _canonical_traffic_artifacts_present(workspace_dir):
+            message = "traffic artifacts are present but could not be validated"
+            raise TrafficProvenanceError(message) from exc
+        return None
+    try:
+        traffic_manifest = read_traffic_manifest(traffic_workspace)
+        exchanges = TrafficStore.open(traffic_workspace).exchanges()
+    except (TrafficRunError, TrafficStoreError) as exc:
+        message = "traffic artifacts are present but could not be validated"
+        raise TrafficProvenanceError(message) from exc
+    if any(
+        exchange.capture_session_id != traffic_manifest.capture_session_id for exchange in exchanges
+    ):
+        message = "traffic capture session does not match its run manifest"
+        raise TrafficProvenanceError(message)
+
+    scan_exchanges = tuple(exchange for exchange in exchanges if exchange.source == "probe_session")
+    if not scan_exchanges:
+        return None
+    physical_requests = sum(exchange.request_sent for exchange in scan_exchanges)
+    return {
+        # The store proves these dispatches occurred, but without the physical
+        # policy ledger it cannot prove that redirects or recorder failures did
+        # not add requests. Never promote this fallback to exact accounting.
+        "status": "lower_bound",
+        "provenance": "validated_workspace_traffic_store",
+        "mode": "recorded_scan_traffic",
+        "physical_request_count": physical_requests,
+        "max_physical_requests": None,
+        "remaining_physical_requests": None,
+        "recorded_exchange_count": len(scan_exchanges),
+        "blocked_count": sum(not exchange.request_sent for exchange in scan_exchanges),
+        "capture_completed": bool(traffic_manifest.completed_at),
+    }
+
+
 def _agent_http_evidence_summary(
     workspace_dir: Path,
 ) -> dict[str, object]:
@@ -600,8 +677,7 @@ def _agent_http_evidence_summary(
         message = "traffic artifacts are present but could not be validated"
         raise TrafficProvenanceError(message) from exc
     if any(
-        exchange.capture_session_id != traffic_manifest.capture_session_id
-        for exchange in exchanges
+        exchange.capture_session_id != traffic_manifest.capture_session_id for exchange in exchanges
     ):
         message = "traffic capture session does not match its run manifest"
         raise TrafficProvenanceError(message)
@@ -630,17 +706,11 @@ def _agent_http_evidence_summary(
         return _empty_agent_http_evidence_summary()
 
     evidence_ids = tuple(
-        dict.fromkeys(
-            evidence_id
-            for link in agent_links
-            for evidence_id in link.evidence_refs
-        )
+        dict.fromkeys(evidence_id for link in agent_links for evidence_id in link.evidence_refs)
     )
     material_evidence_ids = tuple(
         dict.fromkeys(
-            evidence_id
-            for link in agent_links
-            for evidence_id in link.material_evidence_refs
+            evidence_id for link in agent_links for evidence_id in link.material_evidence_refs
         )
     )
     links = [
@@ -708,9 +778,8 @@ def _graph_traffic_expected(workspace_dir: Path) -> bool:
             return True
 
         remote_state = _read_bounded_json_object(candidate / "remote-http-state.json")
-        if (
-            remote_state.get("version") == _PRIVATE_HTTP_STATE_VERSION
-            and remote_state.get("target_identity")
+        if remote_state.get("version") == _PRIVATE_HTTP_STATE_VERSION and remote_state.get(
+            "target_identity"
         ):
             return True
         for receipt_name in ("graph-route-receipt.json", "remote-graph-receipt.json"):
@@ -1020,10 +1089,47 @@ def _proof_observations(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _work_performed(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     work: list[dict[str, Any]] = []
     outcomes_by_action_id = _outcomes_by_action_id(events)
+    started_action_ids = {
+        action_id
+        for event in events
+        if event.get("kind") == "action_started"
+        if (action_id := str(_dict(event.get("payload")).get("action_id") or ""))
+    }
+    scan_action_ids, scan_observation_ids = _scan_probe_link_ids(events)
+    reported_scan_actions: set[str] = set()
+    reported_scan_observations: set[str] = set()
     for event in events:
-        if event.get("kind") != "action_started":
-            continue
+        kind = str(event.get("kind") or "")
         payload = _dict(event.get("payload"))
+        if kind == "scan_probe":
+            action_id = str(payload.get("action_id") or "")
+            observation_id = str(payload.get("source_observation_id") or "")
+            if (action_id and action_id in reported_scan_actions) or (
+                observation_id and observation_id in reported_scan_observations
+            ):
+                continue
+            if action_id:
+                reported_scan_actions.add(action_id)
+            if observation_id:
+                reported_scan_observations.add(observation_id)
+            work.append(_probe_work_item(payload, outcome=""))
+            continue
+        if kind == "tool_run_probe":
+            action_id = str(payload.get("action_id") or "")
+            observation_id = str(payload.get("observation_id") or "")
+            paired_scan_event = (bool(action_id) and action_id in scan_action_ids) or (
+                bool(observation_id) and observation_id in scan_observation_ids
+            )
+            if not paired_scan_event and action_id not in started_action_ids:
+                work.append(
+                    _probe_work_item(
+                        _tool_probe_result(payload),
+                        outcome=_probe_outcome(payload),
+                    )
+                )
+            continue
+        if kind != "action_started":
+            continue
         action_id = str(payload.get("action_id") or "")
         params = _dict(payload.get("params"))
         detail = str(payload.get("detail") or "")
@@ -1040,6 +1146,49 @@ def _work_performed(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return work[:80]
+
+
+def _probe_work_item(
+    payload: dict[str, Any],
+    *,
+    outcome: str,
+) -> dict[str, Any]:
+    probe = str(payload.get("probe") or "")
+    summary = str(payload.get("summary") or "")
+    detail = ": ".join(part for part in (probe, summary) if part)
+    return {
+        "turn": payload.get("turn", ""),
+        "action": "run_probe",
+        "detail": _clip(detail, 180),
+        "outcome": outcome or _probe_outcome(payload),
+    }
+
+
+def _probe_outcome(payload: dict[str, Any]) -> str:
+    if payload.get("timed_out") is True:
+        return "timed out"
+    ok = payload.get("ok")
+    if isinstance(ok, bool):
+        return "ok" if ok else "not confirmed"
+    return ""
+
+
+def _tool_probe_result(payload: dict[str, Any]) -> dict[str, Any]:
+    result = payload.get("result")
+    if not isinstance(result, str):
+        return payload
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, RecursionError):
+        return payload
+    if not isinstance(parsed, dict):
+        return payload
+    normalized = {str(key): value for key, value in parsed.items()}
+    if "ok" not in normalized and isinstance(payload.get("ok"), bool):
+        normalized["ok"] = payload["ok"]
+    if payload.get("timed_out") is True:
+        normalized["timed_out"] = True
+    return normalized
 
 
 def _outcomes_by_action_id(events: list[dict[str, Any]]) -> dict[str, str]:
@@ -1073,19 +1222,134 @@ def _recon_summary(events: list[dict[str, Any]]) -> dict[str, Any]:
             payload = _dict(event.get("payload"))
     pages = [_dict(item) for item in _list(payload.get("pages")) if isinstance(item, dict)]
     forms = sum(len(_list(page.get("forms"))) for page in pages)
+    recon_page_urls = {str(page.get("url") or "") for page in pages if str(page.get("url") or "")}
+    additional_surface_urls: set[str] = set()
+    surface_payloads = _surface_map_payloads(events)
+    surface_requests = [
+        _dict(item)
+        for surface_payload in surface_payloads
+        for item in _list(surface_payload.get("requests"))
+        if isinstance(item, dict)
+    ]
+    surface_findings = [
+        _dict(item)
+        for surface_payload in surface_payloads
+        for item in _list(surface_payload.get("findings"))
+        if isinstance(item, dict)
+    ]
+    surface_response_count = 0
+    surface_status_counts: dict[str, int] = {}
+    for request in surface_requests:
+        status = request.get("status")
+        if not isinstance(status, int) or isinstance(status, bool):
+            continue
+        surface_response_count += 1
+        status_label = str(status)
+        surface_status_counts[status_label] = surface_status_counts.get(status_label, 0) + 1
+        url = str(request.get("final_url") or request.get("url") or "")
+        if url and url not in recon_page_urls:
+            additional_surface_urls.add(url)
+    source_kinds: list[str] = []
+    if payload:
+        source_kinds.append("recon_completed")
+    source_kinds.extend(
+        str(surface_payload.get("_report_source") or "") for surface_payload in surface_payloads
+    )
+    surface_finding_types = _dedupe_strings(
+        [str(finding.get("type") or "") for finding in surface_findings]
+    )[:20]
+    target_url = str(payload.get("target_url") or _target_from_events(events))
     return {
-        "target_url": str(payload.get("target_url") or ""),
-        "origin": str(payload.get("origin") or ""),
-        "page_count": len(pages),
+        "target_url": target_url,
+        "origin": str(payload.get("origin") or _safe_origin(target_url)),
+        "page_count": len(pages) + len(additional_surface_urls),
         "form_count": forms,
         "query_parameter_names": _dedupe_strings(
             [str(item) for item in _list(payload.get("query_parameter_names"))]
         )[:20],
         "interesting_markers": _dedupe_strings(
-            [str(item) for item in _list(payload.get("interesting_markers"))]
+            [
+                *[str(item) for item in _list(payload.get("interesting_markers"))],
+                *surface_finding_types,
+            ]
         )[:20],
-        "errors": _dedupe_strings([str(item) for item in _list(payload.get("errors"))])[:10],
+        "errors": _dedupe_strings(
+            [
+                *[str(item) for item in _list(payload.get("errors"))],
+                *[
+                    str(item)
+                    for surface_payload in surface_payloads
+                    for item in _list(surface_payload.get("errors"))
+                ],
+            ]
+        )[:10],
+        "source_kinds": _dedupe_strings(source_kinds),
+        "surface_request_count": len(surface_requests),
+        "surface_response_count": surface_response_count,
+        "surface_status_counts": dict(
+            sorted(surface_status_counts.items(), key=lambda item: int(item[0]))
+        ),
+        "surface_finding_count": len(surface_findings),
+        "surface_finding_types": surface_finding_types,
     }
+
+
+def _surface_map_payloads(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    scan_action_ids, scan_observation_ids = _scan_probe_link_ids(events)
+    seen_action_ids: set[str] = set()
+    seen_observation_ids: set[str] = set()
+    for event in events:
+        kind = str(event.get("kind") or "")
+        payload = _dict(event.get("payload"))
+        if kind == "scan_probe":
+            result = payload
+        elif kind == "tool_run_probe":
+            action_id = str(payload.get("action_id") or "")
+            observation_id = str(payload.get("observation_id") or "")
+            if (action_id and action_id in scan_action_ids) or (
+                observation_id and observation_id in scan_observation_ids
+            ):
+                continue
+            result = _tool_probe_result(payload)
+        else:
+            continue
+        if str(result.get("probe") or "") != "surface_map":
+            continue
+        action_id = str(payload.get("action_id") or "")
+        observation_id = str(
+            payload.get("source_observation_id") or payload.get("observation_id") or ""
+        )
+        if (action_id and action_id in seen_action_ids) or (
+            observation_id and observation_id in seen_observation_ids
+        ):
+            continue
+        if action_id:
+            seen_action_ids.add(action_id)
+        if observation_id:
+            seen_observation_ids.add(observation_id)
+        result = dict(result)
+        result["_report_source"] = f"{kind}:surface_map"
+        payloads.append(result)
+    return payloads
+
+
+def _scan_probe_link_ids(
+    events: list[dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    action_ids: set[str] = set()
+    observation_ids: set[str] = set()
+    for event in events:
+        if event.get("kind") != "scan_probe":
+            continue
+        payload = _dict(event.get("payload"))
+        action_id = str(payload.get("action_id") or "")
+        observation_id = str(payload.get("source_observation_id") or "")
+        if action_id:
+            action_ids.add(action_id)
+        if observation_id:
+            observation_ids.add(observation_id)
+    return action_ids, observation_ids
 
 
 def _hosting_layer_summary(events: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1294,8 +1558,7 @@ def _executive_summary_text(  # noqa: PLR0913
         )
     if not completed and status != "completed":
         partial = (
-            "The assessment did not reach normal completion. "
-            "Results should be treated as partial."
+            "The assessment did not reach normal completion. Results should be treated as partial."
         )
         if finding_count:
             partial += (
@@ -1386,10 +1649,23 @@ def _title_for(vuln_class: str, endpoint: dict[str, Any]) -> str:
 
 def _target_from_events(events: list[dict[str, Any]]) -> str:
     for event in events:
-        if event.get("kind") == "agent_started":
+        if event.get("kind") in {"agent_started", "scan_started"}:
             payload = _dict(event.get("payload"))
             return str(payload.get("target_url") or "")
     return ""
+
+
+def _safe_origin(target_url: str) -> str:
+    safe_target = sanitize_url(target_url)
+    if safe_target == REDACTED_URL:
+        return ""
+    try:
+        parsed = urlsplit(safe_target)
+    except ValueError:
+        return ""
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def _dedupe_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/packages/ravage/tests/test_deterministic_scan_routing.py
+++ b/packages/ravage/tests/test_deterministic_scan_routing.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ravage import __main__ as cli
+from ravage.agent_core.agent_state import AgentState, load_agent_state
+from ravage.probe_suite import available_probes
+from ravage.probe_suite_parts.result import ProbeRunResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+_BRIEF = """
+engagement_id: "99999999-9999-4999-8999-999999999999"
+scope:
+  in_scope:
+    - "http://127.0.0.1:8765/app"
+  out_of_scope: []
+roe:
+  max_rps: 5
+  no_destructive_actions: true
+  data_handling: "placeholders_only"
+objectives:
+  - "web_application_assessment"
+budget:
+  max_cost_usd: 1
+  max_runtime_min: 5
+context:
+  description: "Local deterministic scan routing test."
+  win_condition: "Record observed target surface."
+""".lstrip()
+
+
+def test_all_scan_probes_follow_dependencies_but_explicit_order_is_preserved() -> None:
+    requested = ["dom_execution", "surface_map", "api_behavior"]
+
+    assert cli._selected_scan_probes(requested, all_probes=False) == requested  # noqa: SLF001
+
+    selected = cli._selected_scan_probes([], all_probes=True)  # noqa: SLF001
+    assert set(selected) == {item["name"] for item in available_probes()}
+    assert selected[: len(cli._SCAN_DISCOVERY_PROBES)] == list(  # noqa: SLF001
+        cli._SCAN_DISCOVERY_PROBES  # noqa: SLF001
+    )
+    for probe, dependencies in cli._SCAN_PROBE_DEPENDENCIES.items():  # noqa: SLF001
+        if probe not in selected:
+            continue
+        for dependency in dependencies:
+            if dependency in selected:
+                assert selected.index(dependency) < selected.index(probe)
+
+
+def test_scan_seeds_target_bound_state_and_ingests_structured_probe_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    brief.write_text(_BRIEF, encoding="utf-8")
+    run_dir = tmp_path / "scan-run"
+    observed: dict[str, object] = {}
+
+    def fake_probe(
+        probe: str,
+        *,
+        target_url: str,
+        state: AgentState,
+        **_kwargs: object,
+    ) -> ProbeRunResult:
+        observed["target_url"] = state.surface.get("target_url")
+        observed["origin"] = state.surface.get("origin")
+        observed["graph_origin"] = state.surface_graph.target_origin
+        return ProbeRunResult(
+            ok=True,
+            probe=probe,
+            summary="observed one route",
+            requests=[
+                {
+                    "method": "GET",
+                    "url": f"{target_url.rstrip('/')}/discovered",
+                    "status": 200,
+                    "headers": {"Server": "nginx/1.27.5"},
+                    "body_snippet": '<a href="/app/next">Next</a>',
+                }
+            ],
+        )
+
+    monkeypatch.setattr(cli, "run_builtin_probe", fake_probe)
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "surface_map",
+            "--run-dir",
+            str(run_dir),
+            "--json",
+        ]
+    )
+
+    assert observed == {
+        "target_url": "http://127.0.0.1:8765/app",
+        "origin": "http://127.0.0.1:8765",
+        "graph_origin": "http://127.0.0.1:8765",
+    }
+    saved = load_agent_state(run_dir / "workspace" / "working_state.json")
+    assert saved is not None
+    assert any(
+        operation.structural_url == "http://127.0.0.1:8765/app/discovered"
+        for operation in (saved.surface_graph.operations or {}).values()
+    )
+    assert "/1.27.5" not in saved.signals.get("endpoints", [])

--- a/packages/ravage/tests/test_deterministic_scan_routing.py
+++ b/packages/ravage/tests/test_deterministic_scan_routing.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from ravage import __main__ as cli
 from ravage.agent_core.agent_state import AgentState, load_agent_state
 from ravage.probe_suite import available_probes
@@ -9,8 +11,6 @@ from ravage.probe_suite_parts.result import ProbeRunResult
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 _BRIEF = """
@@ -32,6 +32,19 @@ context:
   description: "Local deterministic scan routing test."
   win_condition: "Record observed target surface."
 """.lstrip()
+
+
+def test_scan_help_warns_that_all_probes_is_high_traffic(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["scan", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "broad catalog" in output
+    assert "thousands of bounded requests" in output
+    assert "authorized remote targets" in output
 
 
 def test_all_scan_probes_follow_dependencies_but_explicit_order_is_preserved() -> None:

--- a/packages/ravage/tests/test_dom_execution_probe.py
+++ b/packages/ravage/tests/test_dom_execution_probe.py
@@ -121,6 +121,94 @@ def test_dom_execution_finding_carries_executor_execution_marker(monkeypatch) ->
     assert evidence["token_executed"] is True
 
 
+def test_dom_execution_only_dispatches_absolute_same_origin_targets(monkeypatch) -> None:
+    _set_available(monkeypatch, available=True)
+    state = AgentState()
+    state.surface = {
+        "target_url": "http://127.0.0.1:8000/app/start",
+        "parameters": [
+            {
+                "name": "unsafe",
+                "locations": ["https://example.test/cross-origin"],
+                "priority": 100,
+            },
+            {
+                "name": "q",
+                "locations": ["../search?q=1"],
+                "priority": 90,
+            },
+        ],
+    }
+    rendered_urls: list[str] = []
+
+    def fake_render(url: str, **kwargs: object) -> BrowserObservation:
+        rendered_urls.append(url)
+        token = str(kwargs.get("token") or "")
+        return BrowserObservation(
+            available=True,
+            url=url,
+            token_executed=True,
+            final_url=url,
+            executed_values=[token],
+        )
+
+    monkeypatch.setattr(probe_suite, "render_url", fake_render)
+
+    result = run_builtin_probe(
+        "dom_execution",
+        target_url="http://127.0.0.1:8000/app/start",
+        state=state,
+    )
+
+    assert result.ok is True
+    assert rendered_urls
+    assert all(url.startswith("http://127.0.0.1:8000/") for url in rendered_urls)
+    assert rendered_urls[0].startswith("http://127.0.0.1:8000/search?")
+
+
+def test_dom_execution_resolves_relative_form_action_against_observed_page(monkeypatch) -> None:
+    _set_available(monkeypatch, available=True)
+    state = AgentState()
+    state.surface = {
+        "target_url": "http://127.0.0.1:8000/app/start",
+        "forms": [
+            {
+                "action": "submit",
+                "page": "/nested/form",
+                "method": "POST",
+                "inputs": [{"name": "comment", "type": "text"}],
+            }
+        ],
+    }
+    rendered: dict[str, object] = {}
+
+    def fake_render_request(url: str, **kwargs: object) -> BrowserObservation:
+        rendered["url"] = url
+        rendered["page_url"] = kwargs.get("page_url")
+        token = str(kwargs.get("token") or "")
+        return BrowserObservation(
+            available=True,
+            url=url,
+            token_executed=True,
+            final_url=url,
+            executed_values=[token],
+        )
+
+    monkeypatch.setattr(probe_suite, "render_request", fake_render_request)
+
+    result = run_builtin_probe(
+        "dom_execution",
+        target_url="http://127.0.0.1:8000/app/start",
+        state=state,
+    )
+
+    assert result.ok is True
+    assert rendered == {
+        "url": "http://127.0.0.1:8000/nested/submit",
+        "page_url": "http://127.0.0.1:8000/nested/form",
+    }
+
+
 def test_dom_execution_surfaces_render_errors(monkeypatch) -> None:
     _set_available(monkeypatch, available=True)
 

--- a/packages/ravage/tests/test_observation_analysis.py
+++ b/packages/ravage/tests/test_observation_analysis.py
@@ -39,6 +39,25 @@ def test_extract_signals_ignores_local_tool_paths_as_endpoints() -> None:
     assert all("/var/www" not in endpoint for endpoint in signals["endpoints"])
 
 
+def test_extract_signals_does_not_treat_server_version_as_relative_endpoint() -> None:
+    signals = extract_signals(
+        json.dumps(
+            {
+                "requests": [
+                    {
+                        "url": "http://127.0.0.1/app",
+                        "headers": {"Server": "nginx/1.27.5"},
+                        "body_snippet": '<a href="/actual-route">Route</a>',
+                    }
+                ]
+            }
+        )
+    )
+
+    assert "/actual-route" in signals["endpoints"]
+    assert "/1.27.5" not in signals["endpoints"]
+
+
 def test_extract_signals_collects_fetch_endpoint_and_json_body_key() -> None:
     html = """
     <script>

--- a/packages/ravage/tests/test_onboarding_cli.py
+++ b/packages/ravage/tests/test_onboarding_cli.py
@@ -409,3 +409,181 @@ def test_scan_http_error_status_still_counts_as_reachable(
     manifest = read_manifest(run_dir)
     assert manifest is not None
     assert manifest.result_label == "completed"
+
+
+def test_scan_persists_confirmed_native_finding_without_a_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "scan-run"
+    brief.write_text(BRIEF_YAML, encoding="utf-8")
+    monkeypatch.setattr(cli, "run_builtin_probe", lambda *_args, **_kwargs: _file_read_result())
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "file_read_extract",
+            "--run-dir",
+            str(run_dir),
+            "--report",
+            "--json",
+        ]
+    )
+    capsys.readouterr()
+
+    summary = json.loads((run_dir / "scan-summary.json").read_text(encoding="utf-8"))
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    events = [
+        json.loads(line)
+        for line in (run_dir / "workspace" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+
+    assert "findings_count" not in summary
+    assert summary["probe_observations_count"] == 1
+    assert summary["confirmed_findings_count"] == 1
+    assert summary["flags"] == []
+    assert report["executive_summary"]["finding_count"] == 1
+    assert report["captured_proofs"]["count"] == 0
+    assert report["outcome"]["confirmed_finding_count"] == 1
+    assert report["outcome"]["stage"] == "exploit_primitive"
+    assert [finding["vuln_class"] for finding in report["findings"]] == [
+        "path_traversal"
+    ]
+    assert {event["kind"] for event in events} >= {
+        "scan_probe",
+        "tool_run_probe",
+        "outcome_evidence_observed",
+        "finding_confirmed",
+    }
+
+
+def test_scan_separates_candidates_and_exhausted_records_from_confirmed_findings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "scan-run"
+    brief.write_text(BRIEF_YAML, encoding="utf-8")
+    results = iter((_surface_candidate_result(), _exhausted_result()))
+    monkeypatch.setattr(cli, "run_builtin_probe", lambda *_args, **_kwargs: next(results))
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "surface_map",
+            "--probe",
+            "sqli_auth_transition",
+            "--run-dir",
+            str(run_dir),
+            "--report",
+            "--json",
+        ]
+    )
+    capsys.readouterr()
+
+    summary = json.loads((run_dir / "scan-summary.json").read_text(encoding="utf-8"))
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    events = [
+        json.loads(line)
+        for line in (run_dir / "workspace" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+
+    assert summary["probe_observations_count"] == 2
+    assert summary["confirmed_findings_count"] == 0
+    assert report["findings"] == []
+    assert report["outcome"]["stage"] == "suspected_vulnerability"
+    assert report["outcome"]["suspected_vulnerability_count"] == 1
+    scan_findings = [
+        finding["type"]
+        for event in events
+        if event["kind"] == "scan_probe"
+        for finding in event["payload"]["findings"]
+    ]
+    assert scan_findings == ["notable_response", "sqli_auth_transition_exhausted"]
+    assert not any(event["kind"] == "finding_confirmed" for event in events)
+
+
+def _file_read_result() -> ProbeRunResult:
+    url = "http://127.0.0.1:8765/view?file=../../../../etc/passwd"
+    return ProbeRunResult(
+        ok=True,
+        probe="file_read_extract",
+        summary="confirmed local file read without a captured proof",
+        findings=[
+            {
+                "type": "file_read_primitive",
+                "payload": "../../../../etc/passwd",
+                "signal": {"kind": "local_file_read", "matches": ["root:x:0:0"]},
+                "delta": {"body_changed": True},
+                "response": {
+                    "method": "GET",
+                    "url": url,
+                    "final_url": "http://127.0.0.1:8765/view",
+                    "status": 200,
+                    "elapsed_ms": 1,
+                    "body_len": 32,
+                    "body_sha_hint": "0123456789abcdef",
+                    "body_snippet": "root:x:0:0:root:/root:/bin/sh",
+                    "error": "",
+                },
+                "replay": {
+                    "method": "GET",
+                    "url": url,
+                    "payload_field": "file",
+                },
+            }
+        ],
+        requests=[
+            {
+                "method": "GET",
+                "url": url,
+                "status": 200,
+                "error": "",
+            }
+        ],
+    )
+
+
+def _surface_candidate_result() -> ProbeRunResult:
+    url = "http://127.0.0.1:8765/"
+    return ProbeRunResult(
+        ok=True,
+        probe="surface_map",
+        summary="fetched 1 URL, notable=1",
+        findings=[
+            {
+                "type": "notable_response",
+                "url": url,
+                "status": 200,
+                "body_markers": ["login"],
+            }
+        ],
+        requests=[{"method": "GET", "url": url, "status": 200, "error": ""}],
+    )
+
+
+def _exhausted_result() -> ProbeRunResult:
+    url = "http://127.0.0.1:8765/login"
+    return ProbeRunResult(
+        ok=False,
+        probe="sqli_auth_transition",
+        summary="terminal_reason=matrix_exhausted, authenticated=false",
+        findings=[
+            {
+                "type": "sqli_auth_transition_exhausted",
+                "attempts": [{"input": "password", "verified": False}],
+            }
+        ],
+        requests=[{"method": "POST", "url": url, "status": 401, "error": ""}],
+    )

--- a/packages/ravage/tests/test_report_generation.py
+++ b/packages/ravage/tests/test_report_generation.py
@@ -129,9 +129,7 @@ def test_json_report_artifact_redacts_late_metadata_and_preserves_existing_repor
     serialized = json.dumps(report, sort_keys=True)
     assert secret_path_component not in serialized
     assert secret_termination_reason not in serialized
-    assert report["artifacts"]["json_report_path"].endswith(
-        "token=<SECRET_REDACTED>/report.json"
-    )
+    assert report["artifacts"]["json_report_path"].endswith("token=<SECRET_REDACTED>/report.json")
     assert report["artifacts"]["markdown_report_path"] == str(markdown_path)
     assert report["run"]["termination_reason"] == "token=<SECRET_REDACTED>"
 
@@ -207,13 +205,181 @@ def test_write_pentest_report_generates_redacted_markdown_and_json(tmp_path: Pat
     assert "api_key=<SECRET_REDACTED>" in markdown
 
 
+def test_report_summarizes_deterministic_scan_work_recon_and_recorded_traffic(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.record_event(
+        kind="scan_started",
+        payload={"target_url": "http://127.0.0.1:8765/search?token=private"},
+    )
+    surface_payload = {
+        "probe": "surface_map",
+        "ok": True,
+        "summary": "received 2/3 HTTP response(s), notable=1",
+        "findings": [
+            {
+                "type": "interesting_response",
+                "url": "http://127.0.0.1:8765/admin",
+                "status": 403,
+            }
+        ],
+        "requests": [
+            {"url": "http://127.0.0.1:8765/", "status": 200},
+            {"url": "http://127.0.0.1:8765/admin", "status": 403},
+            {
+                "url": "http://127.0.0.1:8765/missing",
+                "status": None,
+                "error": "connection reset",
+            },
+        ],
+        "errors": [],
+    }
+    workspace.record_event(
+        kind="tool_run_probe",
+        payload={
+            "action_id": "scan-001-surface_map",
+            "observation_id": "scan-observation-1",
+            "ok": True,
+            "timed_out": False,
+            "result": json.dumps(surface_payload),
+        },
+    )
+    workspace.record_event(
+        kind="scan_probe",
+        payload={
+            **surface_payload,
+            "action_id": "scan-001-surface_map",
+            "source_observation_id": "scan-observation-1",
+        },
+    )
+    workspace.record_event(
+        kind="scan_probe",
+        payload={
+            "probe": "input_reflection",
+            "ok": False,
+            "summary": "checked 1 input, findings=0",
+            "findings": [],
+            "requests": [],
+            "errors": [],
+        },
+    )
+    _add_deterministic_scan_traffic(workspace.root)
+    output_path = tmp_path / "run" / "deterministic-report.md"
+
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    assert report["work_performed"] == [
+        {
+            "turn": "",
+            "action": "run_probe",
+            "detail": "surface_map: received 2/3 HTTP response(s), notable=1",
+            "outcome": "ok",
+        },
+        {
+            "turn": "",
+            "action": "run_probe",
+            "detail": "input_reflection: checked 1 input, findings=0",
+            "outcome": "not confirmed",
+        },
+    ]
+    assert report["reconnaissance"] == {
+        "target_url": "http://127.0.0.1:8765/search?token=<SECRET_REDACTED>",
+        "origin": "http://127.0.0.1:8765",
+        "page_count": 2,
+        "form_count": 0,
+        "query_parameter_names": [],
+        "interesting_markers": ["interesting_response"],
+        "errors": [],
+        "source_kinds": ["scan_probe:surface_map"],
+        "surface_request_count": 3,
+        "surface_response_count": 2,
+        "surface_status_counts": {"200": 1, "403": 1},
+        "surface_finding_count": 1,
+        "surface_finding_types": ["interesting_response"],
+    }
+    assert report["traffic_accounting"] == {
+        "status": "lower_bound",
+        "provenance": "validated_workspace_traffic_store",
+        "mode": "recorded_scan_traffic",
+        "physical_request_count": 2,
+        "max_physical_requests": None,
+        "remaining_physical_requests": None,
+        "recorded_exchange_count": 2,
+        "blocked_count": 0,
+        "capture_completed": True,
+    }
+    markdown = output_path.read_text(encoding="utf-8")
+    assert "Physical target requests: 2" in markdown
+    assert "Request accounting status: lower_bound" in markdown
+    assert "Surface-map HTTP responses: 2/3 requests" in markdown
+    assert "surface_map: received 2/3 HTTP response(s)" in markdown
+
+
+def test_report_summarizes_orphan_tool_probe_without_duplicating_agent_actions(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.record_event(
+        kind="tool_run_probe",
+        payload={
+            "ok": True,
+            "timed_out": False,
+            "result": json.dumps(
+                {
+                    "probe": "surface_map",
+                    "ok": True,
+                    "summary": "fetched 1 URL(s), notable=1",
+                    "findings": [{"type": "interesting_response"}],
+                    "requests": [{"url": "http://127.0.0.1:8765/", "status": 200}],
+                    "errors": [],
+                }
+            ),
+        },
+    )
+    output_path = tmp_path / "run" / "tool-probe-report.md"
+
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    assert report["work_performed"] == [
+        {
+            "turn": "",
+            "action": "run_probe",
+            "detail": "surface_map: fetched 1 URL(s), notable=1",
+            "outcome": "ok",
+        }
+    ]
+    assert report["reconnaissance"]["source_kinds"] == ["tool_run_probe:surface_map"]
+    assert report["reconnaissance"]["page_count"] == 1
+    assert report["traffic_accounting"] == {
+        "status": "unavailable",
+        "provenance": "traffic_policy_ledger_missing",
+    }
+
+
 def test_report_links_nested_agent_http_traffic_to_identifier_only_evidence(
     tmp_path: Path,
 ) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
-    graph_workspace, request_id, evidence_ids, material_evidence_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, request_id, evidence_ids, material_evidence_ids = _add_agent_http_provenance(
+        workspace.root
     )
     output_path = tmp_path / "run" / "agent-http-report.md"
 
@@ -300,12 +466,7 @@ def test_report_loads_confirmed_findings_from_nested_graph_events_without_audit_
 ) -> None:
     brief_path = _brief(tmp_path)
     workspace = _workspace_with_report_events(tmp_path)
-    graph_events = (
-        workspace.root
-        / "autonomous-route"
-        / "agent-graph"
-        / "events.jsonl"
-    )
+    graph_events = workspace.root / "autonomous-route" / "agent-graph" / "events.jsonl"
     graph_events.parent.mkdir(parents=True)
     workspace.events_path.replace(graph_events)
 
@@ -328,8 +489,8 @@ def test_report_fails_closed_when_new_graph_http_state_loses_traffic(
 ) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
-    graph_workspace, _request_id, _evidence_ids, _material_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, _request_id, _evidence_ids, _material_ids = _add_agent_http_provenance(
+        workspace.root
     )
     state_path = graph_workspace / "graph-http-state.json"
     state_path.write_text('{"version":2,"target_identity":"target:marker"}\n', encoding="utf-8")
@@ -353,8 +514,8 @@ def test_report_fails_closed_when_new_graph_http_state_loses_traffic(
 def test_report_fails_closed_for_tampered_agent_http_blackboard(tmp_path: Path) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
-    graph_workspace, _request_id, _evidence_ids, _material_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, _request_id, _evidence_ids, _material_ids = _add_agent_http_provenance(
+        workspace.root
     )
     blackboard_path = graph_workspace / "evidence-blackboard.json"
     payload = json.loads(blackboard_path.read_text(encoding="utf-8"))
@@ -380,8 +541,8 @@ def test_report_fails_closed_for_tampered_agent_http_blackboard(tmp_path: Path) 
 def test_report_fails_closed_when_agent_http_blackboard_is_missing(tmp_path: Path) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
-    graph_workspace, _request_id, _evidence_ids, _material_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, _request_id, _evidence_ids, _material_ids = _add_agent_http_provenance(
+        workspace.root
     )
     (graph_workspace / "evidence-blackboard.json").unlink()
 
@@ -402,13 +563,11 @@ def test_report_fails_closed_when_agent_http_blackboard_is_missing(tmp_path: Pat
 def test_report_fails_closed_for_ambiguous_agent_http_provenance(tmp_path: Path) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
-    graph_workspace, _request_id, _evidence_ids, _material_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, _request_id, _evidence_ids, _material_ids = _add_agent_http_provenance(
+        workspace.root
     )
     evidence = graph_workspace / "evidence-blackboard.json"
-    (graph_workspace / "remote-evidence-blackboard.json").write_bytes(
-        evidence.read_bytes()
-    )
+    (graph_workspace / "remote-evidence-blackboard.json").write_bytes(evidence.read_bytes())
     output_path = tmp_path / "run" / "ambiguous-agent-http-report.md"
 
     with pytest.raises(
@@ -479,8 +638,8 @@ def test_cli_report_surfaces_malformed_agent_http_store_without_traceback(
 ) -> None:
     brief_path = _brief(tmp_path)
     workspace = _workspace_with_report_events(tmp_path)
-    graph_workspace, _request_id, _evidence_ids, _material_ids = (
-        _add_agent_http_provenance(workspace.root)
+    graph_workspace, _request_id, _evidence_ids, _material_ids = _add_agent_http_provenance(
+        workspace.root
     )
     (graph_workspace / "traffic" / "exchanges.jsonl").write_text(
         f'{{"unsafe":"{_AGENT_HTTP_SECRET}"',
@@ -634,9 +793,7 @@ def test_report_ignores_same_scope_findings_from_other_engagements(
         audit_db_path=audit_path,
     )
 
-    assert [finding["finding_id"] for finding in report["findings"]] == [
-        "finding-current"
-    ]
+    assert [finding["finding_id"] for finding in report["findings"]] == ["finding-current"]
     assert report["findings"][0]["hypothesis"] == "Current engagement finding."
 
 
@@ -682,9 +839,7 @@ def test_report_only_uses_current_in_scope_workspace_findings(tmp_path: Path) ->
         completed=True,
     )
 
-    assert [finding["finding_id"] for finding in report["findings"]] == [
-        "finding-current"
-    ]
+    assert [finding["finding_id"] for finding in report["findings"]] == ["finding-current"]
     assert "parameterized queries" in report["findings"][0]["recommendation"]
 
 
@@ -906,10 +1061,7 @@ def _add_agent_http_provenance(
             source="agent_http",
             source_observation_id=_AGENT_HTTP_OBSERVATION_ID,
             method="GET",
-            url=(
-                "http://127.0.0.1:8765/proof?token="
-                f"{_AGENT_HTTP_SECRET}"
-            ),
+            url=(f"http://127.0.0.1:8765/proof?token={_AGENT_HTTP_SECRET}"),
             request_headers={"Authorization": f"Bearer {_AGENT_HTTP_SECRET}"},
             request_sent=True,
             response_status=200,
@@ -934,6 +1086,30 @@ def _add_agent_http_provenance(
         tuple(record.evidence_id for record in records),
         tuple(record.evidence_id for record in records if record.material),
     )
+
+
+def _add_deterministic_scan_traffic(workspace: Path) -> None:
+    capture_session_id = "deterministic-report-session"
+    store = TrafficStore.create(workspace)
+    manifest = TrafficRunManifest.create(
+        target_url="http://127.0.0.1:8765",
+        capture_session_id=capture_session_id,
+    )
+    write_traffic_manifest(workspace, manifest.complete())
+    for path, status in (("/", 200), ("/admin", 403)):
+        store.append_exchange(
+            build_captured_http_exchange(
+                capture_session_id=capture_session_id,
+                source="probe_session",
+                method="GET",
+                url=f"http://127.0.0.1:8765{path}",
+                request_sent=True,
+                response_status=status,
+                response_final_url=f"http://127.0.0.1:8765{path}",
+                response_body="bounded response",
+                scope_decision="allowed",
+            )
+        )
 
 
 def _confirmed_finding_payload(


### PR DESCRIPTION
## Summary

  - Persist confirmed deterministic vulnerabilities even when no CTF flag is found.
  - Separate raw probe observations from confirmed findings.
  - Keep incomplete or candidate evidence explicitly unconfirmed.
  - Restrict discovered DOM and form targets to valid, same-origin, in-scope URLs.
  - Include deterministic scan work, reconnaissance, and request accounting in reports.
