### PR TITLE
feat(scan): add adaptive planning and reliable coverage reporting

### DIFF
--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -112,6 +112,7 @@ from ravage.probe_suite import (
     probe_requires_anonymous_session,
     run_builtin_probe,
 )
+from ravage.probe_suite_parts.result import ProbeRunResult
 from ravage.report import (
     ProFeatureRequiredError,
     ensure_report_output_supported,
@@ -151,6 +152,7 @@ from ravage.traffic.manifest import (
     write_traffic_manifest,
 )
 from ravage.traffic.policy import (
+    TrafficPolicyBlocked,
     TrafficPolicyConfig,
     TrafficPolicyController,
     TrafficPolicyError,
@@ -266,6 +268,8 @@ _SCAN_PROBE_DEPENDENCIES: dict[str, tuple[str, ...]] = {
     "xss_filter_constraint": ("xss_context",),
     "xxe_boundary": ("file_fetch_parser",),
 }
+
+_SCAN_UNMETERED_PROBES = frozenset({"dom_execution"})
 
 BRIEF_DESCRIPTION_TODO = (
     "TODO: describe the target, challenge text, rules, credentials, and win condition."
@@ -2369,6 +2373,36 @@ def _assert_fresh_attack_workspace(*, run_dir: Path, workspace_dir: Path, resume
     raise SystemExit(message)
 
 
+def _assert_fresh_scan_workspace(
+    *,
+    run_dir: Path,
+    workspace_dir: Path,
+    db_path: Path,
+) -> None:
+    """Reject accidental scan-state reuse until an exact resume contract exists."""
+    existing = [
+        path
+        for path in (
+            workspace_dir / "traffic-policy.json",
+            workspace_dir / "working_state.json",
+            workspace_dir / "events.jsonl",
+            workspace_dir / "transcript.jsonl",
+            db_path,
+            run_dir / "scan-summary.json",
+            run_dir / "report.json",
+            run_dir / "report.md",
+        )
+        if path.exists()
+    ]
+    if not existing:
+        return
+    details = ", ".join(str(path) for path in existing[:3])
+    raise SystemExit(
+        "scan run directory already contains prior state; use a fresh --run-dir. "
+        f"Existing files: {details}"
+    )
+
+
 class _AttackEventSink:
     def __init__(self, *, mode: DisplayMode) -> None:
         output = sys.stdout
@@ -2439,6 +2473,24 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         help="list built-in probe names and exit",
     )
     parser.add_argument("--timeout-seconds", type=int, default=10)
+    parser.add_argument(
+        "--traffic-policy",
+        choices=["observe", "low-noise"],
+        help=(
+            "whole-run physical HTTP policy; defaults to low-noise for authorized "
+            "remote targets and observe for local targets"
+        ),
+    )
+    parser.add_argument(
+        "--max-physical-requests",
+        type=int,
+        help="whole-run physical HTTP request cap in low-noise mode (default: 300)",
+    )
+    parser.add_argument(
+        "--traffic-max-rps",
+        type=float,
+        help="strictly sub-1 whole-run HTTP dispatch rate in low-noise mode (default: 0.5)",
+    )
     parser.add_argument(
         "--identity",
         help="use one named identity from brief.authentication for eligible probes",
@@ -2520,6 +2572,12 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from None
+    _resolve_traffic_policy_args(
+        parser,
+        parsed,
+        default_mode=("observe" if is_local_url(target_url) else "low-noise"),
+        roe_max_rps=brief.roe.max_rps,
+    )
 
     selected_probes = _selected_scan_probes(parsed.probes, all_probes=parsed.all_probes)
     skipped_authenticated_probes: dict[str, str] = {}
@@ -2544,7 +2602,20 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         _validate_report_output(parser, report_path)
 
     run_dir.mkdir(parents=True, exist_ok=True)
+    _assert_fresh_scan_workspace(
+        run_dir=run_dir,
+        workspace_dir=workspace_dir,
+        db_path=db_path,
+    )
     workspace = AgentWorkspace.open(workspace_dir)
+    try:
+        traffic_policy = TrafficPolicyController.open(
+            workspace_dir / "traffic-policy.json",
+            target_url=target_url,
+            config=_traffic_policy_config(parsed),
+        )
+    except (OSError, TrafficPolicyError, ValueError) as exc:
+        parser.error(f"cannot initialize scan traffic policy: {_concise_cli_error(exc)}")
     traffic_capture_session_id = f"scan-{uuid4().hex[:12]}"
     traffic_recorder_errors: list[str] = []
     traffic_store: TrafficStore | None = None
@@ -2597,6 +2668,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     start_payload: dict[str, object] = {
         "target_url": target_url,
         "probes": selected_probes,
+        "traffic_accounting": _scan_traffic_accounting(traffic_policy),
     }
     if parsed.identity:
         start_payload["identity"] = parsed.identity
@@ -2638,6 +2710,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                         traffic_store=traffic_store,
                         traffic_capture_session_id=traffic_capture_session_id,
                         traffic_recorder_errors=traffic_recorder_errors,
+                        traffic_policy=traffic_policy,
                     )
                     if not parsed.json:
                         _write_line(
@@ -2674,20 +2747,35 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                     ) from None
             try:
                 try:
-                    result = run_builtin_probe(
+                    blocked_reason = _guard_scan_probe_traffic(
                         probe,
-                        target_url=target_url,
-                        state=state,
-                        timeout_seconds=max(1, min(parsed.timeout_seconds, 120)),
-                        allow_remote_target=parsed.allow_remote_target,
-                        in_scope=brief.scope.in_scope,
-                        out_of_scope=brief.scope.out_of_scope,
-                        max_rps=brief.roe.max_rps,
-                        session=probe_session,
-                        traffic_observer=(
-                            None if use_authenticated_session else anonymous_traffic_recorder
-                        ),
+                        traffic_policy=traffic_policy,
                     )
+                    if blocked_reason:
+                        result = ProbeRunResult(
+                            ok=False,
+                            probe=probe,
+                            summary=f"blocked by whole-run traffic policy: {blocked_reason}",
+                            errors=[blocked_reason],
+                        )
+                    else:
+                        result = run_builtin_probe(
+                            probe,
+                            target_url=target_url,
+                            state=state,
+                            timeout_seconds=max(1, min(parsed.timeout_seconds, 120)),
+                            allow_remote_target=parsed.allow_remote_target,
+                            in_scope=brief.scope.in_scope,
+                            out_of_scope=brief.scope.out_of_scope,
+                            max_rps=brief.roe.max_rps,
+                            session=probe_session,
+                            traffic_observer=(
+                                None if use_authenticated_session else anonymous_traffic_recorder
+                            ),
+                            traffic_policy=(
+                                None if use_authenticated_session else traffic_policy
+                            ),
+                        )
                 finally:
                     if probe_session is not None and auth_owner is not None:
                         auth_owner.retire_probe_session(probe_session)
@@ -2713,6 +2801,8 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                 "findings": result.findings,
                 "requests": result.requests,
                 "errors": result.errors,
+                "http_request_count": result.http_request_count,
+                "http_request_count_status": result.http_request_count_status,
                 "session_mode": (
                     f"identity:{parsed.identity}" if use_authenticated_session else "anonymous"
                 ),
@@ -2806,10 +2896,24 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             status="confirmed",
             engagement_id=brief.engagement_id,
         )
+        completed_payload = {
+            "probes_run": len(selected_probes),
+            "confirmed_findings_count": confirmed_findings_count,
+            "flags_count": len(state.flags),
+            "traffic_accounting": _scan_traffic_accounting(traffic_policy),
+        }
+        audit.record(
+            engagement_id=brief.engagement_id,
+            actor="scan",
+            action="scan_completed",
+            payload=completed_payload,
+        )
+        workspace.record_event(kind="scan_completed", payload=completed_payload)
     except BaseException as exc:
         failure_payload: dict[str, object] = {
             "error_type": type(exc).__name__,
             "identity": parsed.identity or "",
+            "traffic_accounting": _scan_traffic_accounting(traffic_policy),
         }
         with suppress(Exception):
             audit.record(
@@ -2888,6 +2992,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         "traffic_requests": traffic_requests,
         "traffic_contracts": traffic_contracts,
         "traffic_recorder_errors": traffic_recorder_errors,
+        "traffic_accounting": _scan_traffic_accounting(traffic_policy),
         "flags": list(state.flags),
         "report": report_output,
     }
@@ -2944,6 +3049,53 @@ def _require_scan_target_reached(
     )
 
 
+def _guard_scan_probe_traffic(
+    probe: str,
+    *,
+    traffic_policy: TrafficPolicyController,
+) -> str:
+    """Account for opaque target transports and fail closed in enforced mode."""
+    if probe not in _SCAN_UNMETERED_PROBES:
+        return ""
+    try:
+        traffic_policy.record_unmetered_action()
+    except TrafficPolicyBlocked as exc:
+        return str(exc)
+    return ""
+
+
+def _scan_traffic_accounting(
+    traffic_policy: TrafficPolicyController,
+) -> dict[str, object]:
+    try:
+        snapshot = traffic_policy.snapshot()
+    except (OSError, TrafficPolicyError, ValueError):
+        return {
+            "status": "unavailable",
+            "provenance": "traffic_policy_ledger_unreadable",
+        }
+    config = traffic_policy.config
+    remaining = (
+        None
+        if config.max_physical_requests is None
+        else max(
+            config.max_physical_requests
+            - snapshot.physical_request_count
+            - snapshot.reservation_count,
+            0,
+        )
+    )
+    return {
+        "status": snapshot.accounting_status,
+        "provenance": "workspace_traffic_policy_ledger",
+        "mode": config.mode.value,
+        "max_rps": config.max_rps,
+        "max_physical_requests": config.max_physical_requests,
+        "remaining_physical_requests": remaining,
+        **snapshot.to_json(),
+    }
+
+
 def _configured_scan_session(  # noqa: PLR0913
     *,
     brief: EngagementBrief,
@@ -2951,6 +3103,7 @@ def _configured_scan_session(  # noqa: PLR0913
     identity: str,
     timeout_seconds: int,
     allow_remote_target: bool,
+    traffic_policy: TrafficPolicyController,
     secret_resolver: SecretResolver | None = None,
     traffic_store: TrafficStore | None = None,
     traffic_capture_session_id: str = "",
@@ -3004,6 +3157,7 @@ def _configured_scan_session(  # noqa: PLR0913
         out_of_scope=brief.scope.out_of_scope,
         max_rps=brief.roe.max_rps,
         traffic_observer=traffic_observer,
+        traffic_policy=traffic_policy,
     )
     manager = SessionManager(
         base_session,
@@ -3025,7 +3179,7 @@ def _configured_scan_session(  # noqa: PLR0913
         manager=manager,
         handle=handle,
         redactor=redactor,
-        traffic_policy=None,
+        traffic_policy=traffic_policy,
     )
     return owner, redactor
 

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -32,6 +32,7 @@ from ravage.agent_core.action_executor import (
 )
 from ravage.agent_core.agent_state import (
     AgentState,
+    append_unique,
     load_agent_state,
     resolve_agent_state_path,
     save_agent_state,
@@ -41,6 +42,7 @@ from ravage.agent_core.ai_agent import (
     route_has_paid_transport_risk,
     run_ai_web_agent,
 )
+from ravage.agent_core.attack_surface import merge_surface_state, surface_from_recon
 from ravage.agent_core.autonomous_graph.operational_profile import (
     GraphOperationalProfileName,
 )
@@ -48,7 +50,12 @@ from ravage.agent_core.autonomous_route_selection import (
     AUTONOMOUS_ROUTE_ENGINES,
     run_selected_autonomous_route,
 )
+from ravage.agent_core.observation_analysis import merge_recon_state
 from ravage.agent_core.surface_graph import SurfaceGraphState
+from ravage.agent_core.surface_graph_ingest import (
+    ingest_recon_surface,
+    project_surface_graph,
+)
 from ravage.agent_knowledge import describe_knowledge_pack
 from ravage.agent_knowledge.cli import handle_skills_command
 from ravage.auth import (
@@ -134,6 +141,29 @@ from ravage.runtime import DEFAULT_TOOL_IMAGE
 from ravage.runtime.common import assert_http_url
 from ravage.runtime.scoped_network import ScopedNetworkError
 from ravage.satcom.cli import handle_satcom_command
+from ravage.scan_coverage import (
+    PlannerProbeDecision,
+    ProbeCoverageOutcome,
+    ProbeDisposition,
+    RequestAccountingStatus,
+    ScanCoverageCertificate,
+    ScanCoverageRecorder,
+    write_scan_coverage_certificate,
+)
+from ravage.scan_planner import (
+    DEFAULT_SCAN_PROBES,
+    SCAN_PROBE_CATALOG,
+    ScanPlan,
+    ScanPlanDecision,
+    ScanPlanStatus,
+    build_adaptive_scan_plan,
+)
+from ravage.scan_planner import (
+    DISCOVERY_SCAN_PROBES as _SCAN_DISCOVERY_PROBES,
+)
+from ravage.scan_planner import (
+    SCAN_PROBE_DEPENDENCIES as _SCAN_PROBE_DEPENDENCIES,
+)
 from ravage.self_adapter import build_ravage_competitor_result
 from ravage.setup_checks import (
     discover_brief,
@@ -163,6 +193,7 @@ from ravage.traffic.recorders import ProbeTrafficRecorder
 from ravage.traffic.store import TrafficStore, TrafficStoreError
 from ravage.web_core.http_probe import ProbeSession
 from ravage.web_core.proof_recognizer import recognize_proofs
+from ravage.web_core.recon import run_recon
 from ravage.web_core.scope_policy import assert_authorized_target, is_local_url
 from ravage.xben_parts.models import DEFAULT_BENCHMARKS_ROOT, XbenSettings
 from ravage.xben_parts.runner import run_xben
@@ -193,6 +224,7 @@ _MAX_SCAN_PROOF_VALUE_CHARS = 650_000
 _MAX_SCAN_PROOF_NODES = 20_000
 _MAX_SCAN_OBSERVATION_CHARS = 10_000
 _MAX_SCAN_TRANSCRIPT_CHARS = 80_000
+_MAX_SCAN_COVERAGE_REASON_CODES = 8
 
 _TOP_LEVEL_COMMANDS = (
     "attack",
@@ -228,46 +260,13 @@ class _AttackResultEvent:
     event: dict[str, object]
 
 
-DEFAULT_SCAN_PROBES = (
-    "surface_map",
-    "secret_sweep",
-    "direct_exposure",
-    "api_behavior",
-    "csrf_session",
-    "browser_boundary",
-)
+@dataclass(frozen=True)
+class _ScanProbeExecution:
+    probe: str
+    result: ProbeRunResult
+    policy_blocked: bool = False
+    opaque_unmetered: bool = False
 
-_SCAN_DISCOVERY_PROBES = (
-    "surface_map",
-    "secret_sweep",
-    "direct_exposure",
-    "api_behavior",
-    "browser_boundary",
-)
-
-_SCAN_PROBE_DEPENDENCIES: dict[str, tuple[str, ...]] = {
-    "browser_boundary": ("surface_map",),
-    "captcha_form_state": ("stateful_session",),
-    "cms_exposure": ("direct_exposure",),
-    "cookie_deserialization": ("stateful_session",),
-    "csrf_session": ("stateful_session",),
-    "dom_execution": ("xss_context", "xss_filter_constraint"),
-    "file_read_extract": ("file_fetch_parser",),
-    "filtered_query_bypass": ("sqli_differential",),
-    "graphql_exploit": ("api_behavior",),
-    "idor_boundary": ("api_behavior", "stateful_session"),
-    "jwt_exploit": ("api_behavior", "stateful_session"),
-    "preg_match_subject": ("sqli_differential",),
-    "reflection_value_boundary": ("input_reflection",),
-    "sqli_auth_transition": ("sqli_exploit",),
-    "sqli_exploit": ("data_query", "sqli_differential"),
-    "ssti_deferred_context_closure": ("ssti_fingerprint",),
-    "ssti_fingerprint": ("server_rendering",),
-    "werkzeug_console": ("direct_exposure",),
-    "xss_context": ("input_reflection",),
-    "xss_filter_constraint": ("xss_context",),
-    "xxe_boundary": ("file_fetch_parser",),
-}
 
 _SCAN_UNMETERED_PROBES = frozenset({"dom_execution"})
 
@@ -2389,6 +2388,7 @@ def _assert_fresh_scan_workspace(
             workspace_dir / "transcript.jsonl",
             db_path,
             run_dir / "scan-summary.json",
+            run_dir / "scan-coverage.json",
             run_dir / "report.json",
             run_dir / "report.md",
         )
@@ -2579,9 +2579,23 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         roe_max_rps=brief.roe.max_rps,
     )
 
-    selected_probes = _selected_scan_probes(parsed.probes, all_probes=parsed.all_probes)
+    adaptive_scan = not parsed.probes and not parsed.all_probes
+    adaptive_catalog = tuple(SCAN_PROBE_CATALOG)
     skipped_authenticated_probes: dict[str, str] = {}
-    if parsed.identity:
+    if adaptive_scan and parsed.identity:
+        eligible, skipped_authenticated_probes = _authenticated_scan_selection(
+            list(adaptive_catalog),
+            explicit=False,
+        )
+        adaptive_catalog = tuple(eligible)
+        selected_probes: list[str] = []
+    else:
+        selected_probes = (
+            []
+            if adaptive_scan
+            else _selected_scan_probes(parsed.probes, all_probes=parsed.all_probes)
+        )
+    if parsed.identity and not adaptive_scan:
         selected_probes, skipped_authenticated_probes = _authenticated_scan_selection(
             selected_probes,
             explicit=bool(parsed.probes),
@@ -2654,6 +2668,11 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     state.surface["scope_out_of_scope"] = list(brief.scope.out_of_scope)
     state.surface["scope_max_rps"] = brief.roe.max_rps
     state.surface["allow_remote_target"] = parsed.allow_remote_target
+    state.surface["scan_planner_mode"] = "adaptive" if adaptive_scan else "fixed"
+    adaptive_plan: ScanPlan | None = None
+    if adaptive_scan:
+        adaptive_plan = build_adaptive_scan_plan(state, catalog=adaptive_catalog)
+        selected_probes = list(adaptive_plan.probes)
     write_manifest(
         run_dir,
         RunManifest(
@@ -2668,6 +2687,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     start_payload: dict[str, object] = {
         "target_url": target_url,
         "probes": selected_probes,
+        "planner_mode": "adaptive" if adaptive_scan else "fixed",
         "traffic_accounting": _scan_traffic_accounting(traffic_policy),
     }
     if parsed.identity:
@@ -2680,12 +2700,26 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         payload=start_payload,
     )
     workspace.record_event(kind="scan_started", payload=start_payload)
+    if adaptive_plan is not None:
+        _record_adaptive_scan_plan(
+            adaptive_plan,
+            iteration=0,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=brief.engagement_id,
+        )
 
     probe_observations_count = 0
     confirmed_findings_count = 0
     observed_request_count = 0
     observed_http_response_count = 0
     transport_errors: list[str] = []
+    executions: list[_ScanProbeExecution] = []
+    planner_frontier_exhausted = False
+    coverage_certificate: ScanCoverageCertificate | None = None
+    planner_mode = (
+        "adaptive" if adaptive_scan else ("all_probes" if parsed.all_probes else "explicit")
+    )
     auth_owner: ManagedAttackAuthentication | None = None
     artifact_redactor = AuthArtifactRedactor()
     try:
@@ -2731,7 +2765,62 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                 raise SystemExit(
                     f"cannot authenticate identity {parsed.identity!r}: {exc}"
                 ) from None
-        for index, probe in enumerate(selected_probes, start=1):
+        if adaptive_scan:
+            recon_payload = _seed_adaptive_scan_recon(
+                target_url=target_url,
+                brief=brief,
+                state=state,
+                workspace=workspace,
+                audit=audit,
+                traffic_policy=traffic_policy,
+                timeout_seconds=parsed.timeout_seconds,
+                allow_remote_target=parsed.allow_remote_target,
+            )
+            recon_request_count = recon_payload.get("http_request_count")
+            if isinstance(recon_request_count, int) and not isinstance(
+                recon_request_count, bool
+            ):
+                observed_request_count += recon_request_count
+            recon_pages = recon_payload.get("pages")
+            if isinstance(recon_pages, list):
+                observed_http_response_count += sum(
+                    isinstance(page, Mapping)
+                    and isinstance(page.get("status"), int)
+                    and not isinstance(page.get("status"), bool)
+                    for page in recon_pages
+                )
+            recon_errors = recon_payload.get("errors")
+            if isinstance(recon_errors, list):
+                for error in recon_errors:
+                    detail = str(error).strip()
+                    if detail and detail not in transport_errors:
+                        transport_errors.append(detail)
+            adaptive_plan = build_adaptive_scan_plan(state, catalog=adaptive_catalog)
+            _record_adaptive_scan_plan(
+                adaptive_plan,
+                iteration=1,
+                workspace=workspace,
+                audit=audit,
+                engagement_id=brief.engagement_id,
+            )
+            save_agent_state(workspace.state_path, target_url=target_url, state=state)
+        fixed_probes = tuple(selected_probes)
+        fixed_cursor = 0
+        probe_index = 0
+        while True:
+            if adaptive_scan:
+                assert adaptive_plan is not None
+                if not adaptive_plan.probes:
+                    planner_frontier_exhausted = True
+                    break
+                probe = adaptive_plan.probes[0]
+            else:
+                if fixed_cursor >= len(fixed_probes):
+                    planner_frontier_exhausted = True
+                    break
+                probe = fixed_probes[fixed_cursor]
+                fixed_cursor += 1
+            probe_index += 1
             use_authenticated_session = (
                 auth_owner is not None and not probe_requires_anonymous_session(probe)
             )
@@ -2747,6 +2836,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                     ) from None
             try:
                 try:
+                    blocked_before = traffic_policy.snapshot().blocked_count
                     blocked_reason = _guard_scan_probe_traffic(
                         probe,
                         traffic_policy=traffic_policy,
@@ -2783,6 +2873,18 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                 raise
             except Exception:  # noqa: BLE001 - target failures must not escape artifacts.
                 raise SystemExit(f"scan probe {probe!r} failed") from None
+            blocked_after = traffic_policy.snapshot().blocked_count
+            policy_blocked = bool(blocked_reason) or (
+                blocked_after > blocked_before and not _scan_result_has_http_response(result)
+            )
+            executions.append(
+                _ScanProbeExecution(
+                    probe=probe,
+                    result=result,
+                    policy_blocked=policy_blocked,
+                    opaque_unmetered=(probe in _SCAN_UNMETERED_PROBES and not blocked_reason),
+                )
+            )
             for request in result.requests:
                 if not isinstance(request, dict):
                     continue
@@ -2815,7 +2917,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             payload = _require_scan_payload(artifact_redactor.redact(raw_payload))
             text = json.dumps(payload, indent=2, sort_keys=True)
             safe_summary = artifact_redactor.redact_text(result.summary)
-            action_id = f"scan-{index:03d}-{probe}"
+            action_id = f"scan-{probe_index:03d}-{probe}"
             session_mode = (
                 f"identity:{parsed.identity}" if use_authenticated_session else "anonymous"
             )
@@ -2848,7 +2950,7 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                 payload=scan_payload,
             )
             workspace.record_event(kind="scan_probe", payload=scan_payload)
-            state.turn = index
+            state.turn = probe_index
             state.actions.append(
                 {
                     "action": "run_probe",
@@ -2886,6 +2988,19 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
                     f"{badge(f'scan:{marker}', style)} "
                     f"{badge(session_label, 'info')} {tone(probe, 'info')} {safe_summary}"
                 )
+            if adaptive_scan:
+                adaptive_plan = build_adaptive_scan_plan(
+                    state,
+                    prior_results=tuple(execution.result for execution in executions),
+                    catalog=adaptive_catalog,
+                )
+                _record_adaptive_scan_plan(
+                    adaptive_plan,
+                    iteration=probe_index + 1,
+                    workspace=workspace,
+                    audit=audit,
+                    engagement_id=brief.engagement_id,
+                )
         _require_scan_target_reached(
             observed_requests=observed_request_count,
             observed_responses=observed_http_response_count,
@@ -2896,10 +3011,28 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
             status="confirmed",
             engagement_id=brief.engagement_id,
         )
+        coverage_certificate = _build_scan_coverage_certificate(
+            target_url=target_url,
+            planner_mode=planner_mode,
+            adaptive_plan=adaptive_plan if adaptive_scan else None,
+            executions=executions,
+            skipped_probes=skipped_authenticated_probes,
+            planner_frontier_exhausted=planner_frontier_exhausted,
+            traffic_policy=traffic_policy,
+        )
+        coverage_path = write_scan_coverage_certificate(
+            run_dir / "scan-coverage.json",
+            coverage_certificate,
+        )
         completed_payload = {
-            "probes_run": len(selected_probes),
+            "probes_run": len(executions),
             "confirmed_findings_count": confirmed_findings_count,
             "flags_count": len(state.flags),
+            "planner_mode": planner_mode,
+            "coverage_status": coverage_certificate.status.value,
+            "coverage_completion_basis": coverage_certificate.completion_basis,
+            "coverage_limitations": list(coverage_certificate.limitations),
+            "coverage_artifact": coverage_path.name,
             "traffic_accounting": _scan_traffic_accounting(traffic_policy),
         }
         audit.record(
@@ -2985,7 +3118,9 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         "audit_db": str(db_path),
         "target_url": target_url,
         "identity": parsed.identity or "",
-        "probes_run": len(selected_probes),
+        "planner_mode": planner_mode,
+        "probes_run": len(executions),
+        "probes_executed": [execution.probe for execution in executions],
         "skipped_authenticated_probes": skipped_authenticated_probes,
         "probe_observations_count": probe_observations_count,
         "confirmed_findings_count": confirmed_findings_count,
@@ -2993,6 +3128,16 @@ def _scan(args: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
         "traffic_contracts": traffic_contracts,
         "traffic_recorder_errors": traffic_recorder_errors,
         "traffic_accounting": _scan_traffic_accounting(traffic_policy),
+        "coverage": (
+            {
+                "artifact": str(run_dir / "scan-coverage.json"),
+                "status": coverage_certificate.status.value,
+                "completion_basis": coverage_certificate.completion_basis,
+                "limitations": list(coverage_certificate.limitations),
+            }
+            if coverage_certificate is not None
+            else {}
+        ),
         "flags": list(state.flags),
         "report": report_output,
     }
@@ -3094,6 +3239,258 @@ def _scan_traffic_accounting(
         "remaining_physical_requests": remaining,
         **snapshot.to_json(),
     }
+
+
+def _record_adaptive_scan_plan(
+    plan: ScanPlan,
+    *,
+    iteration: int,
+    workspace: AgentWorkspace,
+    audit: AuditStore,
+    engagement_id: UUID,
+) -> None:
+    payload = plan.to_json()
+    payload["iteration"] = iteration
+    audit.record(
+        engagement_id=engagement_id,
+        actor="scan",
+        action="scan_plan_updated",
+        payload=payload,
+    )
+    workspace.record_event(kind="scan_plan_updated", payload=payload)
+
+
+def _seed_adaptive_scan_recon(  # noqa: PLR0913
+    *,
+    target_url: str,
+    brief: EngagementBrief,
+    state: AgentState,
+    workspace: AgentWorkspace,
+    audit: AuditStore,
+    traffic_policy: TrafficPolicyController,
+    timeout_seconds: int,
+    allow_remote_target: bool,
+) -> dict[str, object]:
+    """Feed native HTML/JS/form discovery into the canonical surface graph."""
+    try:
+        recon = run_recon(
+            target_url,
+            max_pages=12,
+            timeout_seconds=max(1, min(timeout_seconds, 60)),
+            allow_remote_target=allow_remote_target,
+            in_scope=brief.scope.in_scope,
+            out_of_scope=brief.scope.out_of_scope,
+            max_rps=brief.roe.max_rps,
+            traffic_policy=traffic_policy,
+        )
+    except Exception as exc:  # noqa: BLE001 - recon is additive, not a run gate.
+        payload = {
+            "error_type": type(exc).__name__,
+            "error": _concise_cli_error(exc),
+        }
+        audit.record(
+            engagement_id=brief.engagement_id,
+            actor="scan",
+            action="scan_recon_failed",
+            payload=payload,
+        )
+        workspace.record_event(kind="scan_recon_failed", payload=payload)
+        append_unique(state.facts, "adaptive native recon incomplete", limit=80)
+        return {
+            "pages": [],
+            "errors": [str(payload["error"])],
+            "http_request_count": 0,
+        }
+
+    recon_payload: dict[str, object] = recon.to_json()
+    audit.record(
+        engagement_id=brief.engagement_id,
+        actor="scan",
+        action="scan_recon_completed",
+        payload=recon_payload,
+    )
+    workspace.record_event(kind="scan_recon_completed", payload=recon_payload)
+    merge_recon_state(state, recon_payload)
+    preserved_surface = dict(state.surface)
+    context = brief.context if isinstance(brief.context, Mapping) else {}
+    surface = surface_from_recon(
+        target_url=target_url,
+        description=str(context.get("description") or ""),
+        recon_payload=recon_payload,
+    )
+    ingest_recon_surface(state.surface_graph, recon_payload, identity_alias="anonymous")
+    surface = project_surface_graph(state.surface_graph, surface)
+    merge_surface_state(state, surface)
+    state.surface.update(preserved_surface)
+    graph_payload = {
+        "operations": len(state.surface_graph.operations or {}),
+        "identity_observations": len(state.surface_graph.observations or {}),
+        "sources": sorted(
+            {
+                source
+                for operation in (state.surface_graph.operations or {}).values()
+                for source in operation.provenance
+            }
+        ),
+    }
+    audit.record(
+        engagement_id=brief.engagement_id,
+        actor="scan",
+        action="scan_surface_graph_updated",
+        payload=graph_payload,
+    )
+    workspace.record_event(kind="scan_surface_graph_updated", payload=graph_payload)
+    return recon_payload
+
+
+def _build_scan_coverage_certificate(  # noqa: C901, PLR0913
+    *,
+    target_url: str,
+    planner_mode: str,
+    adaptive_plan: ScanPlan | None,
+    executions: list[_ScanProbeExecution],
+    skipped_probes: Mapping[str, str],
+    planner_frontier_exhausted: bool,
+    traffic_policy: TrafficPolicyController,
+) -> ScanCoverageCertificate:
+    recorder = ScanCoverageRecorder()
+    execution_ids: list[tuple[str, _ScanProbeExecution]] = []
+    recorded_probe_ids: set[str] = set()
+    next_rank = 0
+    if adaptive_plan is not None:
+        execution_by_probe = {execution.probe: execution for execution in executions}
+        for rank, decision in enumerate(adaptive_plan.decisions):
+            terminal_disposition = None
+            if decision.status is ScanPlanStatus.NOT_APPLICABLE:
+                terminal_disposition = ProbeDisposition.NOT_APPLICABLE
+            elif decision.status is ScanPlanStatus.BLOCKED:
+                terminal_disposition = ProbeDisposition.UNSUPPORTED
+            recorder.record_planner_decision(
+                PlannerProbeDecision(
+                    probe_id=decision.probe,
+                    family=decision.phase.value,
+                    rank=rank,
+                    surface_key=target_url,
+                    reason_codes=_coverage_reason_codes(decision),
+                    terminal_disposition=terminal_disposition,
+                )
+            )
+            recorded_probe_ids.add(decision.probe)
+            execution = execution_by_probe.get(decision.probe)
+            if execution is not None:
+                execution_ids.append((decision.probe, execution))
+        next_rank = len(adaptive_plan.decisions)
+    else:
+        occurrences: dict[str, int] = {}
+        for rank, execution in enumerate(executions):
+            occurrence = occurrences.get(execution.probe, 0) + 1
+            occurrences[execution.probe] = occurrence
+            probe_id = (
+                execution.probe if occurrence == 1 else f"{execution.probe}.{occurrence}"
+            )
+            recorder.record_planner_decision(
+                PlannerProbeDecision(
+                    probe_id=probe_id,
+                    family=planner_mode,
+                    rank=rank,
+                    surface_key=target_url,
+                    reason_codes=(
+                        "operator_selected" if planner_mode == "explicit" else "full_catalog",
+                    ),
+                )
+            )
+            recorded_probe_ids.add(probe_id)
+            execution_ids.append((probe_id, execution))
+        next_rank = len(executions)
+    for probe, _reason in sorted(skipped_probes.items()):
+        if probe in recorded_probe_ids:
+            continue
+        recorder.record_planner_decision(
+            PlannerProbeDecision(
+                probe_id=probe,
+                family="unsupported",
+                rank=next_rank,
+                surface_key=target_url,
+                reason_codes=("managed_transport_unavailable",),
+                terminal_disposition=ProbeDisposition.UNSUPPORTED,
+            )
+        )
+        next_rank += 1
+    for probe_id, execution in execution_ids:
+        recorder.record_probe_outcome(_scan_probe_coverage_outcome(probe_id, execution))
+    try:
+        traffic_snapshot = traffic_policy.snapshot()
+    except (OSError, TrafficPolicyError, ValueError):
+        traffic_snapshot = None
+    return recorder.finalize(
+        planner_frontier_exhausted=planner_frontier_exhausted,
+        traffic_snapshot=traffic_snapshot,
+        traffic_config=traffic_policy.config,
+    )
+
+
+def _coverage_reason_codes(decision: ScanPlanDecision) -> tuple[str, ...]:
+    reasons = tuple(sorted(set(decision.reasons)))
+    if len(reasons) <= _MAX_SCAN_COVERAGE_REASON_CODES:
+        return reasons
+    return (
+        *reasons[: _MAX_SCAN_COVERAGE_REASON_CODES - 1],
+        "reason_codes_truncated",
+    )
+
+
+def _scan_probe_coverage_outcome(
+    probe_id: str,
+    execution: _ScanProbeExecution,
+) -> ProbeCoverageOutcome:
+    result = execution.result
+    if execution.policy_blocked:
+        disposition = ProbeDisposition.BLOCKED_BUDGET
+        reason_codes = ("traffic_policy_blocked",)
+    elif result.findings:
+        disposition = ProbeDisposition.COMPLETED_FINDING
+        reason_codes = ()
+    elif _scan_probe_transport_incomplete(result):
+        disposition = ProbeDisposition.TRANSPORT_INCOMPLETE
+        reason_codes = ("transport_incomplete",)
+    else:
+        disposition = ProbeDisposition.COMPLETED_NO_FINDING
+        reason_codes = ()
+    if execution.opaque_unmetered:
+        accounting_status = RequestAccountingStatus.LOWER_BOUND
+        reason_codes = (*reason_codes, "opaque_transport")
+    else:
+        try:
+            accounting_status = RequestAccountingStatus(result.http_request_count_status)
+        except (TypeError, ValueError):
+            accounting_status = RequestAccountingStatus.UNAVAILABLE
+    return ProbeCoverageOutcome(
+        probe_id=probe_id,
+        disposition=disposition,
+        finding_count=len(result.findings),
+        physical_request_count=result.http_request_count,
+        request_accounting_status=accounting_status,
+        reason_codes=tuple(sorted(set(reason_codes))),
+    )
+
+
+def _scan_probe_transport_incomplete(result: ProbeRunResult) -> bool:
+    if _scan_result_has_http_response(result):
+        return False
+    request_errors = any(
+        isinstance(request, Mapping) and str(request.get("error") or "").strip()
+        for request in result.requests
+    )
+    return bool(result.errors or request_errors)
+
+
+def _scan_result_has_http_response(result: ProbeRunResult) -> bool:
+    return any(
+        isinstance(request, Mapping)
+        and isinstance(request.get("status"), int)
+        and not isinstance(request.get("status"), bool)
+        for request in result.requests
+    )
 
 
 def _configured_scan_session(  # noqa: PLR0913

--- a/packages/ravage/src/ravage/agent_core/action_executor.py
+++ b/packages/ravage/src/ravage/agent_core/action_executor.py
@@ -14,7 +14,11 @@ from uuid import UUID, uuid5
 from ravage.agent_core.agent_state import AgentState, append_unique, merge_signals
 from ravage.agent_core.agent_strategy import observation_digest
 from ravage.agent_core.live_events import http_step_payload, mask_headers
-from ravage.agent_core.observation_analysis import classify_action_result, extract_signals
+from ravage.agent_core.observation_analysis import (
+    classify_action_result,
+    extract_probe_signals,
+    extract_signals,
+)
 from ravage.agent_core.surface_graph_ingest import ingest_probe_result, project_surface_graph
 from ravage.auth.sessions import AuthenticationError
 from ravage.finding_evidence import confirmed_finding_evidence_failures
@@ -2375,7 +2379,10 @@ def record_probe_result(  # noqa: PLR0913
         source_kind=kind,
         recognized_proofs=recognized_proofs,
     )
-    merge_signals(state, extract_signals(text))
+    signals = (
+        extract_probe_signals(text) if kind == "tool_run_probe" else extract_signals(text)
+    )
+    merge_signals(state, signals)
     known_proof_replayed = _only_known_auto_capture_proofs(
         text,
         enabled=proof_recognition_enabled,

--- a/packages/ravage/src/ravage/agent_core/observation_analysis.py
+++ b/packages/ravage/src/ravage/agent_core/observation_analysis.py
@@ -37,6 +37,20 @@ def extract_signals(text: str) -> dict[str, list[str]]:
     return signals
 
 
+def extract_probe_signals(text: str) -> dict[str, list[str]]:
+    """
+    Extract only typed finding signals from executor-owned probe JSON.
+
+    Probe request URLs and response snippets are evidence of attempts, not new
+    discovery.  Mining the full serialized payload lets attack mutations feed
+    later probes, so this boundary deliberately ignores generic text patterns.
+    """
+    signals: dict[str, list[str]] = {}
+    if _structured_result(text):
+        _collect_structured_signals(signals, text)
+    return signals
+
+
 def observation_facts(text: str) -> list[str]:
     facts: list[str] = []
     lower = text.lower()

--- a/packages/ravage/src/ravage/agent_core/surface_graph.py
+++ b/packages/ravage/src/ravage/agent_core/surface_graph.py
@@ -260,6 +260,11 @@ class SurfaceOperation:
     def structural_url(self) -> str:
         return f"{self.origin}{self.route_shape}"
 
+    @property
+    def actionable(self) -> bool:
+        """Whether trusted discovery, rather than attack traffic alone, found this shape."""
+        return any(source != "probe" for source in self.provenance)
+
     def to_json(self) -> dict[str, object]:
         return {
             "operation_id": self.operation_id,
@@ -557,15 +562,19 @@ class SurfaceGraphState:
         observed_at: object = "",
     ) -> SurfaceOperation:
         source = _source_kind(source_kind)
+        attack_metadata = source == "probe"
         operation = self.add_operation(
             SurfaceOperation.create(
                 url=url,
                 method=method,
                 selector=selector,
-                parameters=parameters,
-                content_types=content_types,
-                header_names=header_names,
-                hints=hints,
+                # Probe mutations remain access evidence, never discovery
+                # metadata. This also prevents a later trusted observation of
+                # the same method/route from inheriting attacker-made fields.
+                parameters=() if attack_metadata else parameters,
+                content_types=() if attack_metadata else content_types,
+                header_names=() if attack_metadata else header_names,
+                hints=() if attack_metadata else hints,
                 provenance=(source,),
             )
         )
@@ -655,7 +664,12 @@ class SurfaceGraphState:
     def to_prompt_json(self, *, limit: int = 40) -> dict[str, object]:
         assert self.operations is not None
         assert self.observations is not None
-        operations = [self.operations[key] for key in sorted(self.operations)[:limit]]
+        actionable_operations = [
+            self.operations[key]
+            for key in sorted(self.operations)
+            if self.operations[key].actionable
+        ]
+        operations = actionable_operations[:limit]
         statuses: dict[str, dict[str, list[int]]] = {}
         for observation in self.observations.values():
             if observation.response_status is None:
@@ -668,6 +682,7 @@ class SurfaceGraphState:
         return {
             "counts": {
                 "operations": len(self.operations),
+                "candidate_operations": len(actionable_operations),
                 "identity_observations": len(self.observations),
             },
             "operations": [

--- a/packages/ravage/src/ravage/agent_core/surface_graph_ingest.py
+++ b/packages/ravage/src/ravage/agent_core/surface_graph_ingest.py
@@ -545,16 +545,12 @@ def ingest_probe_result(  # noqa: C901 - typed finding adapters remain explicit.
     identity_alias: str = "anonymous",
     source_observation_id: str = "",
 ) -> int:
-    """Ingest value-free request summaries and typed API findings from a probe."""
+    """Retain probe attempts while promoting only exact typed surface findings."""
     probe_name = str(probe_payload.get("probe") or "probe")
     refs = tuple(item for item in (source_observation_id, probe_name) if item)
     added = 0
     for request in _mapping_items(probe_payload.get("requests")):
         url = str(request.get("url") or "")
-        request_headers = request.get("request_headers")
-        request_header_names = _string_items(request.get("request_header_names"))
-        if isinstance(request_headers, Mapping):
-            request_header_names = (*request_header_names, *_bounded_mapping_keys(request_headers))
         method = str(request.get("method") or "GET").upper()
         scope_decision = str(request.get("scope_decision") or "unknown")
         request_sent = request.get("request_sent") is not False
@@ -562,9 +558,13 @@ def ingest_probe_result(  # noqa: C901 - typed finding adapters remain explicit.
             graph,
             url=url,
             method=method,
-            parameters=_query_parameters(url),
-            header_names=request_header_names,
-            hints=(probe_name, str(request.get("probe_kind") or "probe")),
+            # Attack probes deliberately mutate URLs, field names, and headers.
+            # Preserve their operation/observation evidence, but do not merge
+            # those attacker-generated attributes into a trusted operation that
+            # native recon, browser capture, or a typed adapter already mapped.
+            parameters=(),
+            header_names=(),
+            hints=(),
             source_kind="probe",
             identity_alias=identity_alias,
             access_level=(
@@ -702,7 +702,7 @@ def project_surface_graph(
     for operation in (
         operations[key]
         for key in sorted(operations)
-        if _operation_is_actionable_projection(graph, operations[key])
+        if _operation_is_actionable_projection(operations[key])
     ):
         url = operation.structural_url
         structural = "{" in operation.route_shape
@@ -777,19 +777,9 @@ def project_surface_graph(
     return legacy
 
 
-def _operation_is_actionable_projection(
-    graph: SurfaceGraphState,
-    operation: SurfaceOperation,
-) -> bool:
-    """Keep negative probe history canonical without promoting it to planners."""
-    if operation.provenance != ("probe",):
-        return True
-    response_statuses = {
-        item.response_status
-        for item in (graph.observations or {}).values()
-        if item.operation_id == operation.operation_id and item.response_status is not None
-    }
-    return not response_statuses or not response_statuses <= {404, 410}
+def _operation_is_actionable_projection(operation: SurfaceOperation) -> bool:
+    """Keep all probe history canonical without promoting attack-made candidates."""
+    return operation.actionable
 
 
 def import_legacy_surface(

--- a/packages/ravage/src/ravage/outcome_evidence.py
+++ b/packages/ravage/src/ravage/outcome_evidence.py
@@ -81,11 +81,14 @@ class QualifiedProbeFinding:
     vuln_class_source: str = "registry"
 
     def finding_id(self, engagement_id: UUID) -> str:
+        affected_parameter = _affected_parameter(self.request)
         identity_parts: dict[str, object] = {
             "vuln_class": self.contract.vuln_class,
-            "endpoint": self.endpoint,
+            "endpoint": _finding_identity_endpoint(
+                self.endpoint,
+                affected_parameter=affected_parameter,
+            ),
         }
-        affected_parameter = _affected_parameter(self.request)
         if affected_parameter:
             identity_parts["affected_parameters"] = [affected_parameter]
         identity = json.dumps(
@@ -96,14 +99,18 @@ class QualifiedProbeFinding:
         return str(uuid5(engagement_id, identity))
 
     def evidence_id(self, engagement_id: UUID) -> str:
+        affected_parameter = _affected_parameter(self.request)
         identity_parts: dict[str, object] = {
             "finding_type": self.finding_type,
-            "probe": self.probe,
-            "endpoint": self.endpoint,
+            "endpoint": _finding_identity_endpoint(
+                self.endpoint,
+                affected_parameter=affected_parameter,
+            ),
         }
-        affected_parameter = _affected_parameter(self.request)
         if affected_parameter:
             identity_parts["affected_parameters"] = [affected_parameter]
+        else:
+            identity_parts["probe"] = self.probe
         identity = json.dumps(
             identity_parts,
             sort_keys=True,
@@ -1424,6 +1431,19 @@ def _affected_parameter(request: Mapping[str, object]) -> dict[str, str]:
         return {}
     [parameter] = _safe_parameters([raw]) or [{}]
     return parameter
+
+
+def _finding_identity_endpoint(
+    endpoint: Mapping[str, object],
+    *,
+    affected_parameter: Mapping[str, str],
+) -> dict[str, object]:
+    if not affected_parameter:
+        return dict(endpoint)
+    return {
+        "method": endpoint.get("method"),
+        "url": endpoint.get("url"),
+    }
 
 
 def _safe_parameters(value: object) -> list[dict[str, str]]:

--- a/packages/ravage/src/ravage/probes/specialists/idor_signals.py
+++ b/packages/ravage/src/ravage/probes/specialists/idor_signals.py
@@ -86,6 +86,14 @@ def _idor_access_signal(
     if _auth_cookie_identity_changed(baseline, response):
         return _auth_cookie_identity_signal(response)
 
+    if _is_pure_identifier_substitution(
+        baseline=baseline,
+        response=response,
+        original_id=original_id,
+        candidate_id=candidate_id,
+    ):
+        return {}
+
     object_delta = _object_access_delta(
         baseline=baseline,
         response=response,
@@ -99,6 +107,25 @@ def _idor_access_signal(
     if sensitive_delta:
         return sensitive_delta
     return {}
+
+
+def _is_pure_identifier_substitution(
+    *,
+    baseline: ProbeResponse,
+    response: ProbeResponse,
+    original_id: str,
+    candidate_id: str,
+) -> bool:
+    if response.status != baseline.status or not original_id or not candidate_id:
+        return False
+    if original_id == candidate_id:
+        return False
+    if original_id not in baseline.body or candidate_id not in response.body:
+        return False
+    sentinel = "<ravage-object-identifier>"
+    normalized_baseline = baseline.body.replace(original_id, sentinel)
+    normalized_response = response.body.replace(candidate_id, sentinel)
+    return normalized_baseline == normalized_response
 
 
 def _proof_or_secret_signal(response: ProbeResponse) -> dict[str, object]:

--- a/packages/ravage/src/ravage/probes/specialists/idor_targets.py
+++ b/packages/ravage/src/ravage/probes/specialists/idor_targets.py
@@ -9,9 +9,11 @@ from ravage.probes.specialists.shared import (
     _dedupe,
     _form_targets,
     _generic_input_targets,
+    _idor_id_format,
     _input_name_priority,
     _int_value,
     _list_of_dicts,
+    _looks_mongo_object_id,
     _name_looks_expression_context,
     _name_looks_idor,
     _string_items,
@@ -19,8 +21,6 @@ from ravage.probes.specialists.shared import (
     _target_current_value,
     _target_headers,
     _value_looks_idor_id,
-    _idor_id_format,
-    _looks_mongo_object_id,
 )
 from ravage.web_core.http_probe import form_defaults
 
@@ -78,7 +78,7 @@ def _idor_targets(state: AgentState) -> list[dict[str, object]]:
             continue
         if _looks_expression_only_idor_candidate(input_name, url):
             continue
-        if not name_looks_idor and not (current_value and _value_looks_idor_id(current_value)):
+        if not name_looks_idor and not _value_is_structured_idor_id(current_value):
             continue
         targets.append(
             target
@@ -93,7 +93,10 @@ def _idor_targets(state: AgentState) -> list[dict[str, object]]:
         for param_name, value in parse_qsl(urlsplit(endpoint).query, keep_blank_values=True):
             if _looks_expression_only_idor_candidate(param_name, endpoint):
                 continue
-            if not (_name_looks_idor(param_name, endpoint) or _value_looks_idor_id(value)):
+            if not (
+                _name_looks_idor(param_name, endpoint)
+                or _value_is_structured_idor_id(value)
+            ):
                 continue
             baseline_id = value or _baseline_value(param_name)
             targets.append(
@@ -194,7 +197,7 @@ def _idor_form_targets(state: AgentState) -> list[dict[str, object]]:
                 continue
             if _looks_expression_only_idor_candidate(name, action):
                 continue
-            if not name_looks_idor and not _value_looks_idor_id(value):
+            if not name_looks_idor and not _value_is_structured_idor_id(value):
                 continue
             baseline_id = value or _baseline_value(name)
             priority = 55 + auth_bonus + _input_name_priority(name)
@@ -221,6 +224,10 @@ def _idor_form_targets(state: AgentState) -> list[dict[str, object]]:
                 }
             )
     return targets
+
+
+def _value_is_structured_idor_id(value: str) -> bool:
+    return _idor_id_format(value) in {"numeric", "uuid", "hash", "objectid"}
 
 
 def _form_auth_bonus(form: dict[str, object]) -> int:

--- a/packages/ravage/src/ravage/report.py
+++ b/packages/ravage/src/ravage/report.py
@@ -331,6 +331,7 @@ def build_pentest_report(  # noqa: PLR0913
     target = target_url or _target_from_events(events) or (manifest.target_url if manifest else "")
     agent_http_evidence = _agent_http_evidence_summary(workspace_dir)
     traffic_accounting = _traffic_accounting_summary(workspace_dir, events=events)
+    scan_coverage = _scan_coverage_summary(workspace_dir)
     report = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
@@ -374,6 +375,7 @@ def build_pentest_report(  # noqa: PLR0913
         },
         "proof_observations": proof_observations,
         "traffic_accounting": traffic_accounting,
+        "scan_coverage": scan_coverage,
         "agent_http_evidence": agent_http_evidence,
         "work_performed": work,
         "methodology": _methodology(),
@@ -442,6 +444,8 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
         "",
     ]
     lines.extend(f"- {item}" for item in _list(report.get("methodology")))
+    lines.extend(["", "## Deterministic Scan Coverage", ""])
+    lines.extend(_scan_coverage_markdown(_dict(report.get("scan_coverage"))))
     lines.extend(["", "## Reconnaissance", ""])
     lines.extend(_recon_markdown(_dict(report.get("reconnaissance"))))
     hosting = _dict(report.get("hosting_layer"))
@@ -547,11 +551,116 @@ def _recon_markdown(recon: dict[str, Any]) -> list[str]:
     return [*lines, ""]
 
 
+def _scan_coverage_markdown(coverage: dict[str, Any]) -> list[str]:
+    status = str(coverage.get("status") or "not_available")
+    if status in {"not_available", "unavailable"}:
+        return [
+            "No validated deterministic scan coverage certificate was available.",
+            "",
+        ]
+    summary = _dict(coverage.get("summary"))
+    disposition_counts = _dict(summary.get("disposition_counts"))
+    limitations = _list(coverage.get("limitations"))
+    lines = [
+        (
+            "This certificate covers only the recorded finite planner frontier. "
+            "It does not claim that the application or any vulnerability family "
+            "was exhausted."
+        ),
+        "",
+        f"- Certificate status: {status}",
+        f"- Completion basis: {coverage.get('completion_basis', '')}",
+        f"- Planner decisions: {summary.get('planner_decision_count', 0)}",
+        f"- Completed probes: {summary.get('completed_probe_count', 0)}",
+        f"- Findings observed by probes: {summary.get('finding_count', 0)}",
+        (
+            "- Dispositions: "
+            + ", ".join(f"{name}={value}" for name, value in sorted(disposition_counts.items()))
+        ),
+        f"- Limitations: {_join(limitations) if limitations else 'none recorded'}",
+        "",
+    ]
+    probes = [_dict(item) for item in _list(coverage.get("probes"))]
+    if not probes:
+        return lines
+    lines.extend(
+        [
+            "| Probe | Family | Disposition | Findings | Physical requests | Accounting |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(
+        (
+            "| "
+            + " | ".join(
+                _table_cell(value)
+                for value in (
+                    probe.get("probe_id", ""),
+                    probe.get("family", ""),
+                    probe.get("disposition", ""),
+                    probe.get("finding_count", 0),
+                    probe.get("physical_request_count", 0),
+                    probe.get("request_accounting_status", ""),
+                )
+            )
+            + " |"
+        )
+        for probe in probes
+    )
+    lines.append("")
+    return lines
+
+
 def redact_sensitive(value: str) -> str:
     redacted = _PROOF_RE.sub(lambda match: _mask_proof(match.group(0)), str(value))
     for pattern in _SECRET_PATTERNS:
         redacted = pattern.sub(_secret_replacement, redacted)
     return redacted
+
+
+def _scan_coverage_summary(workspace_dir: Path) -> dict[str, object]:
+    artifact_path = workspace_dir.parent / "scan-coverage.json"
+    if not artifact_path.exists():
+        return {"status": "not_available"}
+    payload = _read_bounded_json_object(artifact_path)
+    if (
+        payload.get("schema") != "ravage.scan-coverage"
+        or payload.get("version") != 1
+        or payload.get("status") not in {"complete", "partial"}
+        or payload.get("completion_basis")
+        not in {"planner_frontier_exhausted", "planner_frontier_open"}
+    ):
+        return {
+            "status": "unavailable",
+            "limitations": ["coverage_artifact_unreadable"],
+        }
+    summary = _dict(payload.get("summary"))
+    traffic = _dict(payload.get("traffic"))
+    probes = [
+        {
+            key: record.get(key)
+            for key in (
+                "probe_id",
+                "family",
+                "disposition",
+                "finding_count",
+                "physical_request_count",
+                "request_accounting_status",
+                "reason_codes",
+                "surface_ref",
+            )
+        }
+        for item in _list(payload.get("probes"))[:512]
+        if (record := _dict(item))
+    ]
+    return {
+        "status": payload["status"],
+        "completion_basis": payload["completion_basis"],
+        "limitations": [str(item) for item in _list(payload.get("limitations"))[:64]],
+        "summary": summary,
+        "traffic": traffic,
+        "probes": probes,
+    }
 
 
 def _traffic_accounting_summary(

--- a/packages/ravage/src/ravage/scan_coverage.py
+++ b/packages/ravage/src/ravage/scan_coverage.py
@@ -1,0 +1,631 @@
+"""Deterministic, path-free coverage certificates for finite scan plans."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+from ravage.traffic.policy import TrafficPolicyConfig, TrafficPolicySnapshot
+
+SCAN_COVERAGE_SCHEMA = "ravage.scan-coverage"
+SCAN_COVERAGE_VERSION = 1
+MAX_PROBE_RECORDS = 512
+MAX_CERTIFICATE_BYTES = 256_000
+
+_MAX_TOKEN_CHARS = 96
+_MAX_REASON_CODES = 8
+_MAX_SURFACE_KEY_CHARS = 4_096
+_MAX_FINDINGS_PER_PROBE = 10_000
+_MAX_COUNTER_VALUE = 1_000_000_000_000
+_TOKEN_PATTERN = re.compile(r"[a-z0-9](?:[a-z0-9_.:-]{0,94}[a-z0-9])?\Z")
+
+
+class ScanCoverageError(ValueError):
+    """A coverage input cannot be represented truthfully and safely."""
+
+
+class ProbeDisposition(StrEnum):
+    """Final, non-overlapping disposition for one planner decision."""
+
+    COMPLETED_FINDING = "completed_finding"
+    COMPLETED_NO_FINDING = "completed_no_finding"
+    NOT_APPLICABLE = "not_applicable"
+    UNSUPPORTED = "unsupported"
+    BLOCKED_BUDGET = "blocked_budget"
+    TRANSPORT_INCOMPLETE = "transport_incomplete"
+
+
+class RequestAccountingStatus(StrEnum):
+    """How completely a request count represents physical target traffic."""
+
+    EXACT = "exact"
+    LOWER_BOUND = "lower_bound"
+    UNAVAILABLE = "unavailable"
+
+
+class ScanCoverageStatus(StrEnum):
+    """Whether the finite recorded plan completed without known limitations."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+
+
+_PLANNER_TERMINAL_DISPOSITIONS = frozenset(
+    {
+        ProbeDisposition.NOT_APPLICABLE,
+        ProbeDisposition.UNSUPPORTED,
+        ProbeDisposition.BLOCKED_BUDGET,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PlannerProbeDecision:
+    """One bounded planner decision, without emitting its raw target surface."""
+
+    probe_id: str
+    family: str
+    rank: int
+    surface_key: str = field(default="global", repr=False)
+    reason_codes: tuple[str, ...] = ()
+    terminal_disposition: ProbeDisposition | None = None
+
+    def __post_init__(self) -> None:
+        _require_token(self.probe_id, "probe_id")
+        _require_token(self.family, "family")
+        _require_non_negative_count(self.rank, "rank")
+        if not isinstance(self.surface_key, str):
+            message = "surface_key must be a string"
+            raise TypeError(message)
+        if len(self.surface_key) > _MAX_SURFACE_KEY_CHARS:
+            message = "surface_key is too long"
+            raise ScanCoverageError(message)
+        normalized_reasons = _normalize_reason_codes(self.reason_codes)
+        object.__setattr__(self, "reason_codes", normalized_reasons)
+        if self.terminal_disposition is not None:
+            try:
+                disposition = ProbeDisposition(self.terminal_disposition)
+            except ValueError as exc:
+                message = "terminal_disposition is invalid"
+                raise ScanCoverageError(message) from exc
+            if disposition not in _PLANNER_TERMINAL_DISPOSITIONS:
+                message = (
+                    "planner decisions may terminate only as inapplicable, unsupported, or blocked"
+                )
+                raise ScanCoverageError(message)
+            object.__setattr__(self, "terminal_disposition", disposition)
+
+    @property
+    def surface_ref(self) -> str:
+        """Return a deterministic reference without disclosing a URL or path."""
+        digest = hashlib.sha256(self.surface_key.encode("utf-8")).hexdigest()[:24]
+        return f"sha256:{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeCoverageOutcome:
+    """Bounded result supplied after one selected probe finishes or stops."""
+
+    probe_id: str
+    disposition: ProbeDisposition
+    finding_count: int = 0
+    physical_request_count: int = 0
+    request_accounting_status: RequestAccountingStatus = RequestAccountingStatus.EXACT
+    reason_codes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_token(self.probe_id, "probe_id")
+        try:
+            disposition = ProbeDisposition(self.disposition)
+        except ValueError as exc:
+            message = "probe disposition is invalid"
+            raise ScanCoverageError(message) from exc
+        object.__setattr__(self, "disposition", disposition)
+        _require_non_negative_count(
+            self.finding_count,
+            "finding_count",
+            maximum=_MAX_FINDINGS_PER_PROBE,
+        )
+        _require_non_negative_count(self.physical_request_count, "physical_request_count")
+        try:
+            accounting = RequestAccountingStatus(self.request_accounting_status)
+        except ValueError as exc:
+            message = "request_accounting_status is invalid"
+            raise ScanCoverageError(message) from exc
+        object.__setattr__(self, "request_accounting_status", accounting)
+        object.__setattr__(self, "reason_codes", _normalize_reason_codes(self.reason_codes))
+        if disposition is ProbeDisposition.COMPLETED_FINDING and not self.finding_count:
+            message = "completed_finding requires at least one finding"
+            raise ScanCoverageError(message)
+        if disposition is not ProbeDisposition.COMPLETED_FINDING and self.finding_count:
+            message = "only completed_finding may carry findings"
+            raise ScanCoverageError(message)
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeCoverageRecord:
+    """Final certificate record for one planner decision."""
+
+    probe_id: str
+    family: str
+    planner_rank: int
+    surface_ref: str
+    disposition: ProbeDisposition
+    finding_count: int
+    physical_request_count: int
+    request_accounting_status: RequestAccountingStatus
+    reason_codes: tuple[str, ...]
+
+    def to_json(self) -> dict[str, object]:
+        """Return a stable, path-free JSON value."""
+        return {
+            "disposition": self.disposition.value,
+            "family": self.family,
+            "finding_count": self.finding_count,
+            "physical_request_count": self.physical_request_count,
+            "planner_rank": self.planner_rank,
+            "probe_id": self.probe_id,
+            "reason_codes": list(self.reason_codes),
+            "request_accounting_status": self.request_accounting_status.value,
+            "surface_ref": self.surface_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScanTrafficCoverage:
+    """Path-free traffic policy and whole-run accounting projection."""
+
+    accounting_status: RequestAccountingStatus
+    policy_mode: str
+    max_rps: float | None
+    max_physical_requests: int | None
+    cache_enabled: bool | None
+    deduplicate: bool | None
+    max_retries: int | None
+    physical_request_count: int | None
+    completed_request_count: int | None
+    incomplete_request_count: int | None
+    pending_dispatch_count: int | None
+    reservation_count: int | None
+    cache_hit_count: int | None
+    deduplicated_count: int | None
+    retry_count: int | None
+    blocked_count: int | None
+    circuit_open_count: int | None
+    unmetered_action_count: int | None
+
+    def to_json(self) -> dict[str, object]:
+        """Return the fixed-size traffic projection."""
+        return {
+            "accounting_status": self.accounting_status.value,
+            "blocked_count": self.blocked_count,
+            "cache_enabled": self.cache_enabled,
+            "cache_hit_count": self.cache_hit_count,
+            "circuit_open_count": self.circuit_open_count,
+            "completed_request_count": self.completed_request_count,
+            "deduplicate": self.deduplicate,
+            "deduplicated_count": self.deduplicated_count,
+            "incomplete_request_count": self.incomplete_request_count,
+            "max_physical_requests": self.max_physical_requests,
+            "max_retries": self.max_retries,
+            "max_rps": self.max_rps,
+            "pending_dispatch_count": self.pending_dispatch_count,
+            "physical_request_count": self.physical_request_count,
+            "policy_mode": self.policy_mode,
+            "reservation_count": self.reservation_count,
+            "retry_count": self.retry_count,
+            "unmetered_action_count": self.unmetered_action_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScanCoverageCertificate:
+    """Immutable versioned result of a finite planner run."""
+
+    status: ScanCoverageStatus
+    completion_basis: str
+    limitations: tuple[str, ...]
+    probes: tuple[ProbeCoverageRecord, ...]
+    traffic: ScanTrafficCoverage
+
+    def to_json(self) -> dict[str, object]:
+        """Return the deterministic certificate document."""
+        disposition_counts = {
+            disposition.value: sum(record.disposition is disposition for record in self.probes)
+            for disposition in ProbeDisposition
+        }
+        return {
+            "completion_basis": self.completion_basis,
+            "limitations": list(self.limitations),
+            "probes": [record.to_json() for record in self.probes],
+            "schema": SCAN_COVERAGE_SCHEMA,
+            "status": self.status.value,
+            "summary": {
+                "completed_probe_count": sum(
+                    record.disposition
+                    in {
+                        ProbeDisposition.COMPLETED_FINDING,
+                        ProbeDisposition.COMPLETED_NO_FINDING,
+                    }
+                    for record in self.probes
+                ),
+                "disposition_counts": disposition_counts,
+                "finding_count": sum(record.finding_count for record in self.probes),
+                "planner_decision_count": len(self.probes),
+            },
+            "traffic": self.traffic.to_json(),
+            "version": SCAN_COVERAGE_VERSION,
+        }
+
+    def to_json_text(self) -> str:
+        """Serialize reproducibly with a trailing newline."""
+        encoded = json.dumps(self.to_json(), indent=2, sort_keys=True) + "\n"
+        if len(encoded.encode("utf-8")) > MAX_CERTIFICATE_BYTES:
+            message = "scan coverage certificate exceeds its size limit"
+            raise ScanCoverageError(message)
+        return encoded
+
+
+class ScanCoverageRecorder:
+    """Collect planner decisions and outcomes without performing file I/O."""
+
+    def __init__(self, *, max_probe_records: int = MAX_PROBE_RECORDS) -> None:
+        _require_non_negative_count(max_probe_records, "max_probe_records")
+        if not max_probe_records or max_probe_records > MAX_PROBE_RECORDS:
+            message = f"max_probe_records must be between 1 and {MAX_PROBE_RECORDS}"
+            raise ScanCoverageError(message)
+        self._max_probe_records = max_probe_records
+        self._decisions: dict[str, PlannerProbeDecision] = {}
+        self._outcomes: dict[str, ProbeCoverageOutcome] = {}
+
+    def record_planner_decision(self, decision: PlannerProbeDecision) -> None:
+        """Record exactly one planner decision for a probe identifier."""
+        if not isinstance(decision, PlannerProbeDecision):
+            message = "decision must be a PlannerProbeDecision"
+            raise TypeError(message)
+        if decision.probe_id in self._decisions:
+            message = f"duplicate planner decision: {decision.probe_id}"
+            raise ScanCoverageError(message)
+        if len(self._decisions) >= self._max_probe_records:
+            message = "scan coverage planner decision limit reached"
+            raise ScanCoverageError(message)
+        self._decisions[decision.probe_id] = decision
+
+    def record_probe_outcome(self, outcome: ProbeCoverageOutcome) -> None:
+        """Attach one final outcome to a previously selected decision."""
+        if not isinstance(outcome, ProbeCoverageOutcome):
+            message = "outcome must be a ProbeCoverageOutcome"
+            raise TypeError(message)
+        decision = self._decisions.get(outcome.probe_id)
+        if decision is None:
+            message = f"probe outcome has no planner decision: {outcome.probe_id}"
+            raise ScanCoverageError(message)
+        if decision.terminal_disposition is not None:
+            message = f"terminal planner decision cannot accept an outcome: {outcome.probe_id}"
+            raise ScanCoverageError(message)
+        if outcome.probe_id in self._outcomes:
+            message = f"duplicate probe outcome: {outcome.probe_id}"
+            raise ScanCoverageError(message)
+        self._outcomes[outcome.probe_id] = outcome
+
+    def finalize(
+        self,
+        *,
+        planner_frontier_exhausted: bool,
+        traffic_snapshot: TrafficPolicySnapshot | None,
+        traffic_config: TrafficPolicyConfig | None,
+    ) -> ScanCoverageCertificate:
+        """Build a deterministic certificate from the recorded finite plan."""
+        if type(planner_frontier_exhausted) is not bool:
+            message = "planner_frontier_exhausted must be a boolean"
+            raise TypeError(message)
+        records, missing_outcome = self._build_records()
+        traffic = _traffic_coverage(traffic_snapshot, traffic_config)
+        limitations = _limitations(
+            records=records,
+            traffic=traffic,
+            planner_frontier_exhausted=planner_frontier_exhausted,
+            missing_outcome=missing_outcome,
+            traffic_config_available=traffic_config is not None,
+        )
+        certificate = ScanCoverageCertificate(
+            status=(ScanCoverageStatus.PARTIAL if limitations else ScanCoverageStatus.COMPLETE),
+            completion_basis=(
+                "planner_frontier_exhausted"
+                if planner_frontier_exhausted
+                else "planner_frontier_open"
+            ),
+            limitations=limitations,
+            probes=records,
+            traffic=traffic,
+        )
+        certificate.to_json_text()
+        return certificate
+
+    def _build_records(self) -> tuple[tuple[ProbeCoverageRecord, ...], bool]:
+        records: list[ProbeCoverageRecord] = []
+        missing_outcome = False
+        ordered = sorted(
+            self._decisions.values(),
+            key=lambda item: (item.rank, item.probe_id, item.family, item.surface_ref),
+        )
+        for decision in ordered:
+            outcome = self._outcomes.get(decision.probe_id)
+            if decision.terminal_disposition is not None:
+                disposition = decision.terminal_disposition
+                outcome = None
+            elif outcome is None:
+                disposition = ProbeDisposition.TRANSPORT_INCOMPLETE
+                missing_outcome = True
+            else:
+                disposition = outcome.disposition
+            reason_codes = set(decision.reason_codes)
+            if outcome is not None:
+                reason_codes.update(outcome.reason_codes)
+            elif decision.terminal_disposition is None:
+                reason_codes.add("probe_outcome_missing")
+            normalized_reasons = _normalize_reason_codes(tuple(reason_codes))
+            records.append(
+                ProbeCoverageRecord(
+                    probe_id=decision.probe_id,
+                    family=decision.family,
+                    planner_rank=decision.rank,
+                    surface_ref=decision.surface_ref,
+                    disposition=disposition,
+                    finding_count=outcome.finding_count if outcome is not None else 0,
+                    physical_request_count=(
+                        outcome.physical_request_count if outcome is not None else 0
+                    ),
+                    request_accounting_status=(
+                        outcome.request_accounting_status
+                        if outcome is not None
+                        else (
+                            RequestAccountingStatus.EXACT
+                            if decision.terminal_disposition is not None
+                            else RequestAccountingStatus.UNAVAILABLE
+                        )
+                    ),
+                    reason_codes=normalized_reasons,
+                )
+            )
+        return tuple(records), missing_outcome
+
+
+def write_scan_coverage_certificate(
+    path: str | Path,
+    certificate: ScanCoverageCertificate,
+) -> Path:
+    """Atomically persist a private, deterministic coverage certificate."""
+    if not isinstance(certificate, ScanCoverageCertificate):
+        message = "certificate must be a ScanCoverageCertificate"
+        raise TypeError(message)
+    output_path = Path(path).expanduser().absolute()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = certificate.to_json_text()
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        dir=output_path.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.chmod(0o600)
+        temporary_path.replace(output_path)
+        _fsync_directory(output_path.parent)
+    finally:
+        with suppress(FileNotFoundError):
+            temporary_path.unlink()
+    return output_path
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    with suppress(OSError):
+        descriptor = os.open(path, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def _traffic_coverage(
+    snapshot: TrafficPolicySnapshot | None,
+    config: TrafficPolicyConfig | None,
+) -> ScanTrafficCoverage:
+    if snapshot is None:
+        accounting_status = RequestAccountingStatus.UNAVAILABLE
+        counts: tuple[int | None, ...] = (None,) * 11
+    else:
+        if not isinstance(snapshot, TrafficPolicySnapshot):
+            message = "traffic_snapshot must be a TrafficPolicySnapshot or None"
+            raise TypeError(message)
+        try:
+            accounting_status = RequestAccountingStatus(snapshot.accounting_status)
+        except ValueError as exc:
+            message = "traffic snapshot accounting_status is invalid"
+            raise ScanCoverageError(message) from exc
+        counts = (
+            snapshot.physical_request_count,
+            snapshot.completed_request_count,
+            snapshot.incomplete_request_count,
+            snapshot.pending_dispatch_count,
+            snapshot.reservation_count,
+            snapshot.cache_hit_count,
+            snapshot.deduplicated_count,
+            snapshot.retry_count,
+            snapshot.blocked_count,
+            snapshot.circuit_open_count,
+            snapshot.unmetered_action_count,
+        )
+        for value in counts:
+            _require_non_negative_count(value, "traffic snapshot counter")
+    if config is not None and not isinstance(config, TrafficPolicyConfig):
+        message = "traffic_config must be a TrafficPolicyConfig or None"
+        raise TypeError(message)
+    if config is not None and config.max_physical_requests is not None:
+        _require_non_negative_count(config.max_physical_requests, "max_physical_requests")
+    if config is not None:
+        _finite_optional_number(config.max_rps, "max_rps")
+    (
+        physical_request_count,
+        completed_request_count,
+        incomplete_request_count,
+        pending_dispatch_count,
+        reservation_count,
+        cache_hit_count,
+        deduplicated_count,
+        retry_count,
+        blocked_count,
+        circuit_open_count,
+        unmetered_action_count,
+    ) = counts
+    return ScanTrafficCoverage(
+        accounting_status=accounting_status,
+        policy_mode=config.mode.value if config is not None else "unavailable",
+        max_rps=config.max_rps if config is not None else None,
+        max_physical_requests=config.max_physical_requests if config is not None else None,
+        cache_enabled=config.cache_enabled if config is not None else None,
+        deduplicate=config.deduplicate if config is not None else None,
+        max_retries=config.max_retries if config is not None else None,
+        physical_request_count=physical_request_count,
+        completed_request_count=completed_request_count,
+        incomplete_request_count=incomplete_request_count,
+        pending_dispatch_count=pending_dispatch_count,
+        reservation_count=reservation_count,
+        cache_hit_count=cache_hit_count,
+        deduplicated_count=deduplicated_count,
+        retry_count=retry_count,
+        blocked_count=blocked_count,
+        circuit_open_count=circuit_open_count,
+        unmetered_action_count=unmetered_action_count,
+    )
+
+
+def _limitations(  # noqa: C901, PLR0912
+    *,
+    records: tuple[ProbeCoverageRecord, ...],
+    traffic: ScanTrafficCoverage,
+    planner_frontier_exhausted: bool,
+    missing_outcome: bool,
+    traffic_config_available: bool,
+) -> tuple[str, ...]:
+    limitations: set[str] = set()
+    if not planner_frontier_exhausted:
+        limitations.add("planner_frontier_open")
+    if not records:
+        limitations.add("planner_decisions_empty")
+    if missing_outcome:
+        limitations.add("probe_outcome_missing")
+    completed = {
+        ProbeDisposition.COMPLETED_FINDING,
+        ProbeDisposition.COMPLETED_NO_FINDING,
+    }
+    if records and not any(record.disposition in completed for record in records):
+        limitations.add("no_completed_probes")
+    if any(record.disposition is ProbeDisposition.UNSUPPORTED for record in records):
+        limitations.add("unsupported_probe")
+    if any(record.disposition is ProbeDisposition.BLOCKED_BUDGET for record in records):
+        limitations.add("budget_blocked")
+    if any(record.disposition is ProbeDisposition.TRANSPORT_INCOMPLETE for record in records):
+        limitations.add("transport_incomplete")
+    if any(
+        record.request_accounting_status is RequestAccountingStatus.LOWER_BOUND
+        for record in records
+    ):
+        limitations.add("probe_request_accounting_lower_bound")
+    if any(
+        record.request_accounting_status is RequestAccountingStatus.UNAVAILABLE
+        for record in records
+    ):
+        limitations.add("probe_request_accounting_unavailable")
+    if traffic.accounting_status is RequestAccountingStatus.LOWER_BOUND:
+        limitations.add("traffic_accounting_lower_bound")
+    elif traffic.accounting_status is RequestAccountingStatus.UNAVAILABLE:
+        limitations.add("traffic_accounting_unavailable")
+    if not traffic_config_available:
+        limitations.add("traffic_config_unavailable")
+    if any(
+        (value or 0) > 0
+        for value in (
+            traffic.incomplete_request_count,
+            traffic.pending_dispatch_count,
+            traffic.reservation_count,
+        )
+    ):
+        limitations.add("traffic_incomplete")
+    if (traffic.blocked_count or 0) > 0:
+        limitations.add("traffic_policy_blocked")
+    if (traffic.circuit_open_count or 0) > 0:
+        limitations.add("traffic_circuit_open")
+    if (traffic.unmetered_action_count or 0) > 0:
+        limitations.add("unmetered_actions")
+    return tuple(sorted(limitations))
+
+
+def _normalize_reason_codes(reason_codes: tuple[str, ...]) -> tuple[str, ...]:
+    if not isinstance(reason_codes, tuple):
+        message = "reason_codes must be a tuple"
+        raise TypeError(message)
+    if len(reason_codes) > _MAX_REASON_CODES:
+        message = f"reason_codes cannot contain more than {_MAX_REASON_CODES} values"
+        raise ScanCoverageError(message)
+    for reason_code in reason_codes:
+        _require_token(reason_code, "reason_code")
+    return tuple(sorted(set(reason_codes)))
+
+
+def _require_token(value: str, label: str) -> None:
+    if not isinstance(value, str):
+        message = f"{label} must be a string"
+        raise TypeError(message)
+    if len(value) > _MAX_TOKEN_CHARS or _TOKEN_PATTERN.fullmatch(value) is None:
+        message = f"{label} must be a bounded lowercase identifier"
+        raise ScanCoverageError(message)
+
+
+def _require_non_negative_count(
+    value: int,
+    label: str,
+    *,
+    maximum: int = _MAX_COUNTER_VALUE,
+) -> None:
+    if type(value) is not int or not 0 <= value <= maximum:
+        message = f"{label} must be an integer between 0 and {maximum}"
+        raise ScanCoverageError(message)
+
+
+def _finite_optional_number(value: float | None, label: str) -> None:
+    """Validate an optional serialized float when extending the certificate."""
+    if value is not None and (isinstance(value, bool) or not math.isfinite(float(value))):
+        message = f"{label} must be finite or None"
+        raise ScanCoverageError(message)
+
+
+__all__ = [
+    "MAX_CERTIFICATE_BYTES",
+    "MAX_PROBE_RECORDS",
+    "SCAN_COVERAGE_SCHEMA",
+    "SCAN_COVERAGE_VERSION",
+    "PlannerProbeDecision",
+    "ProbeCoverageOutcome",
+    "ProbeDisposition",
+    "RequestAccountingStatus",
+    "ScanCoverageCertificate",
+    "ScanCoverageError",
+    "ScanCoverageRecorder",
+    "ScanCoverageStatus",
+    "ScanTrafficCoverage",
+    "write_scan_coverage_certificate",
+]

--- a/packages/ravage/src/ravage/scan_planner.py
+++ b/packages/ravage/src/ravage/scan_planner.py
@@ -1,0 +1,762 @@
+"""Pure, deterministic planning for the adaptive deterministic scanner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ravage.agent_core.agent_state import AgentState
+from ravage.agent_core.surface_graph import SurfaceOperation, SurfaceParameter
+from ravage.probe_suite_parts.result import ProbeRunResult
+
+SCAN_PLAN_SCHEMA = "ravage.scan-plan.v1"
+
+# These are the historical default probes.  Adaptive planning is additive: a
+# lack of surface evidence must never make the established default scan smaller.
+DEFAULT_SCAN_PROBES = (
+    "surface_map",
+    "secret_sweep",
+    "direct_exposure",
+    "api_behavior",
+    "csrf_session",
+    "browser_boundary",
+)
+
+DISCOVERY_SCAN_PROBES = (
+    "surface_map",
+    "secret_sweep",
+    "direct_exposure",
+    "api_behavior",
+    "browser_boundary",
+)
+
+BREADTH_SCAN_PROBES = (
+    "stateful_session",
+    "csrf_session",
+    "input_reflection",
+    "xss_context",
+    "default_credentials",
+    "server_rendering",
+    "ssti_fingerprint",
+    "data_query",
+    "sqli_differential",
+    "cms_exposure",
+    "command_boundary",
+    "ssrf_boundary",
+    "file_fetch_parser",
+    "xxe_boundary",
+    "cookie_deserialization",
+    "captcha_form_state",
+    "graphql_exploit",
+    "idor_boundary",
+)
+
+DEPTH_SCAN_PROBES = (
+    "sqli_exploit",
+    "filtered_query_bypass",
+    "preg_match_subject",
+    "reflection_value_boundary",
+    "file_read_extract",
+    "jwt_exploit",
+    "werkzeug_console",
+    "dom_execution",
+    "sqli_auth_transition",
+    "ssti_deferred_context_closure",
+    "xss_filter_constraint",
+)
+
+SCAN_PROBE_CATALOG = (
+    *DISCOVERY_SCAN_PROBES,
+    *BREADTH_SCAN_PROBES,
+    *DEPTH_SCAN_PROBES,
+)
+
+SCAN_PROBE_DEPENDENCIES: dict[str, tuple[str, ...]] = {
+    "browser_boundary": ("surface_map",),
+    "captcha_form_state": ("stateful_session",),
+    "cms_exposure": ("direct_exposure",),
+    "cookie_deserialization": ("stateful_session",),
+    "csrf_session": ("stateful_session",),
+    "dom_execution": ("xss_context", "xss_filter_constraint"),
+    "file_read_extract": ("file_fetch_parser",),
+    "filtered_query_bypass": ("sqli_differential",),
+    "graphql_exploit": ("api_behavior",),
+    "idor_boundary": ("api_behavior", "stateful_session"),
+    "jwt_exploit": ("api_behavior", "stateful_session"),
+    "preg_match_subject": ("sqli_differential",),
+    "reflection_value_boundary": ("input_reflection",),
+    "sqli_auth_transition": ("sqli_exploit",),
+    "sqli_exploit": ("data_query", "sqli_differential"),
+    "ssti_deferred_context_closure": ("ssti_fingerprint",),
+    "ssti_fingerprint": ("server_rendering",),
+    "werkzeug_console": ("direct_exposure",),
+    "xss_context": ("input_reflection",),
+    "xss_filter_constraint": ("xss_context",),
+}
+
+
+class ScanPlanPhase(StrEnum):
+    """Stable breadth-before-depth execution phase."""
+
+    DISCOVERY = "discovery"
+    BREADTH = "breadth"
+    DEPTH = "depth"
+
+
+class ScanPlanStatus(StrEnum):
+    """Coverage state for one catalog probe."""
+
+    SELECTED = "selected"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class ScanPlanDecision:
+    """Immutable, reportable decision for one probe in the catalog."""
+
+    probe: str
+    phase: ScanPlanPhase
+    status: ScanPlanStatus
+    reasons: tuple[str, ...]
+    dependencies: tuple[str, ...]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "probe": self.probe,
+            "phase": self.phase.value,
+            "status": self.status.value,
+            "reasons": list(self.reasons),
+            "dependencies": list(self.dependencies),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScanPlan:
+    """Pending probes plus a complete coverage decision ledger."""
+
+    probes: tuple[str, ...]
+    decisions: tuple[ScanPlanDecision, ...]
+    evidence_facts: tuple[str, ...]
+
+    def decision_for(self, probe: str) -> ScanPlanDecision:
+        for decision in self.decisions:
+            if decision.probe == probe:
+                return decision
+        raise KeyError(probe)
+
+    def to_json(self) -> dict[str, object]:
+        counts = {
+            status.value: sum(decision.status is status for decision in self.decisions)
+            for status in ScanPlanStatus
+        }
+        return {
+            "schema": SCAN_PLAN_SCHEMA,
+            "probes": list(self.probes),
+            "evidence_facts": list(self.evidence_facts),
+            "counts": counts,
+            "decisions": [decision.to_json() for decision in self.decisions],
+        }
+
+
+_PHASE_BY_PROBE = {
+    **dict.fromkeys(DISCOVERY_SCAN_PROBES, ScanPlanPhase.DISCOVERY),
+    **dict.fromkeys(BREADTH_SCAN_PROBES, ScanPlanPhase.BREADTH),
+    **dict.fromkeys(DEPTH_SCAN_PROBES, ScanPlanPhase.DEPTH),
+}
+_CANONICAL_INDEX = {probe: index for index, probe in enumerate(SCAN_PROBE_CATALOG)}
+
+_GENERIC_INPUT_PROBES = ("input_reflection", "data_query", "sqli_differential")
+_FACT_PROBES: dict[str, tuple[str, ...]] = {
+    "command_input": ("command_boundary",),
+    "cookie_input": ("cookie_deserialization",),
+    "file_input": ("file_fetch_parser",),
+    "graphql_operation": ("graphql_exploit",),
+    "object_reference": ("idor_boundary",),
+    "template_input": ("server_rendering", "ssti_fingerprint"),
+    "url_input": ("ssrf_boundary",),
+    "xml_input": ("xxe_boundary",),
+}
+
+# A finding can route work only when both its producer and exact finding type
+# match.  Free-form state text and a finding emitted under another probe name do
+# not satisfy this trust boundary.
+_TRUSTED_FINDING_ROUTES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("api_behavior", "graphql_exposed_proof"): ("graphql_exploit",),
+    ("api_behavior", "jwt_observed"): ("jwt_exploit",),
+    ("file_fetch_parser", "file_fetch_parser_signal"): ("file_read_extract",),
+    ("file_fetch_parser", "file_read_extracted_content"): ("file_read_extract",),
+    ("file_fetch_parser", "file_read_extracted_proof"): ("file_read_extract",),
+    ("file_fetch_parser", "php_include_execution"): ("file_read_extract",),
+    ("input_reflection", "form_input_delta"): (
+        "xss_context",
+        "reflection_value_boundary",
+    ),
+    ("input_reflection", "input_delta"): (
+        "xss_context",
+        "reflection_value_boundary",
+    ),
+    ("sqli_differential", "blind_sql_injection_boolean_signal"): (
+        "sqli_exploit",
+        "filtered_query_bypass",
+    ),
+    ("sqli_differential", "blind_sql_injection_timing_signal"): (
+        "sqli_exploit",
+        "filtered_query_bypass",
+    ),
+    ("sqli_differential", "sql_injection_error_signal"): (
+        "sqli_exploit",
+        "filtered_query_bypass",
+    ),
+    ("sqli_differential", "sqli_auth_bypass_proof"): (
+        "sqli_exploit",
+        "sqli_auth_transition",
+    ),
+    ("sqli_differential", "sqli_auth_bypass_signal"): (
+        "sqli_exploit",
+        "sqli_auth_transition",
+    ),
+    ("sqli_differential", "sqli_objective_value_bypass_proof"): (
+        "sqli_exploit",
+        "filtered_query_bypass",
+    ),
+    ("sqli_differential", "sqli_objective_value_bypass_signal"): (
+        "sqli_exploit",
+        "filtered_query_bypass",
+    ),
+    ("sqli_exploit", "sqli_auth_bypass_session"): ("sqli_auth_transition",),
+    ("ssti_fingerprint", "ssti_engine_execution"): ("ssti_deferred_context_closure",),
+    ("ssti_fingerprint", "ssti_extracted_proof"): ("ssti_deferred_context_closure",),
+    ("ssti_fingerprint", "ssti_fingerprint_signal"): ("ssti_deferred_context_closure",),
+    ("xss_context", "xss_reflection_context"): (
+        "xss_filter_constraint",
+        "dom_execution",
+    ),
+    ("xss_filter_constraint", "xss_filter_constraint_proof"): ("dom_execution",),
+}
+
+_OBJECT_PARAMETER_NAMES = frozenset(
+    {
+        "account_id",
+        "customer_id",
+        "document_id",
+        "id",
+        "invoice_id",
+        "item_id",
+        "object_id",
+        "order_id",
+        "org_id",
+        "organization_id",
+        "project_id",
+        "tenant_id",
+        "user_id",
+    }
+)
+_FILE_PARAMETER_NAMES = frozenset(
+    {
+        "doc",
+        "document",
+        "file",
+        "filename",
+        "filepath",
+        "include",
+        "page",
+        "path",
+        "upload",
+    }
+)
+_URL_PARAMETER_NAMES = frozenset(
+    {
+        "callback",
+        "dest",
+        "destination",
+        "feed",
+        "next",
+        "redirect",
+        "target",
+        "uri",
+        "url",
+        "webhook",
+    }
+)
+_COMMAND_PARAMETER_NAMES = frozenset({"cmd", "command", "exec", "execute", "process", "shell"})
+_TEMPLATE_PARAMETER_NAMES = frozenset({"layout", "render", "renderer", "template", "theme", "view"})
+_COOKIE_PARAMETER_NAMES = frozenset({"cookie", "session", "session_cookie"})
+_FILE_DATA_TYPES = frozenset({"binary", "byte", "file", "path", "upload"})
+_URL_DATA_TYPES = frozenset({"uri", "url"})
+_XML_DATA_TYPES = frozenset({"soap", "xml"})
+_COMMAND_DATA_TYPES = frozenset({"command", "shell"})
+_TEMPLATE_DATA_TYPES = frozenset({"template"})
+_XML_CONTENT_TYPES = frozenset({"application/soap+xml", "application/xml", "text/xml"})
+_SIGNAL_FACTS: dict[str, str] = {
+    "command_inputs": "command_input",
+    "command_parameters": "command_input",
+    "cookies": "cookie_input",
+    "file_inputs": "file_input",
+    "file_read_inputs": "file_input",
+    "graphql_endpoints": "graphql_operation",
+    "graphql_operations": "graphql_operation",
+    "idor_candidates": "object_reference",
+    "object_ids": "object_reference",
+    "object_parameters": "object_reference",
+    "ssrf_inputs": "url_input",
+    "template_inputs": "template_input",
+    "template_parameters": "template_input",
+    "upload_inputs": "file_input",
+    "url_inputs": "url_input",
+    "url_parameters": "url_input",
+    "xml_endpoints": "xml_input",
+    "xml_inputs": "xml_input",
+}
+
+
+def build_adaptive_scan_plan(
+    state: AgentState,
+    *,
+    prior_results: Sequence[ProbeRunResult] = (),
+    catalog: Sequence[str] = SCAN_PROBE_CATALOG,
+) -> ScanPlan:
+    """Build a stable, breadth-before-depth plan without mutating inputs."""
+    if not isinstance(state, AgentState):
+        message = "state must be an AgentState"
+        raise TypeError(message)
+    normalized_catalog = _normalize_catalog(catalog)
+    results = _trusted_results(prior_results)
+    completed = frozenset(result.probe for result in results)
+    facts = _surface_facts(state)
+    reasons = _selection_reasons(facts=facts, results=results)
+    catalog_set = frozenset(normalized_catalog)
+    applicable = set(reasons) & catalog_set
+    _add_dependencies(applicable, reasons=reasons, catalog=catalog_set, completed=completed)
+    blocked = _blocked_probes(
+        applicable,
+        catalog=catalog_set,
+        completed=completed,
+        reasons=reasons,
+    )
+    pending = applicable - completed - blocked
+    probes = _dependency_ordered(pending, completed=completed)
+    return ScanPlan(
+        probes=probes,
+        decisions=_build_decisions(
+            normalized_catalog,
+            completed=completed,
+            blocked=blocked,
+            pending=pending,
+            reasons=reasons,
+        ),
+        evidence_facts=tuple(sorted(facts)),
+    )
+
+
+def _selection_reasons(
+    *,
+    facts: frozenset[str],
+    results: tuple[ProbeRunResult, ...],
+) -> dict[str, set[str]]:
+    reasons: dict[str, set[str]] = {}
+    for probe in DEFAULT_SCAN_PROBES:
+        _add_reason(reasons, probe, "required_default")
+    if "parameter" in facts:
+        for probe in _GENERIC_INPUT_PROBES:
+            _add_reason(reasons, probe, "surface:parameter")
+    for fact in sorted(facts):
+        for probe in _FACT_PROBES.get(fact, ()):
+            _add_reason(reasons, probe, f"surface:{fact}")
+    for result in results:
+        _add_result_reasons(reasons, result)
+    return reasons
+
+
+def _add_result_reasons(reasons: dict[str, set[str]], result: ProbeRunResult) -> None:
+    for finding_type in _finding_types(result):
+        route = _TRUSTED_FINDING_ROUTES.get((result.probe, finding_type), ())
+        for probe in route:
+            _add_reason(reasons, probe, f"finding:{result.probe}:{finding_type}")
+
+
+def _build_decisions(
+    catalog: Sequence[str],
+    *,
+    completed: frozenset[str],
+    blocked: set[str],
+    pending: set[str],
+    reasons: dict[str, set[str]],
+) -> tuple[ScanPlanDecision, ...]:
+    return tuple(
+        _decision_for_probe(
+            probe,
+            completed=completed,
+            blocked=blocked,
+            pending=pending,
+            reasons=reasons,
+        )
+        for probe in _ordered_catalog(catalog)
+    )
+
+
+def _decision_for_probe(
+    probe: str,
+    *,
+    completed: frozenset[str],
+    blocked: set[str],
+    pending: set[str],
+    reasons: dict[str, set[str]],
+) -> ScanPlanDecision:
+    if probe in completed:
+        status = ScanPlanStatus.COMPLETED
+        probe_reasons = set(reasons.get(probe, ())) | {"trusted_result:completed"}
+    elif probe in blocked:
+        status = ScanPlanStatus.BLOCKED
+        probe_reasons = reasons.get(probe, set())
+    elif probe in pending:
+        status = ScanPlanStatus.SELECTED
+        probe_reasons = reasons.get(probe, set())
+    else:
+        status = ScanPlanStatus.NOT_APPLICABLE
+        probe_reasons = set()
+    return ScanPlanDecision(
+        probe=probe,
+        phase=_phase_for(probe),
+        status=status,
+        reasons=tuple(sorted(probe_reasons)),
+        dependencies=SCAN_PROBE_DEPENDENCIES.get(probe, ()),
+    )
+
+
+def _normalize_catalog(catalog: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(catalog, (str, bytes)):
+        message = "catalog must be a sequence of probe names"
+        raise TypeError(message)
+    probes = tuple(str(probe).strip() for probe in catalog)
+    if any(not probe for probe in probes):
+        message = "catalog probe names cannot be empty"
+        raise ValueError(message)
+    if len(probes) != len(set(probes)):
+        message = "catalog probe names must be unique"
+        raise ValueError(message)
+    return probes
+
+
+def _trusted_results(results: Sequence[ProbeRunResult]) -> tuple[ProbeRunResult, ...]:
+    if isinstance(results, (str, bytes)):
+        message = "prior_results must contain ProbeRunResult objects"
+        raise TypeError(message)
+    trusted = tuple(results)
+    if any(not isinstance(result, ProbeRunResult) for result in trusted):
+        message = "prior_results must contain ProbeRunResult objects"
+        raise TypeError(message)
+    return trusted
+
+
+def _finding_types(result: ProbeRunResult) -> tuple[str, ...]:
+    finding_types = {
+        str(finding.get("type") or "").strip()
+        for finding in result.findings
+        if isinstance(finding, Mapping) and str(finding.get("type") or "").strip()
+    }
+    return tuple(sorted(finding_types))
+
+
+def _add_reason(reasons: dict[str, set[str]], probe: str, reason: str) -> None:
+    reasons.setdefault(probe, set()).add(reason)
+
+
+def _add_dependencies(
+    applicable: set[str],
+    *,
+    reasons: dict[str, set[str]],
+    catalog: frozenset[str],
+    completed: frozenset[str],
+) -> None:
+    pending = sorted(applicable, key=_probe_sort_key)
+    while pending:
+        probe = pending.pop(0)
+        for dependency in SCAN_PROBE_DEPENDENCIES.get(probe, ()):
+            if dependency in completed or dependency not in catalog:
+                continue
+            _add_reason(reasons, dependency, f"dependency:{probe}")
+            if dependency not in applicable:
+                applicable.add(dependency)
+                pending.append(dependency)
+                pending.sort(key=_probe_sort_key)
+
+
+def _blocked_probes(
+    applicable: set[str],
+    *,
+    catalog: frozenset[str],
+    completed: frozenset[str],
+    reasons: dict[str, set[str]],
+) -> set[str]:
+    blocked: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for probe in sorted(applicable, key=_probe_sort_key):
+            if probe in blocked or probe in completed:
+                continue
+            dependencies = SCAN_PROBE_DEPENDENCIES.get(probe, ())
+            missing = next(
+                (
+                    dependency
+                    for dependency in dependencies
+                    if dependency not in completed
+                    and (dependency not in catalog or dependency in blocked)
+                ),
+                "",
+            )
+            if not missing:
+                continue
+            blocked.add(probe)
+            _add_reason(reasons, probe, f"missing_dependency:{missing}")
+            changed = True
+    return blocked
+
+
+def _dependency_ordered(
+    pending: set[str],
+    *,
+    completed: frozenset[str],
+) -> tuple[str, ...]:
+    remaining = set(pending)
+    ordered: list[str] = []
+    satisfied = set(completed)
+    while remaining:
+        ready = [
+            probe
+            for probe in remaining
+            if all(
+                dependency in satisfied or dependency not in pending
+                for dependency in SCAN_PROBE_DEPENDENCIES.get(probe, ())
+            )
+        ]
+        if not ready:
+            unresolved = ", ".join(sorted(remaining))
+            message = f"cyclic adaptive scan probe dependencies: {unresolved}"
+            raise RuntimeError(message)
+        probe = min(ready, key=_probe_sort_key)
+        ordered.append(probe)
+        satisfied.add(probe)
+        remaining.remove(probe)
+    return tuple(ordered)
+
+
+def _ordered_catalog(catalog: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted(catalog, key=_probe_sort_key))
+
+
+def _probe_sort_key(probe: str) -> tuple[int, int, str]:
+    phase = _phase_for(probe)
+    phase_rank = {
+        ScanPlanPhase.DISCOVERY: 0,
+        ScanPlanPhase.BREADTH: 1,
+        ScanPlanPhase.DEPTH: 2,
+    }[phase]
+    return phase_rank, _CANONICAL_INDEX.get(probe, len(_CANONICAL_INDEX)), probe
+
+
+def _phase_for(probe: str) -> ScanPlanPhase:
+    return _PHASE_BY_PROBE.get(probe, ScanPlanPhase.BREADTH)
+
+
+def _surface_facts(state: AgentState) -> frozenset[str]:
+    facts: set[str] = set()
+    operations = state.surface_graph.operations or {}
+    for operation in sorted(operations.values(), key=lambda item: item.operation_id):
+        _facts_from_operation(facts, operation)
+    _facts_from_legacy_surface(facts, state.surface)
+    _facts_from_signals(facts, state.signals)
+    return frozenset(facts)
+
+
+def _facts_from_operation(facts: set[str], operation: SurfaceOperation) -> None:
+    if operation.parameters:
+        facts.add("parameter")
+    if (
+        operation.selector.startswith(("Query.", "Mutation.", "Subscription."))
+        or "graphql" in operation.provenance
+        or "graphql" in operation.hints
+    ):
+        facts.add("graphql_operation")
+    if "{" in operation.route_shape:
+        facts.add("object_reference")
+    _facts_from_metadata(
+        facts,
+        content_types=operation.content_types,
+        hints=operation.hints,
+    )
+    for parameter in operation.parameters:
+        _facts_from_parameter(facts, parameter)
+
+
+def _facts_from_parameter(facts: set[str], parameter: SurfaceParameter) -> None:
+    name = parameter.name.casefold()
+    data_type = parameter.data_type.casefold()
+    if parameter.location == "graphql":
+        facts.add("graphql_operation")
+    if parameter.location == "cookie" or name in _COOKIE_PARAMETER_NAMES:
+        facts.add("cookie_input")
+    if parameter.location == "path" or name in _OBJECT_PARAMETER_NAMES:
+        facts.add("object_reference")
+    if name in _FILE_PARAMETER_NAMES or data_type in _FILE_DATA_TYPES:
+        facts.add("file_input")
+    if name in _URL_PARAMETER_NAMES or data_type in _URL_DATA_TYPES:
+        facts.add("url_input")
+    if name in _COMMAND_PARAMETER_NAMES or data_type in _COMMAND_DATA_TYPES:
+        facts.add("command_input")
+    if name in _TEMPLATE_PARAMETER_NAMES or data_type in _TEMPLATE_DATA_TYPES:
+        facts.add("template_input")
+    if data_type in _XML_DATA_TYPES:
+        facts.add("xml_input")
+
+
+def _facts_from_metadata(
+    facts: set[str],
+    *,
+    content_types: Sequence[str] = (),
+    hints: Sequence[str] = (),
+) -> None:
+    normalized_content_types = {
+        str(value).split(";", 1)[0].strip().casefold() for value in content_types
+    }
+    normalized_hints = {str(value).strip().casefold() for value in hints}
+    if normalized_content_types & _XML_CONTENT_TYPES or normalized_hints & {"soap", "xml"}:
+        facts.add("xml_input")
+    if "graphql" in normalized_hints:
+        facts.add("graphql_operation")
+    if normalized_hints & {"command", "exec", "shell"}:
+        facts.add("command_input")
+    if normalized_hints & {"file", "include", "upload"}:
+        facts.add("file_input")
+    if normalized_hints & {"render", "template", "view"}:
+        facts.add("template_input")
+    if normalized_hints & {"callback", "ssrf", "url", "webhook"}:
+        facts.add("url_input")
+
+
+def _facts_from_legacy_surface(facts: set[str], surface: Mapping[str, object]) -> None:
+    _facts_from_legacy_parameters(facts, surface.get("parameters"))
+    _facts_from_legacy_templates(facts, surface.get("request_templates"))
+    _facts_from_legacy_endpoints(facts, surface.get("endpoints"))
+    _facts_from_legacy_forms(facts, surface.get("forms"))
+
+
+def _facts_from_legacy_parameters(facts: set[str], value: object) -> None:
+    for raw_parameter in _mapping_items(value):
+        name = str(raw_parameter.get("name") or "").strip()
+        locations = _string_items(raw_parameter.get("sources"))
+        locations += _string_items(raw_parameter.get("location"))
+        data_types = _string_items(raw_parameter.get("data_types"))
+        data_types += _string_items(raw_parameter.get("data_type"))
+        if name:
+            facts.add("parameter")
+            _facts_from_parameter(
+                facts,
+                SurfaceParameter.create(
+                    name=name,
+                    location=_legacy_parameter_location(locations),
+                    data_type=data_types[0] if data_types else "unknown",
+                ),
+            )
+
+
+def _facts_from_legacy_templates(facts: set[str], value: object) -> None:
+    for template in _mapping_items(value):
+        fields = template.get("fields")
+        if isinstance(fields, Mapping) and fields:
+            facts.add("parameter")
+        selector = str(template.get("selector") or "")
+        if selector.startswith(("Query.", "Mutation.", "Subscription.")):
+            facts.add("graphql_operation")
+        _facts_from_metadata(
+            facts,
+            content_types=_string_items(template.get("content_types")),
+            hints=_string_items(template.get("hints")),
+        )
+
+
+def _facts_from_legacy_endpoints(facts: set[str], value: object) -> None:
+    for endpoint in _mapping_items(value):
+        if "{" in str(endpoint.get("url") or ""):
+            facts.add("object_reference")
+        _facts_from_metadata(
+            facts,
+            content_types=_string_items(endpoint.get("content_types")),
+            hints=_string_items(endpoint.get("hints")),
+        )
+
+
+def _facts_from_legacy_forms(facts: set[str], value: object) -> None:
+    for form in _mapping_items(value):
+        for raw_input in _mapping_items(form.get("inputs")):
+            name = str(raw_input.get("name") or "").strip()
+            if not name:
+                continue
+            facts.add("parameter")
+            input_type = str(raw_input.get("type") or "unknown")
+            _facts_from_parameter(
+                facts,
+                SurfaceParameter.create(
+                    name=name,
+                    location="form",
+                    data_type=input_type,
+                ),
+            )
+        _facts_from_metadata(
+            facts,
+            content_types=_string_items(form.get("enctype")),
+        )
+
+
+def _facts_from_signals(facts: set[str], signals: Mapping[str, Sequence[str]]) -> None:
+    for key in sorted(signals):
+        values = signals.get(key)
+        if not values:
+            continue
+        normalized_key = str(key).strip().casefold()
+        if normalized_key in {"forms", "parameters", "request_templates"}:
+            facts.add("parameter")
+        fact = _SIGNAL_FACTS.get(normalized_key)
+        if fact:
+            facts.add(fact)
+
+
+def _mapping_items(value: object, *, limit: int = 512) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(item for item in value[:limit] if isinstance(item, Mapping))
+
+
+def _string_items(value: object, *, limit: int = 64) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if not isinstance(value, Sequence) or isinstance(value, bytes):
+        return []
+    return [str(item) for item in value[:limit] if str(item).strip()]
+
+
+def _legacy_parameter_location(values: Sequence[str]) -> str:
+    for value in values:
+        normalized = value.rsplit(":", 1)[-1].strip().casefold()
+        if normalized in {"body", "cookie", "form", "graphql", "header", "path", "query"}:
+            return normalized
+    return "unknown"
+
+
+__all__ = [
+    "BREADTH_SCAN_PROBES",
+    "DEFAULT_SCAN_PROBES",
+    "DEPTH_SCAN_PROBES",
+    "DISCOVERY_SCAN_PROBES",
+    "SCAN_PLAN_SCHEMA",
+    "SCAN_PROBE_CATALOG",
+    "SCAN_PROBE_DEPENDENCIES",
+    "ScanPlan",
+    "ScanPlanDecision",
+    "ScanPlanPhase",
+    "ScanPlanStatus",
+    "build_adaptive_scan_plan",
+]

--- a/packages/ravage/src/ravage/scan_planner.py
+++ b/packages/ravage/src/ravage/scan_planner.py
@@ -566,6 +566,8 @@ def _surface_facts(state: AgentState) -> frozenset[str]:
     facts: set[str] = set()
     operations = state.surface_graph.operations or {}
     for operation in sorted(operations.values(), key=lambda item: item.operation_id):
+        if not operation.actionable:
+            continue
         _facts_from_operation(facts, operation)
     _facts_from_legacy_surface(facts, state.surface)
     _facts_from_signals(facts, state.signals)

--- a/packages/ravage/tests/test_adaptive_scan_cli.py
+++ b/packages/ravage/tests/test_adaptive_scan_cli.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ravage import __main__ as cli
+from ravage.probe_suite_parts.result import ProbeRunResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _write_brief(path: Path) -> None:
+    path.write_text(
+        """engagement_id: 11111111-1111-4111-8111-111111111111
+scope:
+  in_scope:
+    - http://127.0.0.1:4321/
+  out_of_scope: []
+roe:
+  max_rps: 5
+  no_destructive_actions: true
+objectives:
+  - web_application_assessment
+budget:
+  max_cost_usd: 1.0
+  max_runtime_min: 5
+context:
+  description: adaptive scan CLI fixture
+""",
+        encoding="utf-8",
+    )
+
+
+class _ReconResult:
+    def to_json(self) -> dict[str, object]:
+        return {
+            "target_url": "http://127.0.0.1:4321/",
+            "origin": "http://127.0.0.1:4321",
+            "pages": [
+                {
+                    "url": "http://127.0.0.1:4321/",
+                    "status": 200,
+                    "final_url": "http://127.0.0.1:4321/",
+                    "headers": {"Content-Type": "text/html"},
+                    "links": ["/fetch"],
+                    "scripts": [],
+                    "forms": [
+                        {
+                            "method": "POST",
+                            "action": "http://127.0.0.1:4321/fetch",
+                            "enctype": "application/x-www-form-urlencoded",
+                            "inputs": [
+                                {
+                                    "name": "callback",
+                                    "type": "url",
+                                    "value": "",
+                                    "required": False,
+                                    "disabled": False,
+                                }
+                            ],
+                        }
+                    ],
+                    "request_templates": [],
+                    "query_parameter_names": [],
+                    "interesting_markers": [],
+                    "reflected_parameters": [],
+                    "error": "",
+                }
+            ],
+            "query_parameter_names": [],
+            "interesting_markers": [],
+            "errors": [],
+            "http_request_count": 1,
+        }
+
+
+def test_default_scan_replans_breadth_then_trusted_depth_and_writes_coverage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "run"
+    _write_brief(brief)
+    executed: list[str] = []
+
+    def run_probe(probe: str, **_kwargs: object) -> ProbeRunResult:
+        executed.append(probe)
+        findings = [{"type": "sql_injection_error_signal"}] if probe == "sqli_differential" else []
+        return ProbeRunResult(
+            ok=bool(findings),
+            probe=probe,
+            summary="typed finding" if findings else "completed without a finding",
+            findings=findings,
+        )
+
+    monkeypatch.setattr(cli, "run_recon", lambda *_args, **_kwargs: _ReconResult())
+    monkeypatch.setattr(cli, "run_builtin_probe", run_probe)
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--run-dir",
+            str(run_dir),
+            "--json",
+        ]
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    coverage = json.loads((run_dir / "scan-coverage.json").read_text(encoding="utf-8"))
+    assert summary["planner_mode"] == "adaptive"
+    assert summary["probes_executed"] == executed
+    assert len(executed) == len(set(executed))
+    assert "ssrf_boundary" in executed
+    assert "data_query" in executed
+    assert "sqli_differential" in executed
+    assert "sqli_exploit" in executed
+    assert "filtered_query_bypass" in executed
+    assert executed.index("data_query") < executed.index("sqli_exploit")
+    assert executed.index("sqli_differential") < executed.index("sqli_exploit")
+    assert executed.index("sqli_differential") < executed.index("filtered_query_bypass")
+    assert coverage["status"] == "complete"
+    assert coverage["completion_basis"] == "planner_frontier_exhausted"
+    assert coverage["limitations"] == []
+    encoded_coverage = json.dumps(coverage).lower()
+    assert "no vulnerabilities" not in encoded_coverage
+    assert "application_exhausted" not in encoded_coverage
+    assert "family_exhausted" not in encoded_coverage
+
+
+def test_explicit_probe_order_and_duplicates_do_not_invoke_adaptive_recon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "run"
+    _write_brief(brief)
+    executed: list[str] = []
+
+    def reject_recon(*_args: object, **_kwargs: object) -> object:
+        message = "explicit scans must not invoke adaptive recon"
+        raise AssertionError(message)
+
+    def run_probe(probe: str, **_kwargs: object) -> ProbeRunResult:
+        executed.append(probe)
+        return ProbeRunResult(ok=True, probe=probe, summary="completed")
+
+    monkeypatch.setattr(cli, "run_recon", reject_recon)
+    monkeypatch.setattr(cli, "run_builtin_probe", run_probe)
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "surface_map",
+            "--probe",
+            "secret_sweep",
+            "--probe",
+            "surface_map",
+            "--run-dir",
+            str(run_dir),
+            "--json",
+        ]
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    coverage = json.loads((run_dir / "scan-coverage.json").read_text(encoding="utf-8"))
+    assert executed == ["surface_map", "secret_sweep", "surface_map"]
+    assert summary["planner_mode"] == "explicit"
+    assert [record["probe_id"] for record in coverage["probes"]] == [
+        "surface_map",
+        "secret_sweep",
+        "surface_map.2",
+    ]
+
+
+def test_opaque_explicit_probe_produces_an_honest_partial_certificate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "run"
+    _write_brief(brief)
+    monkeypatch.setattr(
+        cli,
+        "run_builtin_probe",
+        lambda probe, **_kwargs: ProbeRunResult(ok=True, probe=probe, summary="rendered"),
+    )
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "dom_execution",
+            "--run-dir",
+            str(run_dir),
+            "--json",
+        ]
+    )
+
+    capsys.readouterr()
+    coverage = json.loads((run_dir / "scan-coverage.json").read_text(encoding="utf-8"))
+    assert coverage["status"] == "partial"
+    assert coverage["traffic"]["accounting_status"] == "lower_bound"
+    assert "traffic_accounting_lower_bound" in coverage["limitations"]
+    assert "unmetered_actions" in coverage["limitations"]
+    assert coverage["probes"][0]["request_accounting_status"] == "lower_bound"

--- a/packages/ravage/tests/test_authenticated_scan_cli.py
+++ b/packages/ravage/tests/test_authenticated_scan_cli.py
@@ -11,6 +11,7 @@ from ravage import __main__ as cli
 from ravage.auth import SecretValue
 from ravage.probe_suite_parts.result import ProbeRunResult
 from ravage.run_data.brief import load_engagement_brief
+from ravage.traffic.policy import TrafficPolicyConfig, TrafficPolicyController
 from ravage.web_core.http_probe import ProbeResponse, ProbeSession
 
 _TARGET_URL = "http://127.0.0.1:18742/"
@@ -409,17 +410,27 @@ def test_configured_scan_snapshots_unique_secrets_and_classifies_traffic_values(
     monkeypatch.setattr(cli, "ProbeTrafficRecorder", CapturingRecorder)
     monkeypatch.setattr(ProbeSession, "request", request)
 
+    traffic_policy = TrafficPolicyController.open(
+        tmp_path / "traffic-policy.json",
+        target_url=_TARGET_URL,
+        config=TrafficPolicyConfig(),
+    )
     owner, redactor = cli._configured_scan_session(
         brief=brief,
         target_url=_TARGET_URL,
         identity="admin",
         timeout_seconds=5,
         allow_remote_target=False,
+        traffic_policy=traffic_policy,
         secret_resolver=CountingResolver(),
         traffic_store=object(),  # type: ignore[arg-type]
         traffic_capture_session_id="scan-auth-test",
     )
     try:
+        assert owner.traffic_policy is traffic_policy
+        managed_probe_session = owner.session_for_probe(timeout_seconds=5)
+        assert managed_probe_session.traffic_policy is traffic_policy
+        owner.retire_probe_session(managed_probe_session)
         assert Counter(resolver_calls) == Counter({"ADMIN_USER": 1, "ADMIN_PASSWORD": 1})
         [recorder] = recorders
         assert recorder.known == ()  # type: ignore[attr-defined]

--- a/packages/ravage/tests/test_cli_plumbing.py
+++ b/packages/ravage/tests/test_cli_plumbing.py
@@ -19,6 +19,7 @@ from ravage.agent_core.agent_state import AgentState, save_agent_state
 from ravage.agent_core.autonomous_graph.operational_profile import (
     GraphOperationalProfileName,
 )
+from ravage.probe_suite_parts.result import ProbeRunResult
 from ravage.setup_checks import SetupDiagnostic
 from ravage.traffic import TrafficPolicyConfig, TrafficPolicyController
 
@@ -1285,15 +1286,12 @@ def test_cli_scan_runs_explicitly_authorized_remote_target(
     )
     seen: dict[str, object] = {}
 
-    def fake_probe(_probe: str, **kwargs: object) -> SimpleNamespace:
+    def fake_probe(probe: str, **kwargs: object) -> ProbeRunResult:
         seen.update(kwargs)
-        return SimpleNamespace(
+        return ProbeRunResult(
             ok=True,
+            probe=probe,
             summary="scoped remote probe",
-            findings=[],
-            requests=[],
-            errors=[],
-            to_text=lambda: "{}",
         )
 
     monkeypatch.setattr(cli, "run_builtin_probe", fake_probe)

--- a/packages/ravage/tests/test_idor_signal_quality.py
+++ b/packages/ravage/tests/test_idor_signal_quality.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pytest
+from ravage.agent_core.agent_state import AgentState
+from ravage.probes.specialists.idor_signals import _idor_access_signal
+from ravage.probes.specialists.idor_targets import _idor_targets
+from ravage.web_core.http_probe import ProbeResponse
+
+
+def _response(
+    body: str,
+    *,
+    status: int = 200,
+    headers: dict[str, str] | None = None,
+) -> ProbeResponse:
+    return ProbeResponse(
+        method="GET",
+        url="http://127.0.0.1/resource",
+        status=status,
+        final_url="http://127.0.0.1/resource",
+        elapsed_ms=5,
+        body=body,
+        headers=headers or {},
+    )
+
+
+@pytest.mark.parametrize(
+    ("baseline_body", "response_body"),
+    [
+        ('{"results":["apple"]}', '{"results":["admin"]}'),
+        ("<p>Search: apple</p>", "<p>Search: admin</p>"),
+    ],
+)
+def test_idor_signal_rejects_pure_identifier_reflection(
+    baseline_body: str,
+    response_body: str,
+) -> None:
+    signal = _idor_access_signal(
+        baseline=_response(baseline_body),
+        response=_response(response_body),
+        original_id="apple",
+        candidate_id="admin",
+    )
+
+    assert signal == {}
+
+
+def test_idor_signal_keeps_meaningful_object_delta() -> None:
+    signal = _idor_access_signal(
+        baseline=_response('{"id":"10","owner":"alice","data":"mine"}'),
+        response=_response('{"id":"9","owner":"bob","data":"private"}'),
+        original_id="10",
+        candidate_id="9",
+    )
+
+    assert signal["kind"] == "object_access_delta"
+
+
+def test_idor_signal_keeps_proof_from_other_object() -> None:
+    signal = _idor_access_signal(
+        baseline=_response('{"id":"10"}'),
+        response=_response('{"id":"9","proof":"flag{other_object}"}'),
+        original_id="10",
+        candidate_id="9",
+    )
+
+    assert signal["kind"] == "proof_or_secret"
+
+
+def test_idor_signal_keeps_cookie_identity_delta() -> None:
+    signal = _idor_access_signal(
+        baseline=_response(
+            '{"id":"10"}',
+            status=302,
+            headers={"Set-Cookie": "session=owner-10; Path=/"},
+        ),
+        response=_response(
+            '{"id":"9"}',
+            status=302,
+            headers={"Set-Cookie": "session=owner-9; Path=/"},
+        ),
+        original_id="10",
+        candidate_id="9",
+    )
+
+    assert signal["kind"] == "auth_cookie_identity_delta"
+
+
+def test_idor_targets_require_context_for_username_like_values() -> None:
+    state = AgentState()
+    state.surface = {
+        "target_url": "http://127.0.0.1/search?q=apple",
+        "origin": "http://127.0.0.1",
+        "parameters": [
+            {
+                "name": "q",
+                "locations": ["http://127.0.0.1/search?q=apple"],
+                "value": "apple",
+            },
+            {
+                "name": "q",
+                "locations": ["http://127.0.0.1/search?q=42"],
+                "value": "42",
+            },
+            {
+                "name": "user_id",
+                "locations": ["http://127.0.0.1/profile?user_id=alice"],
+                "value": "alice",
+            },
+            {
+                "name": "account",
+                "locations": ["http://127.0.0.1/settings?account=primary"],
+                "value": "primary",
+            },
+        ],
+        "forms": [
+            {
+                "action": "http://127.0.0.1/search",
+                "method": "GET",
+                "inputs": [{"name": "q", "type": "text", "value": "apple"}],
+            }
+        ],
+        "endpoints": [
+            {"url": "http://127.0.0.1/search?q=apple"},
+            {"url": "http://127.0.0.1/search?q=42"},
+            {"url": "http://127.0.0.1/profile?user_id=alice"},
+            {"url": "http://127.0.0.1/settings?account=primary"},
+        ],
+    }
+
+    targets = _idor_targets(state)
+    target_keys = {
+        (str(target.get("input")), str(target.get("baseline_id"))) for target in targets
+    }
+
+    assert ("q", "apple") not in target_keys
+    assert ("q", "42") in target_keys
+    assert ("user_id", "alice") in target_keys
+    assert ("account", "primary") in target_keys

--- a/packages/ravage/tests/test_outcome_evidence.py
+++ b/packages/ravage/tests/test_outcome_evidence.py
@@ -1544,7 +1544,8 @@ def test_full_probe_payload_feeds_identity_aware_graph_before_clipping(
     assert operation.method == "GET"
     assert operation.route_shape == "/api/users/{int}"
     assert operation.provenance == ("probe",)
-    assert {(item.name, item.location) for item in operation.parameters} == {("expand", "query")}
+    assert operation.actionable is False
+    assert operation.parameters == ()
     [observation] = list((state.surface_graph.observations or {}).values())
     assert observation.identity_alias == "alice"
     assert observation.source_kind == "probe"
@@ -1556,7 +1557,7 @@ def test_full_probe_payload_feeds_identity_aware_graph_before_clipping(
 
     projected = json.dumps(state.surface, sort_keys=True)
     serialized_graph = json.dumps(state.surface_graph.to_json(), sort_keys=True)
-    assert "http://127.0.0.1:8765/api/users/{int}" in projected
+    assert "http://127.0.0.1:8765/api/users/{int}" not in projected
     assert observed_value not in projected
     assert observed_value not in serialized_graph
 

--- a/packages/ravage/tests/test_outcome_evidence.py
+++ b/packages/ravage/tests/test_outcome_evidence.py
@@ -267,6 +267,80 @@ def test_distinct_affected_parameters_survive_outcome_and_report_deduplication(
     } == {"alpha", "beta"}
 
 
+def test_affected_parameter_identity_ignores_unrelated_endpoint_parameters() -> None:
+    probe = "sqli_differential"
+    expected_count = 2
+    findings = [
+        {
+            "type": "sql_injection_error_signal",
+            "markers": ["database syntax error"],
+            "delta": {"new_error_markers": ["database"]},
+            "replay": {
+                "method": "GET",
+                "url": url,
+                "payload_field": "q",
+            },
+            "baseline_replay": {
+                "method": "GET",
+                "url": "http://127.0.0.1:8765/lookup?q=plain",
+                "payload_field": "q",
+            },
+            "response": {
+                "method": "GET",
+                "url": "http://127.0.0.1:8765/lookup",
+                "status": 500,
+                "body_sha_hint": "database-error",
+            },
+        }
+        for url in (
+            "http://127.0.0.1:8765/lookup?q=test",
+            "http://127.0.0.1:8765/lookup?q=test&submit=Search",
+        )
+    ]
+    qualified = qualify_probe_findings(
+        probe=probe,
+        probe_text=json.dumps(
+            {
+                "probe": probe,
+                "ok": True,
+                "findings": findings,
+                "requests": [],
+                "errors": [],
+            }
+        ),
+        target_url="http://127.0.0.1:8765/",
+    )
+
+    assert len(qualified) == expected_count
+    first, second = qualified
+    assert first.endpoint != second.endpoint
+    assert first.finding_id(_ENGAGEMENT_ID) == second.finding_id(_ENGAGEMENT_ID)
+    assert first.evidence_id(_ENGAGEMENT_ID) == second.evidence_id(_ENGAGEMENT_ID)
+    assert first.evidence_id(_ENGAGEMENT_ID) == replace(
+        second,
+        probe="alternate_detector",
+    ).evidence_id(_ENGAGEMENT_ID)
+
+    first_without_affected = replace(
+        first,
+        request={key: value for key, value in first.request.items() if key != "affected_parameter"},
+    )
+    second_without_affected = replace(
+        second,
+        request={
+            key: value
+            for key, value in second.request.items()
+            if key != "affected_parameter"
+        },
+    )
+    assert first_without_affected.finding_id(
+        _ENGAGEMENT_ID
+    ) != second_without_affected.finding_id(_ENGAGEMENT_ID)
+    assert first_without_affected.evidence_id(
+        _ENGAGEMENT_ID
+    ) != second_without_affected.evidence_id(_ENGAGEMENT_ID)
+
+
 def test_unknown_signals_are_retained_but_cannot_self_promote() -> None:
     unknown = json.dumps(
         {

--- a/packages/ravage/tests/test_probe_actions.py
+++ b/packages/ravage/tests/test_probe_actions.py
@@ -18,9 +18,12 @@ from ravage.agent_core.surface_graph_ingest import (
     SURFACE_OBSERVATION_INPUT_SCHEMA,
 )
 from ravage.probe_suite import available_probes
+from ravage.probe_suite_parts.sqli.sqli_targets import _sqli_targets
+from ravage.probe_suite_parts.support import _form_targets
 from ravage.run_data.audit import AuditStore
 from ravage.run_data.workspace import AgentWorkspace
 from ravage.runtime import ToolResult, ToolRuntime
+from ravage.scan_planner import build_adaptive_scan_plan
 from ravage.web_core.http_probe import ProbeResponse
 from ravage.web_core.poc_validator import validate_http_poc
 
@@ -130,6 +133,107 @@ def test_executor_owned_probe_batch_feeds_canonical_surface_graph(
     [observation] = (state.surface_graph.observations or {}).values()
     assert observation.identity_alias == "anonymous"
     assert "not-persisted" not in json.dumps(state.surface_graph.to_json())
+
+
+def test_browser_attack_traffic_cannot_fabricate_future_forms_or_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_url = "http://127.0.0.1/"
+    attack_url = f"{target_url}fabricated-login?username=attack&password=attack"
+    fabricated_form = (
+        '<form action="/fabricated-login" method="post">'
+        '<input name="username"><input name="password"></form>'
+    )
+    probe_text = json.dumps(
+        {
+            "ok": True,
+            "probe": "browser_boundary",
+            "summary": "attack response contained target-controlled markup",
+            "findings": [
+                {
+                    "type": "clickjacking_frame_policy_missing",
+                    "url": attack_url,
+                    "body_snippet": fabricated_form,
+                }
+            ],
+            "requests": [
+                {
+                    "method": "POST",
+                    "url": attack_url,
+                    "status": 200,
+                    "body_snippet": fabricated_form,
+                    "request_headers": {"X-Ravage-Probe": "attack"},
+                    "probe_kind": "browser_boundary_attack",
+                },
+                {
+                    "method": "GET",
+                    "url": f"{target_url}fabricated-admin?tenant=attack",
+                    "status": 403,
+                    "body_snippet": "access denied",
+                    "probe_kind": "browser_boundary_attack",
+                },
+            ],
+            "errors": [],
+        }
+    )
+
+    def runner(*args: object, **kwargs: object) -> _CompletedProbeRunner:
+        del args, kwargs
+        return _CompletedProbeRunner(
+            json.dumps({"status": "ok", "ok": True, "text": probe_text})
+        )
+
+    _patch_probe_runner(monkeypatch, runner)
+    state = AgentState(
+        surface={"target_url": target_url, "origin": target_url.rstrip("/")},
+        surface_graph=SurfaceGraphState.for_target(target_url),
+    )
+    targets_before = _sqli_targets(state)
+    plan_before = build_adaptive_scan_plan(state).probes
+    audit = AuditStore(tmp_path / "audit.db")
+    try:
+        execute_action(
+            {"action": "run_probe", "probe": "browser_boundary"},
+            target_url=target_url,
+            runtime=_ProofRuntime(),
+            state=state,
+            workspace=AgentWorkspace.open(tmp_path / "workspace"),
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=2_000,
+            max_transcript_chars=8_000,
+        )
+    finally:
+        audit.close()
+
+    attempts = tuple((state.surface_graph.operations or {}).values())
+    assert {attempt.route_shape for attempt in attempts} == {
+        "/fabricated-admin",
+        "/fabricated-login",
+    }
+    assert all(attempt.provenance == ("probe",) for attempt in attempts)
+    assert all(attempt.actionable is False for attempt in attempts)
+    assert all(attempt.parameters == () for attempt in attempts)
+    assert len(state.surface_graph.observations or {}) == 2
+    prompt_graph = state.surface_graph.to_prompt_json()
+    assert prompt_graph["operations"] == []
+    assert prompt_graph["counts"] == {
+        "operations": 2,
+        "candidate_operations": 0,
+        "identity_observations": 2,
+    }
+    assert state.surface.get("endpoints") == []
+    assert state.surface.get("request_templates") == []
+    assert state.surface.get("parameters") == []
+    assert _form_targets(state, limit=10) == []
+    assert _sqli_targets(state) == targets_before
+    plan_after = build_adaptive_scan_plan(state)
+    assert plan_after.probes == plan_before
+    assert "parameter" not in plan_after.evidence_facts
+    for key in ("forms", "endpoints", "parameters", "request_templates"):
+        assert not state.signals.get(key)
 
 
 def test_validate_http_poc_replays_same_origin_expectations(

--- a/packages/ravage/tests/test_report_generation.py
+++ b/packages/ravage/tests/test_report_generation.py
@@ -17,6 +17,13 @@ from ravage.report import ProFeatureRequiredError, write_pentest_report
 from ravage.report_artifact import write_json_report_artifact
 from ravage.run_data.audit import AuditStore
 from ravage.run_data.workspace import AgentWorkspace
+from ravage.scan_coverage import (
+    PlannerProbeDecision,
+    ProbeCoverageOutcome,
+    ProbeDisposition,
+    ScanCoverageRecorder,
+    write_scan_coverage_certificate,
+)
 from ravage.traffic.contracts import build_captured_http_exchange
 from ravage.traffic.manifest import TrafficRunManifest, write_traffic_manifest
 from ravage.traffic.policy import (
@@ -108,9 +115,7 @@ def test_json_report_artifact_redacts_late_metadata_and_preserves_existing_repor
     brief_path = _brief(tmp_path)
     workspace = _workspace_with_report_events(tmp_path)
     secret_path_component = "token=artifact-secret-value"  # noqa: S105 - redaction fixture.
-    secret_termination_reason = (  # noqa: S105 - redaction fixture.
-        "token=termination-secret-value"
-    )
+    secret_termination_reason = "token=termination-secret-value"  # noqa: S105 - redaction fixture.
     output_path = tmp_path / secret_path_component / "report.json"
     markdown_path = tmp_path / "human-report.md"
     markdown_path.write_text("# Existing human report\n", encoding="utf-8")
@@ -203,6 +208,59 @@ def test_write_pentest_report_generates_redacted_markdown_and_json(tmp_path: Pat
     assert "flag{unit_report_secret}" not in markdown
     assert "sk-ABCDEF1234567890ABCDEF" not in markdown
     assert "api_key=<SECRET_REDACTED>" in markdown
+
+
+def test_report_includes_path_free_scan_coverage_without_overclaiming(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    traffic_policy = TrafficPolicyController.open(
+        workspace.root / "traffic-policy.json",
+        target_url="http://127.0.0.1:8765",
+        config=TrafficPolicyConfig(),
+    )
+    recorder = ScanCoverageRecorder()
+    private_surface = "http://127.0.0.1:8765/private/admin?token=secret"
+    recorder.record_planner_decision(
+        PlannerProbeDecision(
+            probe_id="surface_map",
+            family="discovery",
+            rank=0,
+            surface_key=private_surface,
+            reason_codes=("required_default",),
+        )
+    )
+    recorder.record_probe_outcome(
+        ProbeCoverageOutcome(
+            probe_id="surface_map",
+            disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+        )
+    )
+    write_scan_coverage_certificate(
+        workspace.root.parent / "scan-coverage.json",
+        recorder.finalize(
+            planner_frontier_exhausted=True,
+            traffic_snapshot=traffic_policy.snapshot(),
+            traffic_config=traffic_policy.config,
+        ),
+    )
+
+    output_path = workspace.root.parent / "coverage-report.md"
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    markdown = output_path.read_text(encoding="utf-8")
+    assert report["scan_coverage"]["status"] == "complete"
+    assert report["scan_coverage"]["completion_basis"] == "planner_frontier_exhausted"
+    assert "## Deterministic Scan Coverage" in markdown
+    assert "does not claim that the application" in markdown
+    assert private_surface not in json.dumps(report)
+    assert private_surface not in markdown
 
 
 def test_report_summarizes_deterministic_scan_work_recon_and_recorded_traffic(

--- a/packages/ravage/tests/test_scan_coverage.py
+++ b/packages/ravage/tests/test_scan_coverage.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+from ravage.scan_coverage import (
+    MAX_CERTIFICATE_BYTES,
+    PlannerProbeDecision,
+    ProbeCoverageOutcome,
+    ProbeDisposition,
+    RequestAccountingStatus,
+    ScanCoverageError,
+    ScanCoverageRecorder,
+    ScanCoverageStatus,
+    write_scan_coverage_certificate,
+)
+from ravage.traffic.policy import (
+    TrafficPolicyConfig,
+    TrafficPolicyMode,
+    TrafficPolicySnapshot,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PRIVATE_FILE_MODE = 0o600
+
+
+def _snapshot(**changes: int | str) -> TrafficPolicySnapshot:
+    snapshot = TrafficPolicySnapshot(
+        physical_request_count=3,
+        completed_request_count=3,
+        incomplete_request_count=0,
+        pending_dispatch_count=0,
+        reservation_count=0,
+        cache_hit_count=0,
+        deduplicated_count=0,
+        retry_count=0,
+        blocked_count=0,
+        circuit_open_count=0,
+        unmetered_action_count=0,
+        accounting_status="exact",
+    )
+    return replace(snapshot, **changes)
+
+
+def _config() -> TrafficPolicyConfig:
+    return TrafficPolicyConfig(
+        mode=TrafficPolicyMode.ENFORCE,
+        max_rps=0.5,
+        max_physical_requests=20,
+        cache_enabled=True,
+        deduplicate=True,
+    )
+
+
+def _complete_recorder() -> ScanCoverageRecorder:
+    recorder = ScanCoverageRecorder()
+    recorder.record_planner_decision(
+        PlannerProbeDecision(
+            probe_id="surface_map",
+            family="recon",
+            rank=0,
+            surface_key="http://127.0.0.1/private/path?q=secret",
+            reason_codes=("broad_first",),
+        )
+    )
+    recorder.record_probe_outcome(
+        ProbeCoverageOutcome(
+            probe_id="surface_map",
+            disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+            physical_request_count=3,
+        )
+    )
+    return recorder
+
+
+def test_exact_finite_plan_produces_versioned_complete_certificate() -> None:
+    recorder = _complete_recorder()
+    recorder.record_planner_decision(
+        PlannerProbeDecision(
+            probe_id="sqli_differential",
+            family="injection",
+            rank=1,
+            reason_codes=("observed_query_input",),
+        )
+    )
+    recorder.record_probe_outcome(
+        ProbeCoverageOutcome(
+            probe_id="sqli_differential",
+            disposition=ProbeDisposition.COMPLETED_FINDING,
+            finding_count=2,
+        )
+    )
+    recorder.record_planner_decision(
+        PlannerProbeDecision(
+            probe_id="graphql_schema",
+            family="graphql",
+            rank=2,
+            terminal_disposition=ProbeDisposition.NOT_APPLICABLE,
+            reason_codes=("surface_absent",),
+        )
+    )
+
+    certificate = recorder.finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(),
+        traffic_config=_config(),
+    )
+    payload = certificate.to_json()
+
+    assert certificate.status is ScanCoverageStatus.COMPLETE
+    assert payload["schema"] == "ravage.scan-coverage"
+    assert payload["version"] == 1
+    assert payload["completion_basis"] == "planner_frontier_exhausted"
+    assert payload["limitations"] == []
+    assert payload["summary"] == {
+        "completed_probe_count": 2,
+        "disposition_counts": {
+            "blocked_budget": 0,
+            "completed_finding": 1,
+            "completed_no_finding": 1,
+            "not_applicable": 1,
+            "transport_incomplete": 0,
+            "unsupported": 0,
+        },
+        "finding_count": 2,
+        "planner_decision_count": 3,
+    }
+    graphql = certificate.probes[2].to_json()
+    assert graphql["request_accounting_status"] == "exact"
+    assert graphql["physical_request_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("disposition", "expected_limitation"),
+    [
+        (ProbeDisposition.UNSUPPORTED, "unsupported_probe"),
+        (ProbeDisposition.BLOCKED_BUDGET, "budget_blocked"),
+        (ProbeDisposition.TRANSPORT_INCOMPLETE, "transport_incomplete"),
+    ],
+)
+def test_incomplete_dispositions_force_partial_status(
+    disposition: ProbeDisposition,
+    expected_limitation: str,
+) -> None:
+    recorder = _complete_recorder()
+    recorder.record_planner_decision(
+        PlannerProbeDecision(probe_id="candidate_probe", family="candidate", rank=1)
+    )
+    recorder.record_probe_outcome(
+        ProbeCoverageOutcome(probe_id="candidate_probe", disposition=disposition)
+    )
+
+    certificate = recorder.finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert expected_limitation in certificate.limitations
+
+
+@pytest.mark.parametrize("accounting_status", ["lower_bound", "unavailable"])
+def test_non_exact_whole_run_accounting_forces_partial(accounting_status: str) -> None:
+    certificate = _complete_recorder().finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(accounting_status=accounting_status),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert f"traffic_accounting_{accounting_status}" in certificate.limitations
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_limitation"),
+    [
+        ({"incomplete_request_count": 1}, "traffic_incomplete"),
+        ({"pending_dispatch_count": 1}, "traffic_incomplete"),
+        ({"blocked_count": 1}, "traffic_policy_blocked"),
+        ({"circuit_open_count": 1}, "traffic_circuit_open"),
+        ({"unmetered_action_count": 1}, "unmetered_actions"),
+    ],
+)
+def test_whole_run_transport_and_policy_gaps_force_partial(
+    changes: dict[str, int],
+    expected_limitation: str,
+) -> None:
+    certificate = _complete_recorder().finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(**changes),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert expected_limitation in certificate.limitations
+
+
+def test_missing_traffic_accounting_is_explicitly_partial() -> None:
+    certificate = _complete_recorder().finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=None,
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert certificate.traffic.accounting_status is RequestAccountingStatus.UNAVAILABLE
+    assert certificate.traffic.physical_request_count is None
+    assert "traffic_accounting_unavailable" in certificate.limitations
+
+
+def test_per_probe_lower_bound_accounting_forces_partial() -> None:
+    recorder = ScanCoverageRecorder()
+    recorder.record_planner_decision(
+        PlannerProbeDecision(probe_id="dom_execution", family="browser", rank=0)
+    )
+    recorder.record_probe_outcome(
+        ProbeCoverageOutcome(
+            probe_id="dom_execution",
+            disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+            physical_request_count=1,
+            request_accounting_status=RequestAccountingStatus.LOWER_BOUND,
+        )
+    )
+
+    certificate = recorder.finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(accounting_status="lower_bound"),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert "probe_request_accounting_lower_bound" in certificate.limitations
+
+
+def test_missing_probe_outcome_is_materialized_without_claiming_completion() -> None:
+    recorder = ScanCoverageRecorder()
+    recorder.record_planner_decision(
+        PlannerProbeDecision(probe_id="secret_sweep", family="exposure", rank=0)
+    )
+
+    certificate = recorder.finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert certificate.probes[0].disposition is ProbeDisposition.TRANSPORT_INCOMPLETE
+    assert certificate.probes[0].reason_codes == ("probe_outcome_missing",)
+    assert "probe_outcome_missing" in certificate.limitations
+
+
+def test_json_is_deterministic_path_free_and_uses_narrow_completion_wording() -> None:
+    private_surface = "/Users/operator/customer/admin?token=private"
+
+    def build(*, reverse: bool) -> str:
+        recorder = ScanCoverageRecorder()
+        decisions = [
+            PlannerProbeDecision(
+                probe_id="second",
+                family="injection",
+                rank=1,
+                surface_key=private_surface,
+                reason_codes=("signal_b", "signal_a"),
+            ),
+            PlannerProbeDecision(
+                probe_id="first",
+                family="recon",
+                rank=0,
+                surface_key="https://example.invalid/private",
+            ),
+        ]
+        for decision in reversed(decisions) if reverse else decisions:
+            recorder.record_planner_decision(decision)
+        outcomes = [
+            ProbeCoverageOutcome(
+                probe_id="second",
+                disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+            ),
+            ProbeCoverageOutcome(
+                probe_id="first",
+                disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+            ),
+        ]
+        for outcome in reversed(outcomes) if reverse else outcomes:
+            recorder.record_probe_outcome(outcome)
+        return recorder.finalize(
+            planner_frontier_exhausted=True,
+            traffic_snapshot=_snapshot(),
+            traffic_config=_config(),
+        ).to_json_text()
+
+    forward = build(reverse=False)
+    reverse = build(reverse=True)
+
+    assert forward == reverse
+    assert private_surface not in forward
+    assert "/Users/operator" not in forward
+    assert "example.invalid/private" not in forward
+    assert forward.count("planner_frontier_exhausted") == 1
+    assert "application_exhausted" not in forward
+    assert "family_exhausted" not in forward
+    assert "no_vulnerability" not in forward
+    assert "no vulnerabilities" not in forward.lower()
+    assert len(forward.encode()) < MAX_CERTIFICATE_BYTES
+    assert json.loads(forward)["probes"][0]["probe_id"] == "first"
+
+
+def test_open_planner_frontier_is_partial() -> None:
+    certificate = _complete_recorder().finalize(
+        planner_frontier_exhausted=False,
+        traffic_snapshot=_snapshot(),
+        traffic_config=_config(),
+    )
+
+    assert certificate.status is ScanCoverageStatus.PARTIAL
+    assert certificate.completion_basis == "planner_frontier_open"
+    assert "planner_frontier_open" in certificate.limitations
+
+
+def test_inputs_are_bounded_and_do_not_accept_path_identifiers() -> None:
+    with pytest.raises(ScanCoverageError, match="lowercase identifier"):
+        PlannerProbeDecision(probe_id="/admin", family="recon", rank=0)
+
+    recorder = ScanCoverageRecorder(max_probe_records=1)
+    recorder.record_planner_decision(PlannerProbeDecision(probe_id="first", family="recon", rank=0))
+    with pytest.raises(ScanCoverageError, match="decision limit"):
+        recorder.record_planner_decision(
+            PlannerProbeDecision(probe_id="second", family="recon", rank=1)
+        )
+
+
+def test_finding_dispositions_enforce_consistent_counts() -> None:
+    with pytest.raises(ScanCoverageError, match="at least one finding"):
+        ProbeCoverageOutcome(
+            probe_id="sqli",
+            disposition=ProbeDisposition.COMPLETED_FINDING,
+        )
+    with pytest.raises(ScanCoverageError, match="only completed_finding"):
+        ProbeCoverageOutcome(
+            probe_id="sqli",
+            disposition=ProbeDisposition.COMPLETED_NO_FINDING,
+            finding_count=1,
+        )
+
+
+def test_certificate_writer_is_atomic_private_and_reproducible(tmp_path: Path) -> None:
+    certificate = _complete_recorder().finalize(
+        planner_frontier_exhausted=True,
+        traffic_snapshot=_snapshot(),
+        traffic_config=_config(),
+    )
+    output_path = tmp_path / "nested" / "scan-coverage.json"
+
+    written = write_scan_coverage_certificate(output_path, certificate)
+    first = output_path.read_bytes()
+    write_scan_coverage_certificate(output_path, certificate)
+
+    assert written == output_path.absolute()
+    assert output_path.read_bytes() == first == certificate.to_json_text().encode()
+    assert stat.S_IMODE(output_path.stat().st_mode) == _PRIVATE_FILE_MODE
+    assert list(output_path.parent.glob(f".{output_path.name}.*.tmp")) == []

--- a/packages/ravage/tests/test_scan_planner.py
+++ b/packages/ravage/tests/test_scan_planner.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from ravage.agent_core.agent_state import AgentState
+from ravage.agent_core.surface_graph import SurfaceGraphState, SurfaceParameter
+from ravage.probe_suite import available_probes
+from ravage.probe_suite_parts.result import ProbeRunResult
+from ravage.scan_planner import (
+    DEFAULT_SCAN_PROBES,
+    DEPTH_SCAN_PROBES,
+    DISCOVERY_SCAN_PROBES,
+    SCAN_PLAN_SCHEMA,
+    SCAN_PROBE_CATALOG,
+    SCAN_PROBE_DEPENDENCIES,
+    ScanPlanPhase,
+    ScanPlanStatus,
+    build_adaptive_scan_plan,
+)
+
+TARGET = "https://example.test"
+
+
+def _state() -> AgentState:
+    return AgentState(surface_graph=SurfaceGraphState.for_target(TARGET))
+
+
+def _result(probe: str, *finding_types: str) -> ProbeRunResult:
+    return ProbeRunResult(
+        ok=bool(finding_types),
+        probe=probe,
+        summary="test result",
+        findings=[{"type": finding_type} for finding_type in finding_types],
+    )
+
+
+def test_empty_state_keeps_every_historical_default_and_its_dependencies() -> None:
+    plan = build_adaptive_scan_plan(_state())
+
+    assert set(DEFAULT_SCAN_PROBES) <= set(plan.probes)
+    assert plan.probes == (
+        "surface_map",
+        "secret_sweep",
+        "direct_exposure",
+        "api_behavior",
+        "browser_boundary",
+        "stateful_session",
+        "csrf_session",
+    )
+    assert plan.decision_for("csrf_session").reasons == ("required_default",)
+    assert plan.decision_for("stateful_session").reasons == ("dependency:csrf_session",)
+    assert plan.decision_for("sqli_exploit").status is ScanPlanStatus.NOT_APPLICABLE
+
+
+def test_plan_is_immutable_and_serializes_a_complete_coverage_ledger() -> None:
+    plan = build_adaptive_scan_plan(_state())
+
+    with pytest.raises(FrozenInstanceError):
+        plan.probes = ()  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        plan.decisions[0].status = ScanPlanStatus.COMPLETED  # type: ignore[misc]
+
+    payload = plan.to_json()
+    assert payload["schema"] == SCAN_PLAN_SCHEMA
+    assert len(payload["decisions"]) == len(SCAN_PROBE_CATALOG)  # type: ignore[arg-type]
+    assert payload["counts"] == {
+        "selected": 7,
+        "completed": 0,
+        "blocked": 0,
+        "not_applicable": len(SCAN_PROBE_CATALOG) - 7,
+    }
+
+
+def test_catalog_matches_the_builtin_probe_suite() -> None:
+    assert set(SCAN_PROBE_CATALOG) == {item["name"] for item in available_probes()}
+    assert len(SCAN_PROBE_CATALOG) == len(set(SCAN_PROBE_CATALOG))
+
+
+def test_generic_parameter_enables_only_breadth_input_tests() -> None:
+    state = _state()
+    state.surface_graph.add(
+        url=f"{TARGET}/search",
+        method="GET",
+        parameters=(SurfaceParameter.create(name="value", location="query"),),
+        source_kind="native_recon",
+    )
+
+    plan = build_adaptive_scan_plan(state)
+
+    assert {"input_reflection", "data_query", "sqli_differential"} <= set(plan.probes)
+    assert not (set(DEPTH_SCAN_PROBES) & set(plan.probes))
+    assert plan.decision_for("sqli_exploit").status is ScanPlanStatus.NOT_APPLICABLE
+    assert plan.decision_for("file_read_extract").status is ScanPlanStatus.NOT_APPLICABLE
+    assert plan.decision_for("dom_execution").status is ScanPlanStatus.NOT_APPLICABLE
+
+
+def test_typed_graph_facts_route_relevant_breadth_probes() -> None:
+    state = _state()
+    graph = state.surface_graph
+    graph.add(
+        url=f"{TARGET}/graphql",
+        method="POST",
+        selector="Query.user",
+        parameters=(SurfaceParameter.create(name="id", location="graphql"),),
+        hints=("graphql",),
+        source_kind="graphql",
+    )
+    graph.add(
+        url=f"{TARGET}/accounts/123",
+        parameters=(SurfaceParameter.create(name="account_id", location="path"),),
+        source_kind="openapi",
+    )
+    graph.add(
+        url=f"{TARGET}/read",
+        parameters=(SurfaceParameter.create(name="filename", location="query"),),
+        source_kind="openapi",
+    )
+    graph.add(
+        url=f"{TARGET}/parse",
+        method="POST",
+        content_types=("application/xml; charset=utf-8",),
+        source_kind="openapi",
+    )
+    graph.add(
+        url=f"{TARGET}/fetch",
+        parameters=(SurfaceParameter.create(name="callback", location="body", data_type="url"),),
+        source_kind="openapi",
+    )
+    graph.add(
+        url=f"{TARGET}/run",
+        parameters=(SurfaceParameter.create(name="command", location="body"),),
+        source_kind="openapi",
+    )
+    graph.add(
+        url=f"{TARGET}/preview",
+        parameters=(SurfaceParameter.create(name="template", location="form"),),
+        source_kind="native_recon",
+    )
+
+    plan = build_adaptive_scan_plan(state)
+
+    assert {
+        "graphql_exploit",
+        "idor_boundary",
+        "file_fetch_parser",
+        "xxe_boundary",
+        "ssrf_boundary",
+        "command_boundary",
+        "server_rendering",
+        "ssti_fingerprint",
+    } <= set(plan.probes)
+    assert plan.decision_for("graphql_exploit").reasons == ("surface:graphql_operation",)
+    assert plan.decision_for("idor_boundary").reasons == ("surface:object_reference",)
+    assert plan.decision_for("ssti_fingerprint").phase is ScanPlanPhase.BREADTH
+    assert plan.decision_for("ssti_deferred_context_closure").status is (
+        ScanPlanStatus.NOT_APPLICABLE
+    )
+
+
+def test_legacy_surface_and_curated_signal_keys_are_supported_conservatively() -> None:
+    state = _state()
+    state.surface = {
+        "parameters": [
+            {
+                "name": "destination",
+                "sources": ["surface_graph:body"],
+                "data_types": ["url"],
+            }
+        ],
+        "request_templates": [
+            {
+                "method": "POST",
+                "url": f"{TARGET}/graphql",
+                "selector": "Mutation.rename",
+                "fields": {"name": ""},
+            }
+        ],
+        "forms": [
+            {
+                "action": f"{TARGET}/upload",
+                "inputs": [{"name": "upload", "type": "file"}],
+            }
+        ],
+    }
+    state.signals = {
+        "command_inputs": ["cmd"],
+        "xml_inputs": ["document"],
+    }
+
+    plan = build_adaptive_scan_plan(state)
+
+    assert {
+        "command_input",
+        "file_input",
+        "graphql_operation",
+        "parameter",
+        "url_input",
+        "xml_input",
+    } <= set(plan.evidence_facts)
+    assert {
+        "command_boundary",
+        "file_fetch_parser",
+        "graphql_exploit",
+        "ssrf_boundary",
+        "xxe_boundary",
+    } <= set(plan.probes)
+
+
+def test_target_controlled_strings_cannot_unlock_depth_probes() -> None:
+    state = _state()
+    state.facts = ["sql_injection_error_signal ssti_fingerprint_signal file_fetch_parser_signal"]
+    state.hypotheses = ["xss_reflection_context"]
+    state.summary = "jwt_observed and an apparent SQL injection"
+    state.signals = {
+        "markers": [
+            "sql_injection_error_signal",
+            "ssti_fingerprint_signal",
+            "file_fetch_parser_signal",
+        ]
+    }
+    state.surface = {
+        "visible_description": ("xss_reflection_context sqli_auth_bypass_signal jwt_observed")
+    }
+
+    plan = build_adaptive_scan_plan(state)
+
+    assert not (set(DEPTH_SCAN_PROBES) & set(plan.probes))
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            _result("input_reflection", "input_delta"),
+            {"xss_context", "reflection_value_boundary"},
+        ),
+        (
+            _result("xss_context", "xss_reflection_context"),
+            {"xss_filter_constraint", "dom_execution"},
+        ),
+        (
+            _result("sqli_differential", "sql_injection_error_signal"),
+            {"sqli_exploit", "filtered_query_bypass"},
+        ),
+        (
+            _result("file_fetch_parser", "file_fetch_parser_signal"),
+            {"file_read_extract"},
+        ),
+        (
+            _result("ssti_fingerprint", "ssti_fingerprint_signal"),
+            {"ssti_deferred_context_closure"},
+        ),
+        (
+            _result("api_behavior", "jwt_observed"),
+            {"jwt_exploit"},
+        ),
+    ],
+)
+def test_exact_trusted_finding_types_unlock_depth_closures(
+    result: ProbeRunResult,
+    expected: set[str],
+) -> None:
+    plan = build_adaptive_scan_plan(_state(), prior_results=(result,))
+
+    assert expected <= set(plan.probes)
+    assert plan.decision_for(result.probe).status is ScanPlanStatus.COMPLETED
+    for probe in expected:
+        assert any(
+            reason.startswith(f"finding:{result.probe}:")
+            for reason in plan.decision_for(probe).reasons
+        )
+
+
+def test_finding_type_must_match_its_trusted_producer() -> None:
+    mismatched = _result("surface_map", "sql_injection_error_signal")
+
+    plan = build_adaptive_scan_plan(_state(), prior_results=(mismatched,))
+
+    assert plan.decision_for("sqli_exploit").status is ScanPlanStatus.NOT_APPLICABLE
+    assert plan.decision_for("filtered_query_bypass").status is ScanPlanStatus.NOT_APPLICABLE
+
+
+def test_plain_result_mappings_are_rejected_at_the_trust_boundary() -> None:
+    untrusted = {
+        "probe": "sqli_differential",
+        "findings": [{"type": "sql_injection_error_signal"}],
+    }
+
+    with pytest.raises(TypeError, match="ProbeRunResult"):
+        build_adaptive_scan_plan(_state(), prior_results=(untrusted,))  # type: ignore[arg-type]
+
+
+def test_completed_probes_are_reported_but_never_scheduled_twice() -> None:
+    results = (
+        _result("surface_map"),
+        _result("surface_map"),
+        _result("api_behavior", "graphql_exposed_proof"),
+        _result("graphql_exploit"),
+    )
+
+    plan = build_adaptive_scan_plan(_state(), prior_results=results)
+
+    assert "surface_map" not in plan.probes
+    assert "api_behavior" not in plan.probes
+    assert "graphql_exploit" not in plan.probes
+    assert len(plan.probes) == len(set(plan.probes))
+    assert plan.decision_for("surface_map").status is ScanPlanStatus.COMPLETED
+    assert plan.decision_for("graphql_exploit").status is ScanPlanStatus.COMPLETED
+
+
+def test_order_is_stable_across_graph_and_catalog_insertion_order() -> None:
+    operations = (
+        (
+            f"{TARGET}/fetch",
+            SurfaceParameter.create(name="url", location="query", data_type="url"),
+        ),
+        (
+            f"{TARGET}/users/123",
+            SurfaceParameter.create(name="id", location="path", data_type="integer"),
+        ),
+        (
+            f"{TARGET}/run",
+            SurfaceParameter.create(name="cmd", location="body"),
+        ),
+    )
+
+    def planned(order: tuple[int, ...], catalog: tuple[str, ...]) -> object:
+        state = _state()
+        for index in order:
+            url, parameter = operations[index]
+            state.surface_graph.add(
+                url=url,
+                method="POST",
+                parameters=(parameter,),
+                source_kind="openapi",
+            )
+        return build_adaptive_scan_plan(state, catalog=catalog).to_json()
+
+    assert planned((0, 1, 2), SCAN_PROBE_CATALOG) == planned(
+        (2, 0, 1),
+        tuple(reversed(SCAN_PROBE_CATALOG)),
+    )
+
+
+def test_every_selected_dependency_precedes_its_consumer() -> None:
+    state = _state()
+    state.surface_graph.add(
+        url=f"{TARGET}/users/123",
+        parameters=(SurfaceParameter.create(name="id", location="path"),),
+        source_kind="openapi",
+    )
+    results = (
+        _result("xss_context", "xss_reflection_context"),
+        _result("sqli_differential", "sql_injection_error_signal"),
+        _result("ssti_fingerprint", "ssti_fingerprint_signal"),
+    )
+
+    plan = build_adaptive_scan_plan(state, prior_results=results)
+
+    for probe in plan.probes:
+        for dependency in SCAN_PROBE_DEPENDENCIES.get(probe, ()):
+            if dependency in plan.probes:
+                assert plan.probes.index(dependency) < plan.probes.index(probe)
+
+    phases = [plan.decision_for(probe).phase for probe in plan.probes]
+    phase_rank = {
+        ScanPlanPhase.DISCOVERY: 0,
+        ScanPlanPhase.BREADTH: 1,
+        ScanPlanPhase.DEPTH: 2,
+    }
+    assert [phase_rank[phase] for phase in phases] == sorted(phase_rank[phase] for phase in phases)
+
+
+def test_missing_catalog_dependency_blocks_probe_with_a_coverage_reason() -> None:
+    result = _result("sqli_differential", "sql_injection_error_signal")
+    catalog = tuple(
+        probe for probe in SCAN_PROBE_CATALOG if probe not in {"data_query", "sqli_differential"}
+    )
+
+    plan = build_adaptive_scan_plan(_state(), prior_results=(result,), catalog=catalog)
+
+    decision = plan.decision_for("sqli_exploit")
+    assert decision.status is ScanPlanStatus.BLOCKED
+    assert "missing_dependency:data_query" in decision.reasons
+    assert "sqli_exploit" not in plan.probes
+
+
+def test_invalid_catalog_and_state_inputs_fail_cleanly() -> None:
+    with pytest.raises(TypeError, match="AgentState"):
+        build_adaptive_scan_plan(object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="sequence"):
+        build_adaptive_scan_plan(_state(), catalog="surface_map")
+    with pytest.raises(ValueError, match="unique"):
+        build_adaptive_scan_plan(_state(), catalog=("surface_map", "surface_map"))
+
+
+def test_discovery_phase_is_always_before_breadth_and_depth() -> None:
+    results = (
+        _result("xss_context", "xss_reflection_context"),
+        _result("sqli_differential", "blind_sql_injection_boolean_signal"),
+    )
+    plan = build_adaptive_scan_plan(_state(), prior_results=results)
+
+    selected_discovery = [probe for probe in DISCOVERY_SCAN_PROBES if probe in plan.probes]
+    assert plan.probes[: len(selected_discovery)] == tuple(selected_discovery)
+    first_depth = min(
+        (plan.probes.index(probe) for probe in DEPTH_SCAN_PROBES if probe in plan.probes),
+        default=len(plan.probes),
+    )
+    assert all(
+        plan.decision_for(probe).phase is not ScanPlanPhase.BREADTH
+        for probe in plan.probes[first_depth:]
+    )

--- a/packages/ravage/tests/test_scan_planner.py
+++ b/packages/ravage/tests/test_scan_planner.py
@@ -95,6 +95,43 @@ def test_generic_parameter_enables_only_breadth_input_tests() -> None:
     assert plan.decision_for("dom_execution").status is ScanPlanStatus.NOT_APPLICABLE
 
 
+def test_probe_mutations_cannot_seed_planner_facts_or_taint_later_discovery() -> None:
+    state = _state()
+    attempted = state.surface_graph.add(
+        url=f"{TARGET}/fabricated-login?command=attack",
+        method="POST",
+        parameters=(SurfaceParameter.create(name="command", location="query"),),
+        hints=("command",),
+        source_kind="probe",
+        access_level="response",
+        response_status=200,
+    )
+
+    attack_plan = build_adaptive_scan_plan(state)
+
+    assert attempted.operation_id in state.surface_graph.operations  # type: ignore[operator]
+    assert attempted.actionable is False
+    assert attempted.parameters == ()
+    assert "parameter" not in attack_plan.evidence_facts
+    assert "command_input" not in attack_plan.evidence_facts
+    assert "command_boundary" not in attack_plan.probes
+
+    discovered = state.surface_graph.add(
+        url=f"{TARGET}/fabricated-login?q=observed",
+        method="POST",
+        parameters=(SurfaceParameter.create(name="q", location="query"),),
+        source_kind="native_recon",
+    )
+    trusted_plan = build_adaptive_scan_plan(state)
+
+    assert discovered.operation_id == attempted.operation_id
+    assert discovered.actionable is True
+    assert {item.name for item in discovered.parameters} == {"q"}
+    assert "parameter" in trusted_plan.evidence_facts
+    assert "command_input" not in trusted_plan.evidence_facts
+    assert "command_boundary" not in trusted_plan.probes
+
+
 def test_typed_graph_facts_route_relevant_breadth_probes() -> None:
     state = _state()
     graph = state.surface_graph

--- a/packages/ravage/tests/test_scan_traffic_policy.py
+++ b/packages/ravage/tests/test_scan_traffic_policy.py
@@ -132,6 +132,7 @@ def test_scan_low_noise_cap_matches_real_physical_dispatches(
 
     summary = json.loads(capsys.readouterr().out)
     accounting = summary["traffic_accounting"]
+    coverage = json.loads((run_dir / "scan-coverage.json").read_text(encoding="utf-8"))
     assert dispatched_paths == ["/surface_map"]
     assert accounting["physical_request_count"] == len(dispatched_paths) == 1
     assert accounting["completed_request_count"] == 1
@@ -139,6 +140,13 @@ def test_scan_low_noise_cap_matches_real_physical_dispatches(
     assert accounting["remaining_physical_requests"] == 0
     assert accounting["accounting_status"] == "exact"
     assert accounting["provenance"] == "workspace_traffic_policy_ledger"
+    assert coverage["status"] == "partial"
+    assert "budget_blocked" in coverage["limitations"]
+    assert "traffic_policy_blocked" in coverage["limitations"]
+    assert [record["disposition"] for record in coverage["probes"]] == [
+        "completed_no_finding",
+        "blocked_budget",
+    ]
 
 
 def test_scan_opaque_transport_is_accounted_or_blocked(tmp_path: Path) -> None:
@@ -153,12 +161,18 @@ def test_scan_opaque_transport_is_accounted_or_blocked(tmp_path: Path) -> None:
         config=TrafficPolicyConfig.low_noise(max_physical_requests=3, max_rps=0.9),
     )
 
-    assert cli._guard_scan_probe_traffic(  # noqa: SLF001
-        "surface_map", traffic_policy=observe
-    ) == ""
-    assert cli._guard_scan_probe_traffic(  # noqa: SLF001
-        "dom_execution", traffic_policy=observe
-    ) == ""
+    assert (
+        cli._guard_scan_probe_traffic(  # noqa: SLF001
+            "surface_map", traffic_policy=observe
+        )
+        == ""
+    )
+    assert (
+        cli._guard_scan_probe_traffic(  # noqa: SLF001
+            "dom_execution", traffic_policy=observe
+        )
+        == ""
+    )
     observed = cli._scan_traffic_accounting(observe)  # noqa: SLF001
     assert observed["unmetered_action_count"] == 1
     assert observed["accounting_status"] == "lower_bound"

--- a/packages/ravage/tests/test_scan_traffic_policy.py
+++ b/packages/ravage/tests/test_scan_traffic_policy.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING, ClassVar, cast
+
+import pytest
+from ravage import __main__ as cli
+from ravage.probe_suite_parts.result import ProbeRunResult
+from ravage.traffic.policy import (
+    TrafficPolicyConfig,
+    TrafficPolicyController,
+)
+from ravage.web_core.http_probe import ProbeSession
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+
+_CLI_USAGE_ERROR = 2
+_LEDGER_FAILURE_MESSAGE = "private ledger failure"
+
+
+class _CountingHandler(BaseHTTPRequestHandler):
+    paths: ClassVar[list[str]] = []
+
+    def do_GET(self) -> None:
+        type(self).paths.append(self.path)
+        body = b'{"ok":true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+
+@pytest.fixture
+def counting_server() -> Iterator[tuple[str, list[str]]]:
+    _CountingHandler.paths = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CountingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}/", _CountingHandler.paths
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _write_brief(path: Path, target_url: str) -> None:
+    path.write_text(
+        f"""engagement_id: 11111111-1111-4111-8111-111111111111
+scope:
+  in_scope:
+    - {target_url}
+  out_of_scope: []
+roe:
+  max_rps: 5
+  no_destructive_actions: true
+objectives:
+  - web_application_assessment
+budget:
+  max_cost_usd: 1.0
+  max_runtime_min: 5
+context:
+  description: scan traffic policy integration fixture
+""",
+        encoding="utf-8",
+    )
+
+
+def _metered_probe(probe: str, **kwargs: object) -> ProbeRunResult:
+    target_url = str(kwargs["target_url"])
+    policy = cast("TrafficPolicyController", kwargs["traffic_policy"])
+    observer = cast("Callable[[dict[str, object]], None] | None", kwargs["traffic_observer"])
+    session = ProbeSession(
+        target_url,
+        in_scope=cast("tuple[str, ...]", kwargs["in_scope"]),
+        out_of_scope=cast("tuple[str, ...]", kwargs["out_of_scope"]),
+        traffic_observer=observer,
+        traffic_policy=policy,
+    )
+    response = session.get(f"{target_url.rstrip('/')}/{probe}")
+    return ProbeRunResult(
+        ok=response.ok,
+        probe=probe,
+        summary="request completed" if response.ok else response.error,
+        requests=[response.summary()],
+        errors=[response.error] if response.error else [],
+        http_request_count=session.physical_request_count,
+    )
+
+
+def test_scan_low_noise_cap_matches_real_physical_dispatches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    counting_server: tuple[str, list[str]],
+) -> None:
+    target_url, dispatched_paths = counting_server
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "run"
+    _write_brief(brief, target_url)
+    monkeypatch.setattr(cli, "run_builtin_probe", _metered_probe)
+
+    cli.main(
+        [
+            "scan",
+            str(brief),
+            "--probe",
+            "surface_map",
+            "--probe",
+            "secret_sweep",
+            "--traffic-policy",
+            "low-noise",
+            "--max-physical-requests",
+            "1",
+            "--traffic-max-rps",
+            "0.9",
+            "--run-dir",
+            str(run_dir),
+            "--json",
+        ]
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    accounting = summary["traffic_accounting"]
+    assert dispatched_paths == ["/surface_map"]
+    assert accounting["physical_request_count"] == len(dispatched_paths) == 1
+    assert accounting["completed_request_count"] == 1
+    assert accounting["blocked_count"] == 1
+    assert accounting["remaining_physical_requests"] == 0
+    assert accounting["accounting_status"] == "exact"
+    assert accounting["provenance"] == "workspace_traffic_policy_ledger"
+
+
+def test_scan_opaque_transport_is_accounted_or_blocked(tmp_path: Path) -> None:
+    observe = TrafficPolicyController.open(
+        tmp_path / "observe.json",
+        target_url="http://127.0.0.1:4321/",
+        config=TrafficPolicyConfig(),
+    )
+    enforce = TrafficPolicyController.open(
+        tmp_path / "enforce.json",
+        target_url="http://127.0.0.1:4321/",
+        config=TrafficPolicyConfig.low_noise(max_physical_requests=3, max_rps=0.9),
+    )
+
+    assert cli._guard_scan_probe_traffic(  # noqa: SLF001
+        "surface_map", traffic_policy=observe
+    ) == ""
+    assert cli._guard_scan_probe_traffic(  # noqa: SLF001
+        "dom_execution", traffic_policy=observe
+    ) == ""
+    observed = cli._scan_traffic_accounting(observe)  # noqa: SLF001
+    assert observed["unmetered_action_count"] == 1
+    assert observed["accounting_status"] == "lower_bound"
+
+    reason = cli._guard_scan_probe_traffic(  # noqa: SLF001
+        "dom_execution", traffic_policy=enforce
+    )
+    assert "unmetered network-capable actions" in reason
+    blocked = cli._scan_traffic_accounting(enforce)  # noqa: SLF001
+    assert blocked["unmetered_action_count"] == 0
+    assert blocked["blocked_count"] == 1
+    assert blocked["accounting_status"] == "exact"
+
+
+def test_scan_requires_a_fresh_run_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "run"
+    _write_brief(brief, "http://127.0.0.1:4321/")
+    monkeypatch.setattr(
+        cli,
+        "run_builtin_probe",
+        lambda probe, **_kwargs: ProbeRunResult(ok=True, probe=probe, summary="done"),
+    )
+    command = [
+        "scan",
+        str(brief),
+        "--probe",
+        "surface_map",
+        "--run-dir",
+        str(run_dir),
+        "--json",
+    ]
+
+    cli.main(command)
+    capsys.readouterr()
+    with pytest.raises(SystemExit, match="scan run directory already contains prior state"):
+        cli.main(command)
+
+
+def test_scan_aborts_when_mandatory_traffic_ledger_cannot_initialize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    _write_brief(brief, "http://127.0.0.1:4321/")
+    probe_called = False
+
+    def fail_open(*_args: object, **_kwargs: object) -> TrafficPolicyController:
+        raise OSError(_LEDGER_FAILURE_MESSAGE)
+
+    def run_probe(probe: str, **_kwargs: object) -> ProbeRunResult:
+        nonlocal probe_called
+        probe_called = True
+        return ProbeRunResult(ok=True, probe=probe, summary="unexpected")
+
+    monkeypatch.setattr(cli.TrafficPolicyController, "open", fail_open)
+    monkeypatch.setattr(cli, "run_builtin_probe", run_probe)
+
+    with pytest.raises(SystemExit) as stopped:
+        cli.main(
+            [
+                "scan",
+                str(brief),
+                "--probe",
+                "surface_map",
+                "--run-dir",
+                str(tmp_path / "run"),
+            ]
+        )
+
+    assert stopped.value.code == _CLI_USAGE_ERROR
+    assert not probe_called
+    stderr = capsys.readouterr().err
+    assert "cannot initialize scan traffic policy" in stderr
+    assert _LEDGER_FAILURE_MESSAGE in stderr

--- a/packages/ravage/tests/test_surface_graph.py
+++ b/packages/ravage/tests/test_surface_graph.py
@@ -361,6 +361,53 @@ def test_probe_adapter_ingests_requests_openapi_routes_and_graphql_selectors() -
         if item.operation_id == probe_operation.operation_id
     )
     assert probe_observation.scope_decision == "unknown"
+    assert probe_operation.actionable is False
+    promoted = [item for item in graph.operations.values() if item.actionable]  # type: ignore[union-attr]
+    assert {source for item in promoted for source in item.provenance} >= {
+        "openapi",
+        "graphql",
+    }
+    projected = project_surface_graph(graph)
+    assert {item["url"] for item in projected["endpoints"]} >= {  # type: ignore[index]
+        f"{TARGET}/api/items/{'{int}'}",
+        f"{TARGET}/graphql",
+    }
+
+
+def test_probe_query_fields_cannot_contaminate_an_existing_trusted_operation() -> None:
+    graph = SurfaceGraphState.for_target(TARGET)
+    trusted = graph.add(
+        url=f"{TARGET}/search?q=observed",
+        parameters=(SurfaceParameter.create(name="q", location="query"),),
+        source_kind="native_recon",
+    )
+
+    ingest_probe_result(
+        graph,
+        {
+            "probe": "browser_boundary",
+            "requests": [
+                {
+                    "method": "GET",
+                    "url": f"{TARGET}/search?q=attack&fabricated_password=attack",
+                    "status": 200,
+                    "request_header_names": ["X-Fabricated-Auth"],
+                    "probe_kind": "browser_boundary_attack",
+                }
+            ],
+        },
+        source_observation_id="obs_attack",
+    )
+
+    merged = graph.operations[trusted.operation_id]  # type: ignore[index]
+    assert merged.provenance == ("native_recon", "probe")
+    assert {item.name for item in merged.parameters} == {"q"}
+    assert merged.header_names == ()
+    assert merged.hints == ()
+    assert len(graph.observations or {}) == 2
+    projected = project_surface_graph(graph)
+    [template] = projected["request_templates"]  # type: ignore[misc]
+    assert template["fields"] == {"q": ""}
 
 
 def test_old_state_imports_legacy_surface_and_versioned_state_fails_closed() -> None:
@@ -448,14 +495,11 @@ def test_empty_projection_is_an_exact_noop_and_projection_does_not_mutate_input(
     projected = project_surface_graph(graph, legacy)
 
     assert legacy == before
-    assert projected["endpoints"][0]["sources"] == ["legacy", "probe"]  # type: ignore[index]
-    assert projected["request_templates"][0]["fields"] == {  # type: ignore[index]
-        "existing": "value",
-        "q": "",
-    }
+    assert projected["endpoints"][0]["sources"] == ["legacy"]  # type: ignore[index]
+    assert projected["request_templates"][0]["fields"] == {"existing": "value"}  # type: ignore[index]
 
 
-def test_projection_retains_negative_probe_history_without_promoting_it() -> None:
+def test_projection_retains_probe_history_without_promoting_attack_surface() -> None:
     graph = SurfaceGraphState.for_target(TARGET)
     missing = graph.add(
         url=f"{TARGET}/missing?q=example",
@@ -551,11 +595,11 @@ def test_projection_retains_negative_probe_history_without_promoting_it() -> Non
     assert f"{TARGET}/gone" not in template_urls
     assert f"{TARGET}/late-missing" not in template_urls
     assert not {"q", "gone_id", "candidate"} & parameter_names
-    assert f"{TARGET}/statusless-request" in endpoint_urls
-    assert f"{TARGET}/authenticate" in endpoint_urls
-    assert f"{TARGET}/protected" in endpoint_urls
-    assert f"{TARGET}/method-specific" in endpoint_urls
-    assert f"{TARGET}/mixed-history" in endpoint_urls
+    assert f"{TARGET}/statusless-request" not in endpoint_urls
+    assert f"{TARGET}/authenticate" not in endpoint_urls
+    assert f"{TARGET}/protected" not in endpoint_urls
+    assert f"{TARGET}/method-specific" not in endpoint_urls
+    assert f"{TARGET}/mixed-history" not in endpoint_urls
     assert f"{TARGET}/declared" in endpoint_urls
     assert f"{TARGET}/declared" in template_urls
     assert "schema_field" in parameter_names
@@ -773,7 +817,7 @@ def test_sensitive_path_values_are_structuralized_before_graph_persistence() -> 
 def test_exchange_parameter_adapter_skips_malformed_names_per_item() -> None:
     graph = SurfaceGraphState.for_target(TARGET)
     exchange = SimpleNamespace(
-        source="probe_session",
+        source="external_tool",
         request_url=f"{TARGET}/items?!!!=bad&valid=ok",
         request_method="POST",
         request_body_field_names=("!!!", "email"),


### PR DESCRIPTION
## Summary

  - Ravage starts with broad checks and only runs deeper tests when it finds useful evidence.
  - Now it counts the real requests made during the full scan.
  - Keep vulnerabilities in reports even when no CTF flag is found.
  - Reflected search input is no longer wrongly reported as IDOR.