### PR TITLE
feat(improvement): verify candidate runs before promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ ravage skills validate builtin
 The [Improvement Lab](docs/improvement-lab.md) ingests sanitized prior-run
 structure, evaluates candidate patches in independent workspaces, archives
 accepted and rejected versions, and requires matched no-regression evidence
-before promotion. It is a sidecar: it does not mutate the source checkout or
-silently promote itself.
+before promotion. Promotable receipts must trace back to separately signed,
+archived execution evidence. It is a sidecar: it does not mutate the source
+checkout or silently promote itself.
 
 Passive orbital and packet artifacts can be inspected separately:
 

--- a/docs/improvement-lab.md
+++ b/docs/improvement-lab.md
@@ -54,7 +54,10 @@ flowchart LR
   evidence-advance, classification, closure, and accounting patterns;
 - independent candidate clones with source-state checks before and after;
 - pinned, networkless, non-root/capability-dropped container job specifications
-  for more reproducible candidate checks;
+  plus a bounded host executor that revalidates and runs those jobs without
+  granting network access;
+- Ed25519-signed execution envelopes, frozen-output validation, and a receipt
+  adapter that counts only executor-verified findings and observations;
 - exact matched champion-versus-candidate evaluation with at least three
   repeats, controls, conservative stability gates, and efficiency limits;
 - Ed25519-signed evaluation bindings that pin the champion and candidate,
@@ -67,13 +70,13 @@ flowchart LR
   patch.
 
 The lab is not autonomous or self-training. It does not yet contain an
-unattended code-proposing model broker, a trusted execution/evidence adapter, a
-live target scheduler, or a microVM backend. It does not execute the emitted
-job specification, derive receipts from reports or traffic, authenticate the
-person named in an approval record, or merge code. A Codex agent or human can
-propose a candidate patch today, and a separately trusted executor must run the
-pinned suite, derive the receipts, and control the referee key. Human identity
-and mainline authorization remain controls of the surrounding review system.
+unattended code-proposing model broker, a live target scheduler, or a microVM
+backend. The bounded executor and receipt adapter are library components; the
+CLI still expects a trusted evaluator to create and sign the final execution
+observations and finding verdicts. It does not authenticate the person named in
+an approval record or merge code. Executor and referee keys are deliberately
+separate. Human identity and mainline authorization remain controls of the
+surrounding review system.
 
 The proposal step should receive only the generated brief and development
 capsules. Candidate execution additionally receives the candidate source and
@@ -130,8 +133,8 @@ Create holdout capsules separately:
 Candidate-visible export fails if even one sealed capsule is mixed in. Use a
 different HMAC domain for development and holdout identities, so matching IDs
 cannot disclose the hidden partition. The current lab can archive these sealed
-artifacts, but it does not schedule a holdout run or derive a promotion receipt
-from one; that remains the trusted evaluator's job.
+artifacts and derive a receipt from a signed completed run, but it does not
+schedule the holdout itself; that remains the trusted evaluator's job.
 
 ## Trusted Historical Replay
 
@@ -164,6 +167,10 @@ or live authorized runs.
 .venv/bin/python scripts/improvement_lab.py referee-keygen \
   --private-key "$LAB_ROOT/referee-private.key" \
   --public-key "$LAB_ROOT/referee-public.key"
+
+.venv/bin/python scripts/improvement_lab.py executor-keygen \
+  --private-key "$LAB_ROOT/executor-private.key" \
+  --public-key "$LAB_ROOT/executor-public.key"
 
 .venv/bin/python scripts/improvement_lab.py artifact-add \
   --archive "$LAB_ROOT/archive" \
@@ -212,9 +219,10 @@ gate rather than relying on the verification performed by other lab commands.
 
 Use `.ravage/improvement-lab/<operator-label>/archive` as the local default;
 the generated ID in `format.json` is authoritative. The repository already
-ignores `.ravage/`; do not commit an archive or its HMAC key
-or referee private key to Git. Keep the referee private key outside both the
-archive and candidate environments; use a secret manager or KMS in production.
+ignores `.ravage/`; do not commit an archive, its HMAC key, or either private
+key to Git. Keep executor and referee private keys outside both the archive and
+candidate environments, and never give either key to a candidate. Use a secret
+manager or KMS in production.
 For disaster recovery, mirror the archive to private, encrypted, versioned
 object storage with retention lock. A mirror is a backup, not a candidate
 input, and must preserve object names and the ledger exactly. Store the current
@@ -238,7 +246,9 @@ Keep the compact decision record indefinitely:
 - every registered candidate patch, configuration, and parent identity;
 - secret-safe development capsules and capability briefs;
 - aggregate historical-replay, repeated-run, control, evaluation, tournament,
-  rejection, and approval receipts recorded through the archive; and
+  rejection, and approval receipts recorded through the archive;
+- canonical signed execution envelopes referenced by fixture and live
+  receipts; and
 - the content-addressed objects, manifests, lab pointer, and event ledger.
 
 Do not put candidate workspaces, container images, caches, packet captures,
@@ -253,12 +263,9 @@ expiry.
 
 The archive is intentionally append-only, so retention is applied to the raw
 vault and disposable workspaces, not to decision records. Content addressing
-deduplicates identical archive objects. At the current demonstration scale, 15
-workspace run directories occupy about 19 MB of allocated disk while the
-verified compact archive occupies about 212 KB, roughly 90 times less; treat
-that ratio as an observation, not a fixed capacity guarantee. Those existing
-workspace runs are measurement inputs, not an example of the encrypted raw
-vault policy described above.
+deduplicates identical archive objects. Archive growth is roughly proportional
+to registered candidates, signed run envelopes, and evaluations; raw response
+bodies and full workspaces are deliberately excluded.
 
 Monitor `object_bytes` and `verified_bytes` from `archive-verify`. A sensible
 operating budget is to investigate any candidate that adds more than 10 MB,
@@ -355,14 +362,15 @@ image and resolve from `/trusted-tests`, not from candidate-controlled source:
   --evaluation-suite "$LAB_ROOT/evaluation-suite.json" \
   --runner-image registry.example/improvement@sha256:IMAGE_DIGEST \
   --referee-public-key "$LAB_ROOT/referee-public.key" \
+  --executor-public-key "$LAB_ROOT/executor-public.key" \
   --candidate-artifact-id DEVELOPMENT_CORPUS_ARTIFACT_ID \
   --candidate-artifact-id CAPABILITY_BRIEF_ARTIFACT_ID
 ```
 
 One campaign has one fixed champion commit, tree, policy, suite, runner image,
-referee key, and exact corpus/brief pair. The archive rebuilds the brief from
-the corpus before exposing either to a candidate. A candidate cannot change
-that baseline during its tournament.
+separate referee and executor keys, and exact corpus/brief pair. The archive
+rebuilds the brief from the corpus before exposing either to a candidate. A
+candidate cannot change that baseline during its tournament.
 
 After an operator-selected patch passes the normal review and is committed,
 start the next campaign from that clean commit and pass the old lab champion
@@ -442,31 +450,52 @@ mounted, so Git's `assume-unchanged` and `skip-worktree` hints cannot hide a
 substitution. Because the generated command uses `--pull=never`, the trusted
 executor must preload and verify the digest-pinned image.
 
-This command remains a specification builder. A trusted executor must
-revalidate immediately before launch and enforce time, disk, process, and
-file-size limits. Tests visible inside this development container are not a
-sealed promotion holdout. Live model/target evaluation needs a future scoped
-model broker and target-only network rather than general internet access. Use
-fresh `--lab-root`, `--candidate-view-root`, and `--job-output` paths for every
-retry.
+This command remains a specification builder. Evaluator services can call the
+bounded `execute_offline_job` API, which revalidates immediately before launch,
+enforces a timeout, captures bounded output, and freezes a size-limited output
+tree. Deployment-level process and disk quotas still belong to the container
+runtime. Tests visible inside this development container are not a sealed
+promotion holdout. Live model/target evaluation needs a future scoped model
+broker and target-only network rather than general internet access. Use fresh
+`--lab-root`, `--candidate-view-root`, and `--job-output` paths for every retry.
 
 ## Evaluate Detection, Including No-Flag Targets
 
-The current CLI does not execute the container job or convert a Ravage report,
-traffic capture, or target run into these files. A separately trusted
-executor/evidence adapter must produce the receipts from evaluator-owned
-observations. `evaluate` validates, retains, compares, and signs the supplied
-fields; it cannot independently prove that the declared execution occurred or
-that a self-supplied metric is truthful.
+The evaluator must first sign an execution envelope with the campaign's
+executor key. The envelope binds the campaign, champion/candidate side, suite,
+trusted tests, runner image, source tree, artifact tree, case, repeat, seed,
+target snapshot, model, prompt, external resource counts, safety counts, and
+finding verdicts. Candidate-side evidence also binds the candidate ID. Champion
+evidence is campaign-scoped so one exact signed baseline can be reused fairly
+across that campaign's candidates. Do not create an envelope inside a candidate
+container.
 
-The canonical retained form uses `ravage.improvement-run.v1` per-case receipts.
+Use `receipt-build` on the evaluator host after the artifact tree is frozen:
+
+```bash
+.venv/bin/python scripts/improvement_lab.py receipt-build \
+  --archive "$LAB_ROOT/archive" \
+  --candidate-id CANDIDATE_ID \
+  --artifacts "$WORK_ROOT/jobs/CANDIDATE_ID/output" \
+  --execution-envelope "$WORK_ROOT/attestations/RUN_ID.signed.json" \
+  --output "$LAB_ROOT/receipts/RUN_ID.json"
+```
+
+The command re-verifies the executor signature, artifact-tree digest, nominated
+finding identities, proof-integrity claims, and physical-request accounting. It
+counts only signed executor verdicts, writes one canonical receipt, and retains
+the exact signed envelope in the archive. Candidate-declared flags and finding
+status do not create promotion credit. A missing envelope, wrong key, changed
+artifact, unsigned metric, or under-reported mismatch fails closed.
+
+The canonical retained form uses `ravage.improvement-run.v2` per-case receipts.
 Each input file may be a top-level receipt list or an object with a `receipts`
 list. Champion and candidate files must contain the exact same
 `(cohort, case_id, execution_kind, repeat)` matrix. Each receipt must explicitly
 report:
 
-- a unique run ID, a matched pair-seed digest, target-snapshot digest, and model
-  and prompt fingerprints;
+- a unique run ID and signed-execution-envelope digest, a matched pair-seed
+  digest, target-snapshot digest, and model and prompt fingerprints;
 - evidence-backed, verified, confirmed, and suspected vulnerability counts;
 - expected vulnerability count when evaluator-owned ground truth exists;
 - proof-integrity and false-proof failures;
@@ -482,8 +511,9 @@ case is still a regression. On a target without a flag, set `case_success` to
 counts. Suspected findings remain telemetry but do not count as an improvement.
 The lab receipt stores aggregate counts, not vulnerability identities,
 descriptions, or evidence. The normal Ravage report and sealed evaluator vault
-must retain every actual finding, and the trusted adapter must derive the counts
-from that report.
+must retain every actual finding. Historical v1 receipts remain readable only
+for diagnostic `historical_replay`; they cannot be used for promotion because
+they have no signed execution-envelope digest.
 
 ```bash
 .venv/bin/python scripts/improvement_lab.py evaluate \
@@ -509,14 +539,14 @@ Promotion requires at least three repeats, a stable lower confidence bound,
 strictly better evidence-backed detection, no persistent case regression, no
 control regression, zero safety/accounting violations, no timeouts/errors, and
 no more than the configured cost/request-per-result regression.
-The signature binds the result to the archived campaign, candidate bytes,
-champion source, evaluation policy and suite, digest-pinned runner, and exact
-champion/candidate receipt-set objects. Archive verification reloads those
-objects and recomputes the full decision against the pinned suite. Rebinding a
-good result to another candidate, supplying a favorable subset, or silently
-changing the policy fails verification. The signature authenticates its signer
-and these exact bindings; without the future trusted executor it does not prove
-the underlying execution claims.
+The referee signature binds the result to the archived campaign, candidate
+bytes, champion source, evaluation policy and suite, digest-pinned runner, and
+exact champion/candidate receipt-set objects. Each promotable receipt points to
+its own canonical executor-signed envelope. Archive verification follows every
+pointer, re-verifies the separate executor key, checks the side and campaign
+binding, reproduces the exact receipt, and then recomputes the full decision.
+Rebinding a good result, swapping champion and candidate evidence, supplying a
+favorable subset, or silently changing the policy fails verification.
 
 ## How To Know It Worked
 
@@ -531,9 +561,9 @@ The mechanism is healthy only when all of the following hold:
   candidate, evaluate it, re-verify the signed decision, rank it, accept it with
   compare-and-swap, recover derived files, and verify the same ledger head and
   archive checkpoint;
-- altered receipts, a favorable suite subset, a changed candidate or test tree,
-  a wrong external checkpoint, stale promotion, and conflicting retries are
-  all rejected; and
+- altered receipts or execution envelopes, reused or wrong-side evidence, a
+  favorable suite subset, a changed candidate or test tree, a wrong external
+  checkpoint, stale promotion, and conflicting retries are all rejected; and
 - recovery after a committed event but missing derived manifest or pointer
   restores the exact projection without adding a second ledger event or
   changing the externally anchored archive checkpoint.
@@ -553,10 +583,10 @@ capture or `case_success` utility. Confirm that every counted finding also
 appears in the normal Ravage report; the compact lab receipt alone cannot show
 that. Public prior logs are diagnostic data, not a sealed promotion holdout.
 
-Passing these checks validates the archive and evaluator. Until a trusted
-executor/evidence adapter exists, it does not prove that an untrusted producer
-honestly generated the original receipts, and it is not unattended autonomous
-self-improvement.
+Passing these checks validates the archive, signed execution chain, adapter,
+and referee. It still depends on protecting the executor/referee private keys
+and on the trusted evaluator honestly observing the run; it is not unattended
+autonomous self-improvement.
 
 ## Tournament And Operator Approval
 
@@ -625,10 +655,10 @@ long-lived VM per conversational agent. Each environment should have:
 - bounded CPU, memory, processes, time, model calls, and physical requests; and
 - a single append-only result channel to the trusted evaluator.
 
-The current code emits hardened container specifications for development
-checks; it does not run them. Use a future microVM backend when running
-adversarial candidate-generated tools or when a stronger kernel boundary is
-worth the startup cost.
+The current code emits hardened container specifications and provides a bounded
+host executor for networkless development checks. Use a future microVM backend
+when running adversarial candidate-generated tools or when a stronger kernel
+boundary is worth the startup cost.
 
 ## Benchmark And Overfitting Rules
 

--- a/tests/improvement_lab/test_archive.py
+++ b/tests/improvement_lab/test_archive.py
@@ -144,7 +144,7 @@ def _execution_envelope(  # noqa: PLR0913 - execution identity is deliberately e
     candidate_patch = str(candidate["patch_object"])
     binding = ExecutionBinding(
         campaign_id=str(campaign["campaign_id"]),
-        candidate_id=candidate_id,
+        candidate_id=None if side == "champion" else candidate_id,
         candidate_tree_digest=(
             str(campaign["champion_tree"])
             if side == "champion"

--- a/tests/improvement_lab/test_archive.py
+++ b/tests/improvement_lab/test_archive.py
@@ -6,6 +6,7 @@ import os
 import stat
 import subprocess
 import sys
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -20,9 +21,17 @@ from tools.improvement_lab.corpus import candidate_visible_export
 from tools.improvement_lab.evaluation import (
     EvaluationConfig,
     EvaluationReceipt,
+    EvaluationSuite,
+    EvaluationSuiteCase,
     RunReceipt,
     evaluate_candidate,
-    evaluation_suite_from_receipts,
+)
+from tools.improvement_lab.execution_attestation import (
+    ExecutionBinding,
+    ExternalRunObservations,
+    FindingVerdict,
+    SignedExecutionEnvelope,
+    sign_execution_envelope,
 )
 from tools.improvement_lab.lessons import build_improvement_brief
 
@@ -35,11 +44,15 @@ _CHAMPION_TREE = "b" * 40
 _STATUS_DIGEST = f"sha256:{'c' * 64}"
 _REFEREE_PRIVATE_KEY = b"r" * 32
 _REFEREE_PUBLIC_KEY = public_key_from_private(_REFEREE_PRIVATE_KEY)
+_EXECUTOR_PRIVATE_KEY = b"x" * 32
+_EXECUTOR_PUBLIC_KEY = public_key_from_private(_EXECUTOR_PRIVATE_KEY)
 _RUNNER_IMAGE = f"example.invalid/referee@sha256:{'d' * 64}"
 _TWO_CANDIDATES = 2
 _THREE_ARTIFACTS = 3
 _FIVE_LEDGER_EVENTS = 5
-_SIX_LEDGER_EVENTS = 6
+_SIGNED_EVALUATION_ARTIFACTS = 14
+_SIGNED_EVALUATION_LEDGER_EVENTS = 17
+_ACCEPTED_EVALUATION_LEDGER_EVENTS = 18
 _CONCURRENT_OBJECTS = 20
 
 
@@ -51,91 +64,33 @@ def _digest(value: str) -> str:
     return f"sha256:{hashlib.sha256(value.encode()).hexdigest()}"
 
 
-def _run_receipt(
-    *,
-    case_id: str,
-    repeat: int,
-    control: bool,
-    side: str,
-    detected: int,
-) -> RunReceipt:
-    expected = 0 if control else 1
-    return RunReceipt.from_mapping(
-        {
-            "case_id": case_id,
-            "cohort": "control" if control else "capability",
-            "repeat": repeat,
-            "execution_kind": "fixture",
-            "status": "completed",
-            "is_control": control,
-            "case_success": True if control else bool(detected),
-            "expected_vulnerability_count": expected,
-            "run_id": _digest(f"run:{side}:{case_id}:{repeat}"),
-            "pair_seed_digest": _digest(f"seed:{case_id}:{repeat}"),
-            "target_snapshot_digest": _digest(f"target:{case_id}"),
-            "model_fingerprint": _digest("model:fixed"),
-            "prompt_fingerprint": _digest(f"prompt:{side}"),
-            "metrics": {
-                "evidence_backed_vulnerability_count": detected,
-                "verified_vulnerability_count": detected,
-                "confirmed_finding_count": detected,
-                "suspected_vulnerability_count": 0,
-                "proof_integrity_failure_count": 0,
-                "false_proof_count": 0,
-                "request_accounting_mismatch_count": 0,
-                "loop_violation_count": 0,
-                "provenance_violation_count": 0,
-                "secret_leak_violation_count": 0,
-                "unmetered_action_count": 0,
-                "incomplete_request_count": 0,
-                "physical_request_count": 10,
-                "model_request_count": 2,
-                "cost_usd": 0.1,
-                "request_accounting_status": "exact",
-            },
-        }
-    )
-
-
-def _receipt_sets(*, accepted: bool) -> tuple[tuple[RunReceipt, ...], tuple[RunReceipt, ...]]:
-    champion: list[RunReceipt] = []
-    candidate: list[RunReceipt] = []
-    for repeat in range(1, 4):
-        champion.append(
-            _run_receipt(
-                case_id="capability-case",
-                repeat=repeat,
-                control=False,
-                side="champion",
-                detected=0,
-            )
-        )
-        candidate.append(
-            _run_receipt(
-                case_id="capability-case",
-                repeat=repeat,
-                control=False,
-                side="candidate",
-                detected=1 if accepted else 0,
-            )
-        )
-        for side, output in (("champion", champion), ("candidate", candidate)):
-            output.append(
-                _run_receipt(
-                    case_id="control-case",
-                    repeat=repeat,
-                    control=True,
-                    side=side,
-                    detected=0,
-                )
-            )
-    return tuple(champion), tuple(candidate)
-
-
 def _suite_bytes(tag: str = "sealed-a") -> bytes:
-    champion, _candidate = _receipt_sets(accepted=True)
-    suite = evaluation_suite_from_receipts(
-        champion,
+    suite = EvaluationSuite(
+        cases=(
+            EvaluationSuiteCase(
+                case_id="capability-case",
+                cohort="capability",
+                execution_kind="fixture",
+                repeats=3,
+                is_control=False,
+                expected_vulnerability_count=1,
+                target_snapshot_digests=tuple(
+                    _digest("target:capability-case") for _repeat in range(3)
+                ),
+            ),
+            EvaluationSuiteCase(
+                case_id="control-case",
+                cohort="control",
+                execution_kind="fixture",
+                repeats=3,
+                is_control=True,
+                expected_vulnerability_count=0,
+                target_snapshot_digests=tuple(
+                    _digest("target:control-case") for _repeat in range(3)
+                ),
+            ),
+        ),
+        model_fingerprint=_digest("model:fixed"),
         trusted_tests_digest=_digest(f"tests:{tag}"),
         runner_command=("/usr/local/bin/python", "-I", "/trusted-tests/trusted_referee.py"),
     )
@@ -167,25 +122,191 @@ def _campaign(archive: LabArchive) -> dict[str, object]:
         evaluation_suite=_suite_bytes(),
         runner_image=_RUNNER_IMAGE,
         referee_public_key=_REFEREE_PUBLIC_KEY,
+        executor_public_key=_EXECUTOR_PUBLIC_KEY,
         proposal_input_artifact_ids=_proposal_inputs(archive),
     )
 
 
+def _execution_envelope(  # noqa: PLR0913 - execution identity is deliberately explicit.
+    archive: LabArchive,
+    campaign: dict[str, object],
+    candidate: dict[str, object],
+    *,
+    case_id: str,
+    repeat: int,
+    side: str,
+    detected: int,
+    private_key: bytes = _EXECUTOR_PRIVATE_KEY,
+) -> SignedExecutionEnvelope:
+    candidate_id = str(candidate["candidate_id"])
+    suite = archive.campaign_evaluation_suite(candidate_id)
+    control = case_id == "control-case"
+    candidate_patch = str(candidate["patch_object"])
+    binding = ExecutionBinding(
+        campaign_id=str(campaign["campaign_id"]),
+        candidate_id=candidate_id,
+        candidate_tree_digest=(
+            str(campaign["champion_tree"])
+            if side == "champion"
+            else candidate_patch.removeprefix("sha256:")
+        ),
+        candidate_content_digest=(
+            str(campaign["source_status_digest"])
+            if side == "champion"
+            else candidate_patch
+        ),
+        evaluation_suite_object=str(campaign["evaluation_suite_object"]),
+        trusted_tests_digest=suite.trusted_tests_digest,
+        runner_image=str(campaign["runner_image"]),
+        job_spec_digest=_digest(f"job:{side}:{case_id}:{repeat}"),
+        artifact_tree_digest=_digest(f"artifacts:{side}:{case_id}:{repeat}"),
+        artifact_case_path=f"cases/{side}/{case_id}/repeat-{repeat}",
+        case_id=case_id,
+        cohort="control" if control else "capability",
+        repeat=repeat,
+        execution_kind="fixture",
+        evaluation_side=side,
+        is_control=control,
+        expected_vulnerability_count=0 if control else 1,
+        run_id=_digest(f"run:{side}:{case_id}:{repeat}"),
+        pair_seed_digest=_digest(f"seed:{case_id}:{repeat}"),
+        target_snapshot_digest=_digest(f"target:{case_id}"),
+        model_fingerprint=_digest("model:fixed"),
+        prompt_fingerprint=_digest(f"prompt:{side}"),
+    )
+    observations = ExternalRunObservations(
+        status="completed",
+        case_success=True if control else bool(detected),
+        physical_request_count=10,
+        model_request_count=2,
+        cost_usd=0.1,
+        request_accounting_status="exact",
+        proof_integrity_failure_count=0,
+        false_proof_count=0,
+        request_accounting_mismatch_count=0,
+        loop_violation_count=0,
+        provenance_violation_count=0,
+        secret_leak_violation_count=0,
+        unmetered_action_count=0,
+        incomplete_request_count=0,
+    )
+    verdicts = tuple(
+        sorted(
+            (
+                FindingVerdict(
+                    _digest(f"finding:{side}:{case_id}:{repeat}:{index}"),
+                    "confirmed_finding",
+                )
+                for index in range(detected)
+            ),
+            key=lambda item: item.finding_digest,
+        )
+    )
+    return sign_execution_envelope(
+        binding,
+        observations,
+        verdicts,
+        private_key=private_key,
+    )
+
+
+def _retain_execution_receipt(  # noqa: PLR0913 - mirrors the signed run identity.
+    archive: LabArchive,
+    campaign: dict[str, object],
+    candidate: dict[str, object],
+    *,
+    case_id: str,
+    repeat: int,
+    side: str,
+    detected: int,
+) -> RunReceipt:
+    signed = _execution_envelope(
+        archive,
+        campaign,
+        candidate,
+        case_id=case_id,
+        repeat=repeat,
+        side=side,
+        detected=detected,
+    )
+    retained = archive.retain_execution_envelope(
+        str(candidate["candidate_id"]),
+        signed_envelope=signed,
+    )
+    receipt = signed.to_run_receipt()
+    assert retained["content_object"] == receipt.execution_attestation_digest
+    return receipt
+
+
+def _receipt_sets(
+    archive: LabArchive,
+    campaign: dict[str, object],
+    candidate: dict[str, object],
+    *,
+    accepted: bool,
+) -> tuple[tuple[RunReceipt, ...], tuple[RunReceipt, ...]]:
+    champion: list[RunReceipt] = []
+    challenger: list[RunReceipt] = []
+    for repeat in range(1, 4):
+        champion.append(
+            _retain_execution_receipt(
+                archive,
+                campaign,
+                candidate,
+                case_id="capability-case",
+                repeat=repeat,
+                side="champion",
+                detected=0,
+            )
+        )
+        challenger.append(
+            _retain_execution_receipt(
+                archive,
+                campaign,
+                candidate,
+                case_id="capability-case",
+                repeat=repeat,
+                side="candidate",
+                detected=1 if accepted else 0,
+            )
+        )
+        for side, output in (("champion", champion), ("candidate", challenger)):
+            output.append(
+                _retain_execution_receipt(
+                    archive,
+                    campaign,
+                    candidate,
+                    case_id="control-case",
+                    repeat=repeat,
+                    side=side,
+                    detected=0,
+                )
+            )
+    return tuple(champion), tuple(challenger)
+
+
 def _signed_evaluation(
     archive: LabArchive,
-    candidate_id: str,
+    campaign: dict[str, object],
+    candidate: dict[str, object],
     *,
     accepted: bool,
 ) -> dict[str, object]:
-    champion, candidate = _receipt_sets(accepted=accepted)
+    candidate_id = str(candidate["candidate_id"])
+    champion, challenger = _receipt_sets(
+        archive,
+        campaign,
+        candidate,
+        accepted=accepted,
+    )
     binding = archive.prepare_evaluation_binding(
         candidate_id,
         champion_receipts=champion,
-        candidate_receipts=candidate,
+        candidate_receipts=challenger,
     )
     receipt = evaluate_candidate(
         champion,
-        candidate,
+        challenger,
         config=archive.campaign_evaluation_config(candidate_id),
         suite=archive.campaign_evaluation_suite(candidate_id),
     )
@@ -195,6 +316,21 @@ def _signed_evaluation(
         binding,
         private_key=_REFEREE_PRIVATE_KEY,
     ).to_json()
+
+
+def _register_test_candidate(
+    archive: LabArchive,
+    campaign: dict[str, object],
+    *,
+    patch: bytes = b"candidate",
+) -> dict[str, object]:
+    return archive.register_candidate(
+        campaign_id=str(campaign["campaign_id"]),
+        parent_ref=str(archive.current_pointer()["champion_ref"]),
+        artifact_kind="source_patch",
+        patch=patch,
+        config={},
+    )
 
 
 def test_archive_objects_are_content_addressed_and_idempotent(tmp_path: Path) -> None:
@@ -293,7 +429,8 @@ def test_human_approval_advances_only_lab_pointer_with_cas(tmp_path: Path) -> No
         candidate_id=str(candidate["candidate_id"]),
         signed_evaluation=_signed_evaluation(
             archive,
-            str(candidate["candidate_id"]),
+            campaign,
+            candidate,
             accepted=True,
         ),
     )
@@ -333,7 +470,7 @@ def test_human_approval_advances_only_lab_pointer_with_cas(tmp_path: Path) -> No
             expected_champion_ref=original_ref,
             approval=conflicting_approval,
         )
-    assert archive.verify().ledger_events == _SIX_LEDGER_EVENTS
+    assert archive.verify().ledger_events == _ACCEPTED_EVALUATION_LEDGER_EVENTS
 
 
 def test_rejected_evaluation_cannot_advance_pointer(tmp_path: Path) -> None:
@@ -351,7 +488,8 @@ def test_rejected_evaluation_cannot_advance_pointer(tmp_path: Path) -> None:
         candidate_id=str(candidate["candidate_id"]),
         signed_evaluation=_signed_evaluation(
             archive,
-            str(candidate["candidate_id"]),
+            campaign,
+            candidate,
             accepted=False,
         ),
     )
@@ -393,6 +531,144 @@ def test_archive_rejects_self_attested_evaluation_mapping(tmp_path: Path) -> Non
                 "receipt_digest": f"sha256:{'0' * 64}",
             },
         )
+
+
+def test_campaign_requires_distinct_referee_and_executor_keys(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+
+    with pytest.raises(ArchiveError, match="executor and referee keys must be distinct"):
+        archive.create_campaign(
+            champion_commit=_CHAMPION_COMMIT,
+            champion_tree=_CHAMPION_TREE,
+            source_status_digest=_STATUS_DIGEST,
+            evaluation_config=EvaluationConfig().to_json(),
+            evaluation_suite=_suite_bytes(),
+            runner_image=_RUNNER_IMAGE,
+            referee_public_key=_REFEREE_PUBLIC_KEY,
+            executor_public_key=_REFEREE_PUBLIC_KEY,
+            proposal_input_artifact_ids=_proposal_inputs(archive),
+        )
+
+
+def test_evaluation_binding_rejects_missing_execution_envelope(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    campaign = _campaign(archive)
+    candidate = _register_test_candidate(archive, campaign)
+    champion = _execution_envelope(
+        archive,
+        campaign,
+        candidate,
+        case_id="capability-case",
+        repeat=1,
+        side="champion",
+        detected=0,
+    ).to_run_receipt()
+    challenger = _execution_envelope(
+        archive,
+        campaign,
+        candidate,
+        case_id="capability-case",
+        repeat=1,
+        side="candidate",
+        detected=1,
+    ).to_run_receipt()
+
+    with pytest.raises(ArchiveError, match="archive file is missing"):
+        archive.prepare_evaluation_binding(
+            str(candidate["candidate_id"]),
+            champion_receipts=(champion,),
+            candidate_receipts=(challenger,),
+        )
+
+
+def test_execution_envelope_rejects_wrong_key_and_wrong_side(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    campaign = _campaign(archive)
+    candidate = _register_test_candidate(archive, campaign)
+    wrong_key = _execution_envelope(
+        archive,
+        campaign,
+        candidate,
+        case_id="capability-case",
+        repeat=1,
+        side="champion",
+        detected=0,
+        private_key=b"w" * 32,
+    )
+    with pytest.raises(ArchiveError, match="valid executor attestation"):
+        archive.retain_execution_envelope(
+            str(candidate["candidate_id"]),
+            signed_envelope=wrong_key,
+        )
+
+    candidate_side = _retain_execution_receipt(
+        archive,
+        campaign,
+        candidate,
+        case_id="capability-case",
+        repeat=1,
+        side="candidate",
+        detected=1,
+    )
+    with pytest.raises(ArchiveError, match="bound to the wrong side"):
+        archive.prepare_evaluation_binding(
+            str(candidate["candidate_id"]),
+            champion_receipts=(candidate_side,),
+            candidate_receipts=(candidate_side,),
+        )
+
+
+def test_evaluation_binding_rejects_receipt_drift_and_envelope_reuse(
+    tmp_path: Path,
+) -> None:
+    archive = _archive(tmp_path)
+    campaign = _campaign(archive)
+    candidate = _register_test_candidate(archive, campaign)
+    champion = _retain_execution_receipt(
+        archive,
+        campaign,
+        candidate,
+        case_id="capability-case",
+        repeat=1,
+        side="champion",
+        detected=0,
+    )
+
+    with pytest.raises(ArchiveError, match="differs from its signed execution"):
+        archive.prepare_evaluation_binding(
+            str(candidate["candidate_id"]),
+            champion_receipts=(replace(champion, physical_request_count=11),),
+            candidate_receipts=(champion,),
+        )
+    with pytest.raises(ArchiveError, match="reused across promotion receipt sets"):
+        archive.prepare_evaluation_binding(
+            str(candidate["candidate_id"]),
+            champion_receipts=(champion,),
+            candidate_receipts=(champion,),
+        )
+
+
+def test_archive_verification_recomputes_linked_execution_evidence(tmp_path: Path) -> None:
+    archive = _archive(tmp_path)
+    campaign = _campaign(archive)
+    candidate = _register_test_candidate(archive, campaign)
+    evaluation = archive.record_evaluation(
+        candidate_id=str(candidate["candidate_id"]),
+        signed_evaluation=_signed_evaluation(
+            archive,
+            campaign,
+            candidate,
+            accepted=True,
+        ),
+    )
+
+    manifest, receipt = archive.evaluation_receipt(str(evaluation["evaluation_id"]))
+    verification = archive.verify()
+
+    assert manifest == evaluation
+    assert receipt.accepted is True
+    assert verification.artifacts == _SIGNED_EVALUATION_ARTIFACTS
+    assert verification.ledger_events == _SIGNED_EVALUATION_LEDGER_EVENTS
 
 
 def test_export_copies_patch_without_applying_or_overwriting(tmp_path: Path) -> None:
@@ -688,6 +964,7 @@ def test_archive_completed_retries_are_idempotent(tmp_path: Path) -> None:
         "evaluation_suite": _suite_bytes(),
         "runner_image": _RUNNER_IMAGE,
         "referee_public_key": _REFEREE_PUBLIC_KEY,
+        "executor_public_key": _EXECUTOR_PUBLIC_KEY,
         "proposal_input_artifact_ids": inputs,
     }
     first_campaign = archive.create_campaign(**arguments)
@@ -708,7 +985,8 @@ def test_archive_completed_retries_are_idempotent(tmp_path: Path) -> None:
     assert archive.register_candidate(**candidate_arguments) == candidate
     signed = _signed_evaluation(
         archive,
-        str(candidate["candidate_id"]),
+        first_campaign,
+        candidate,
         accepted=True,
     )
     evaluation = archive.record_evaluation(
@@ -722,7 +1000,7 @@ def test_archive_completed_retries_are_idempotent(tmp_path: Path) -> None:
         )
         == evaluation
     )
-    assert archive.verify().ledger_events == _FIVE_LEDGER_EVENTS
+    assert archive.verify().ledger_events == _SIGNED_EVALUATION_LEDGER_EVENTS
 
 
 def test_candidate_brief_must_be_strict_and_match_its_exact_corpus(tmp_path: Path) -> None:
@@ -772,6 +1050,7 @@ def test_candidate_brief_must_be_strict_and_match_its_exact_corpus(tmp_path: Pat
             evaluation_suite=_suite_bytes(),
             runner_image=_RUNNER_IMAGE,
             referee_public_key=_REFEREE_PUBLIC_KEY,
+            executor_public_key=_EXECUTOR_PUBLIC_KEY,
             proposal_input_artifact_ids=(
                 str(corpus_manifest["artifact_id"]),
                 str(brief_manifest["artifact_id"]),
@@ -798,7 +1077,8 @@ def test_stale_sibling_cannot_replace_accepted_candidate(tmp_path: Path) -> None
             candidate_id=str(candidate["candidate_id"]),
             signed_evaluation=_signed_evaluation(
                 archive,
-                str(candidate["candidate_id"]),
+                campaign,
+                candidate,
                 accepted=True,
             ),
         )
@@ -847,7 +1127,8 @@ def test_archive_rolls_to_new_reviewed_campaign_after_acceptance(tmp_path: Path)
         candidate_id=str(candidate["candidate_id"]),
         signed_evaluation=_signed_evaluation(
             archive,
-            str(candidate["candidate_id"]),
+            campaign,
+            candidate,
             accepted=True,
         ),
     )
@@ -875,6 +1156,7 @@ def test_archive_rolls_to_new_reviewed_campaign_after_acceptance(tmp_path: Path)
         evaluation_suite=_suite_bytes("sealed-b"),
         runner_image=_RUNNER_IMAGE,
         referee_public_key=_REFEREE_PUBLIC_KEY,
+        executor_public_key=_EXECUTOR_PUBLIC_KEY,
         proposal_input_artifact_ids=archive.candidate_input_artifact_ids(
             str(candidate["candidate_id"])
         ),
@@ -907,7 +1189,8 @@ def test_evaluation_signature_cannot_be_rebound_or_change_campaign_policy(tmp_pa
     )
     signed_first = _signed_evaluation(
         archive,
-        str(first["candidate_id"]),
+        campaign,
+        first,
         accepted=True,
     )
     with pytest.raises(ArchiveError, match="does not match"):
@@ -916,7 +1199,12 @@ def test_evaluation_signature_cannot_be_rebound_or_change_campaign_policy(tmp_pa
             signed_evaluation=signed_first,
         )
 
-    champion, candidate_receipts = _receipt_sets(accepted=True)
+    champion, candidate_receipts = _receipt_sets(
+        archive,
+        campaign,
+        first,
+        accepted=True,
+    )
     binding = archive.prepare_evaluation_binding(
         str(first["candidate_id"]),
         champion_receipts=champion,

--- a/tests/improvement_lab/test_cli.py
+++ b/tests/improvement_lab/test_cli.py
@@ -7,21 +7,36 @@ import stat
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import pytest
+
 from tools.improvement_lab import cli
 from tools.improvement_lab.archive import LabArchive
-from tools.improvement_lab.attestation import generate_referee_keypair, write_referee_key
+from tools.improvement_lab.attestation import (
+    generate_referee_keypair,
+    public_key_from_private,
+    write_referee_key,
+)
 from tools.improvement_lab.corpus import CorpusFormatError, candidate_visible_export
 from tools.improvement_lab.evaluation import (
     EvaluationConfig,
     RunReceipt,
+    canonical_run_receipts_bytes,
     evaluation_suite_from_receipts,
 )
+from tools.improvement_lab.execution_attestation import (
+    ExecutionBinding,
+    ExternalRunObservations,
+    FindingVerdict,
+    SignedExecutionEnvelope,
+    canonical_execution_envelope_bytes,
+    sign_execution_envelope,
+    write_signed_execution_envelope,
+)
 from tools.improvement_lab.lessons import build_improvement_brief
+from tools.improvement_lab.offline_executor import freeze_output_tree
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 _PRIVATE_FILE_MODE = 0o600
 _CLI_ERROR = 2
@@ -82,6 +97,10 @@ def _write_private_key(path: Path) -> None:
     path.chmod(0o600)
 
 
+def _digest(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode()).hexdigest()}"
+
+
 def _run_receipt(
     *,
     case_id: str,
@@ -90,9 +109,6 @@ def _run_receipt(
     detected: int,
     side: str,
 ) -> dict[str, object]:
-    def digest(value: str) -> str:
-        return f"sha256:{hashlib.sha256(value.encode()).hexdigest()}"
-
     return {
         "case_id": case_id,
         "cohort": "control" if control else "capability",
@@ -102,11 +118,14 @@ def _run_receipt(
         "is_control": control,
         "case_success": bool(detected),
         "expected_vulnerability_count": 1,
-        "run_id": digest(f"run:{side}:{case_id}:{repeat}"),
-        "pair_seed_digest": digest(f"seed:{case_id}:{repeat}"),
-        "target_snapshot_digest": digest(f"target:{case_id}"),
-        "model_fingerprint": digest("model:fixed"),
-        "prompt_fingerprint": digest(f"prompt:{side}"),
+        "run_id": _digest(f"run:{side}:{case_id}:{repeat}"),
+        "execution_attestation_digest": _digest(
+            f"attestation:{side}:{case_id}:{repeat}"
+        ),
+        "pair_seed_digest": _digest(f"seed:{case_id}:{repeat}"),
+        "target_snapshot_digest": _digest(f"target:{case_id}"),
+        "model_fingerprint": _digest("model:fixed"),
+        "prompt_fingerprint": _digest(f"prompt:{side}"),
         "metrics": {
             "evidence_backed_vulnerability_count": detected,
             "verified_vulnerability_count": detected,
@@ -126,6 +145,79 @@ def _run_receipt(
             "request_accounting_status": "exact",
         },
     }
+
+
+def _sign_run_receipt(  # noqa: PLR0913 - fixture exposes each signed binding input.
+    receipt: RunReceipt,
+    *,
+    campaign_id: str,
+    candidate_id: str,
+    evaluation_suite_object: str,
+    trusted_tests_digest: str,
+    runner_image: str,
+    champion_tree: str,
+    executor_private_key: bytes,
+    side: str,
+) -> SignedExecutionEnvelope:
+    binding = ExecutionBinding(
+        campaign_id=campaign_id,
+        candidate_id=None if side == "champion" else candidate_id,
+        candidate_tree_digest=(champion_tree if side == "champion" else "f" * 40),
+        candidate_content_digest=_digest(
+            f"candidate-content:{side}:{receipt.case_id}:{receipt.repeat}"
+        ),
+        evaluation_suite_object=evaluation_suite_object,
+        trusted_tests_digest=trusted_tests_digest,
+        runner_image=runner_image,
+        job_spec_digest=_digest(f"job:{side}:{receipt.case_id}:{receipt.repeat}"),
+        artifact_tree_digest=_digest(
+            f"artifacts:{side}:{receipt.case_id}:{receipt.repeat}"
+        ),
+        artifact_case_path="case",
+        case_id=receipt.case_id,
+        cohort=receipt.cohort,
+        repeat=receipt.repeat,
+        execution_kind=receipt.execution_kind,
+        evaluation_side=side,
+        is_control=receipt.is_control,
+        expected_vulnerability_count=receipt.expected_vulnerability_count,
+        run_id=receipt.run_id,
+        pair_seed_digest=receipt.pair_seed_digest,
+        target_snapshot_digest=receipt.target_snapshot_digest,
+        model_fingerprint=receipt.model_fingerprint,
+        prompt_fingerprint=receipt.prompt_fingerprint,
+    )
+    observations = ExternalRunObservations(
+        status=receipt.status,
+        case_success=receipt.case_success,
+        physical_request_count=receipt.physical_request_count,
+        model_request_count=receipt.model_request_count,
+        cost_usd=receipt.cost_usd,
+        request_accounting_status=receipt.request_accounting_status,
+        proof_integrity_failure_count=receipt.proof_integrity_failure_count,
+        false_proof_count=receipt.false_proof_count,
+        request_accounting_mismatch_count=receipt.request_accounting_mismatch_count,
+        loop_violation_count=receipt.loop_violation_count,
+        provenance_violation_count=receipt.provenance_violation_count,
+        secret_leak_violation_count=receipt.secret_leak_violation_count,
+        unmetered_action_count=receipt.unmetered_action_count,
+        incomplete_request_count=receipt.incomplete_request_count,
+    )
+    verdicts = tuple(
+        FindingVerdict(
+            finding_digest=_digest(
+                f"finding:{side}:{receipt.case_id}:{receipt.repeat}:{index}"
+            ),
+            stage="confirmed_finding",
+        )
+        for index in range(receipt.confirmed_finding_count)
+    )
+    return sign_execution_envelope(
+        binding,
+        observations,
+        verdicts,
+        private_key=executor_private_key,
+    )
 
 
 def test_keygen_and_ingest_previous_log_create_private_secret_safe_corpus(
@@ -177,6 +269,51 @@ def test_keygen_and_ingest_previous_log_create_private_secret_safe_corpus(
         == _CLI_ERROR
     )
     assert "group or other" in capsys.readouterr().err
+
+
+def test_executor_keygen_creates_a_distinct_keypair_with_owner_only_private_key(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    referee_private = tmp_path / "referee.private"
+    referee_public = tmp_path / "referee.public"
+    executor_private = tmp_path / "executor.private"
+    executor_public = tmp_path / "executor.public"
+
+    assert (
+        cli.main(
+            (
+                "referee-keygen",
+                "--private-key",
+                str(referee_private),
+                "--public-key",
+                str(referee_public),
+            )
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        cli.main(
+            (
+                "executor-keygen",
+                "--private-key",
+                str(executor_private),
+                "--public-key",
+                str(executor_public),
+            )
+        )
+        == 0
+    )
+
+    assert executor_private.read_bytes() != referee_private.read_bytes()
+    assert executor_public.read_bytes() != referee_public.read_bytes()
+    assert public_key_from_private(executor_private.read_bytes()) == (
+        executor_public.read_bytes()
+    )
+    assert stat.S_IMODE(executor_private.stat().st_mode) == _PRIVATE_FILE_MODE
+    assert stat.S_IMODE(referee_private.stat().st_mode) == _PRIVATE_FILE_MODE
+    assert json.loads(capsys.readouterr().out)["created"] is True
 
 
 def test_cli_rejects_ambiguous_json_configuration(
@@ -283,16 +420,85 @@ def test_brief_cli_derives_versioned_candidate_input(
     assert stat.S_IMODE(brief_path.stat().st_mode) == _PRIVATE_FILE_MODE
 
 
+def test_campaign_create_requires_and_forwards_a_separate_executor_key(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _referee_private, referee_public = generate_referee_keypair()
+    _executor_private, executor_public = generate_referee_keypair()
+    referee_public_path = tmp_path / "referee.public"
+    executor_public_path = tmp_path / "executor.public"
+    write_referee_key(referee_public_path, referee_public, public=True)
+    write_referee_key(executor_public_path, executor_public, public=True)
+    evaluation_config = tmp_path / "evaluation-config.json"
+    evaluation_suite = tmp_path / "evaluation-suite.json"
+    evaluation_config.write_text("{}\n", encoding="utf-8")
+    evaluation_suite.write_text("{}\n", encoding="utf-8")
+    argv = (
+        "campaign-create",
+        "--archive",
+        str(tmp_path / "archive"),
+        "--source",
+        str(tmp_path / "source"),
+        "--evaluation-config",
+        str(evaluation_config),
+        "--evaluation-suite",
+        str(evaluation_suite),
+        "--runner-image",
+        f"example.invalid/referee@sha256:{'d' * 64}",
+        "--referee-public-key",
+        str(referee_public_path),
+        "--executor-public-key",
+        str(executor_public_path),
+        "--candidate-artifact-id",
+        f"artifact_{'a' * 24}",
+    )
+    executor_option = argv.index("--executor-public-key")
+    without_executor = argv[:executor_option] + argv[executor_option + 2 :]
+    with pytest.raises(SystemExit) as missing:
+        cli.build_parser().parse_args(without_executor)
+    assert missing.value.code == _CLI_ERROR
+    capsys.readouterr()
+
+    captured: dict[str, object] = {}
+
+    def create_campaign(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"campaign_id": f"campaign_{'b' * 24}"}
+
+    archive = SimpleNamespace(
+        create_campaign=create_campaign,
+        current_pointer=lambda: {"champion_ref": f"source:{'c' * 40}"},
+    )
+    monkeypatch.setattr(cli, "_verified_archive", lambda _path: archive)
+    monkeypatch.setattr(
+        cli,
+        "require_clean_champion",
+        lambda _path: SimpleNamespace(
+            head_commit="c" * 40,
+            tree_digest="d" * 40,
+            status_digest="e" * 64,
+        ),
+    )
+
+    assert cli.main(argv) == 0
+    assert captured["referee_public_key"] == referee_public
+    assert captured["executor_public_key"] == executor_public
+    assert captured["executor_public_key"] != captured["referee_public_key"]
+
+
 def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) -> None:
     archive_path = tmp_path / "archive"
     archive = LabArchive.initialize(archive_path)
     private_key, public_key = generate_referee_keypair()
+    executor_private_key, executor_public_key = generate_referee_keypair()
     private_key_path = tmp_path / "referee.private"
     write_referee_key(private_key_path, private_key, public=False)
-    champion: list[dict[str, object]] = []
-    candidate: list[dict[str, object]] = []
+    champion_inputs: list[dict[str, object]] = []
+    candidate_inputs: list[dict[str, object]] = []
     for repeat in range(1, 4):
-        champion.append(
+        champion_inputs.append(
             _run_receipt(
                 case_id="opaque-capability",
                 repeat=repeat,
@@ -301,7 +507,7 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
                 side="champion",
             )
         )
-        candidate.append(
+        candidate_inputs.append(
             _run_receipt(
                 case_id="opaque-capability",
                 repeat=repeat,
@@ -310,7 +516,7 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
                 side="candidate",
             )
         )
-        champion.append(
+        champion_inputs.append(
             _run_receipt(
                 case_id="opaque-control",
                 repeat=repeat,
@@ -319,7 +525,7 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
                 side="champion",
             )
         )
-        candidate.append(
+        candidate_inputs.append(
             _run_receipt(
                 case_id="opaque-control",
                 repeat=repeat,
@@ -328,7 +534,7 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
                 side="candidate",
             )
         )
-    parsed_champion = tuple(RunReceipt.from_mapping(item) for item in champion)
+    parsed_champion = tuple(RunReceipt.from_mapping(item) for item in champion_inputs)
     suite = evaluation_suite_from_receipts(
         parsed_champion,
         trusted_tests_digest=f"sha256:{'e' * 64}",
@@ -353,6 +559,7 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
         evaluation_suite=json.dumps(suite.to_json()).encode(),
         runner_image=f"example.invalid/referee@sha256:{'d' * 64}",
         referee_public_key=public_key,
+        executor_public_key=executor_public_key,
         proposal_input_artifact_ids=(
             str(corpus_manifest["artifact_id"]),
             str(brief_manifest["artifact_id"]),
@@ -366,11 +573,36 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
         config={"hypothesis": "test"},
     )
     candidate_id = str(candidate_manifest["candidate_id"])
+    signed_receipts: dict[str, list[RunReceipt]] = {
+        "champion": [],
+        "candidate": [],
+    }
+    for side, inputs in (
+        ("champion", champion_inputs),
+        ("candidate", candidate_inputs),
+    ):
+        for item in inputs:
+            envelope = _sign_run_receipt(
+                RunReceipt.from_mapping(item),
+                campaign_id=str(campaign["campaign_id"]),
+                candidate_id=candidate_id,
+                evaluation_suite_object=str(campaign["evaluation_suite_object"]),
+                trusted_tests_digest=suite.trusted_tests_digest,
+                runner_image=str(campaign["runner_image"]),
+                champion_tree=str(campaign["champion_tree"]),
+                executor_private_key=executor_private_key,
+                side=side,
+            )
+            archive.retain_execution_envelope(
+                candidate_id,
+                signed_envelope=envelope,
+            )
+            signed_receipts[side].append(envelope.to_run_receipt())
     champion_path = tmp_path / "champion.json"
     candidate_path = tmp_path / "candidate.json"
     output = tmp_path / "evaluation.json"
-    champion_path.write_text(json.dumps(champion), encoding="utf-8")
-    candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+    champion_path.write_bytes(canonical_run_receipts_bytes(signed_receipts["champion"]))
+    candidate_path.write_bytes(canonical_run_receipts_bytes(signed_receipts["candidate"]))
 
     assert (
         cli.main(
@@ -412,6 +644,182 @@ def test_evaluate_cli_accepts_only_repeated_matched_improvement(tmp_path: Path) 
         )
         == 0
     )
+
+
+def test_receipt_build_retains_signed_envelope_and_writes_canonical_receipt(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    archive_path = tmp_path / "archive"
+    archive = LabArchive.initialize(archive_path)
+    _referee_private, referee_public = generate_referee_keypair()
+    executor_private, executor_public = generate_referee_keypair()
+    suite_inputs = tuple(
+        RunReceipt.from_mapping(
+            _run_receipt(
+                case_id="receipt-case",
+                repeat=repeat,
+                control=False,
+                detected=0,
+                side="champion",
+            )
+        )
+        for repeat in range(1, 4)
+    )
+    suite = evaluation_suite_from_receipts(
+        suite_inputs,
+        trusted_tests_digest=_digest("trusted-tests"),
+        runner_command=("/usr/local/bin/python", "-I", "/trusted-tests/referee.py"),
+    )
+    corpus = candidate_visible_export([])
+    corpus_manifest = archive.record_artifact(
+        kind="development_corpus",
+        visibility="candidate",
+        content=json.dumps(corpus).encode(),
+    )
+    brief_manifest = archive.record_artifact(
+        kind="capability_brief",
+        visibility="candidate",
+        content=json.dumps(build_improvement_brief(corpus)).encode(),
+    )
+    runner_image = f"example.invalid/referee@sha256:{'d' * 64}"
+    campaign = archive.create_campaign(
+        champion_commit="a" * 40,
+        champion_tree="b" * 40,
+        source_status_digest=_digest("clean-source"),
+        evaluation_config=EvaluationConfig().to_json(),
+        evaluation_suite=json.dumps(suite.to_json()).encode(),
+        runner_image=runner_image,
+        referee_public_key=referee_public,
+        executor_public_key=executor_public,
+        proposal_input_artifact_ids=(
+            str(corpus_manifest["artifact_id"]),
+            str(brief_manifest["artifact_id"]),
+        ),
+    )
+    candidate = archive.register_candidate(
+        campaign_id=str(campaign["campaign_id"]),
+        parent_ref=str(archive.current_pointer()["champion_ref"]),
+        artifact_kind="source_patch",
+        patch=b"candidate patch",
+        config={"hypothesis": "receipt adapter"},
+    )
+    candidate_id = str(candidate["candidate_id"])
+
+    artifact_root = tmp_path / "artifacts"
+    case_root = artifact_root / "case-one"
+    traffic_root = case_root / "workspace"
+    traffic_root.mkdir(parents=True)
+    (case_root / "report.json").write_text(
+        json.dumps(
+            {
+                "findings": [],
+                "outcome": {"evidence": []},
+                "traffic_accounting": {
+                    "status": "exact",
+                    "physical_request_count": 4,
+                    "incomplete_request_count": 0,
+                    "unmetered_action_count": 0,
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (traffic_root / "traffic-policy.json").write_text(
+        json.dumps(
+            {
+                "schema": "ravage.traffic-policy",
+                "physical_request_count": 4,
+                "incomplete_request_count": 0,
+                "unmetered_action_count": 0,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    frozen = freeze_output_tree(artifact_root)
+    suite_receipt = suite_inputs[0]
+    envelope = sign_execution_envelope(
+        ExecutionBinding(
+            campaign_id=str(campaign["campaign_id"]),
+            candidate_id=candidate_id,
+            candidate_tree_digest="f" * 40,
+            candidate_content_digest=_digest("candidate-content"),
+            evaluation_suite_object=str(campaign["evaluation_suite_object"]),
+            trusted_tests_digest=suite.trusted_tests_digest,
+            runner_image=runner_image,
+            job_spec_digest=_digest("job-spec"),
+            artifact_tree_digest=frozen.digest,
+            artifact_case_path="case-one",
+            case_id=suite_receipt.case_id,
+            cohort=suite_receipt.cohort,
+            repeat=suite_receipt.repeat,
+            execution_kind=suite_receipt.execution_kind,
+            evaluation_side="candidate",
+            is_control=suite_receipt.is_control,
+            expected_vulnerability_count=suite_receipt.expected_vulnerability_count,
+            run_id=_digest("candidate-run"),
+            pair_seed_digest=suite_receipt.pair_seed_digest,
+            target_snapshot_digest=suite_receipt.target_snapshot_digest,
+            model_fingerprint=suite_receipt.model_fingerprint,
+            prompt_fingerprint=_digest("candidate-prompt"),
+        ),
+        ExternalRunObservations(
+            status="completed",
+            case_success=False,
+            physical_request_count=4,
+            model_request_count=2,
+            cost_usd=0.1,
+            request_accounting_status="exact",
+            proof_integrity_failure_count=0,
+            false_proof_count=0,
+            request_accounting_mismatch_count=0,
+            loop_violation_count=0,
+            provenance_violation_count=0,
+            secret_leak_violation_count=0,
+            unmetered_action_count=0,
+            incomplete_request_count=0,
+        ),
+        (),
+        private_key=executor_private,
+    )
+    envelope_path = tmp_path / "execution-envelope.json"
+    receipt_path = tmp_path / "receipt.json"
+    write_signed_execution_envelope(envelope_path, envelope)
+
+    assert (
+        cli.main(
+            (
+                "receipt-build",
+                "--archive",
+                str(archive_path),
+                "--candidate-id",
+                candidate_id,
+                "--artifacts",
+                str(artifact_root),
+                "--execution-envelope",
+                str(envelope_path),
+                "--output",
+                str(receipt_path),
+            )
+        )
+        == 0
+    )
+
+    expected_receipt = envelope.to_run_receipt()
+    assert receipt_path.read_bytes() == canonical_run_receipts_bytes((expected_receipt,))
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == _PRIVATE_FILE_MODE
+    assert archive.read_object(
+        str(expected_receipt.execution_attestation_digest)
+    ) == canonical_execution_envelope_bytes(envelope)
+    result = json.loads(capsys.readouterr().out)
+    assert result["case_id"] == suite_receipt.case_id
+    assert result["evaluation_side"] == "candidate"
+    assert result["execution_attestation_digest"] == (
+        expected_receipt.execution_attestation_digest
+    )
+    assert str(result["artifact_id"]).startswith("artifact_")
 
 
 def test_archive_cli_records_and_verifies_immutable_artifact(

--- a/tests/improvement_lab/test_cli_workflow.py
+++ b/tests/improvement_lab/test_cli_workflow.py
@@ -10,18 +10,32 @@ from tools.improvement_lab.archive import APPROVAL_SCHEMA_VERSION
 from tools.improvement_lab.corpus import candidate_visible_export
 from tools.improvement_lab.evaluation import (
     EvaluationConfig,
+    EvaluationSuite,
+    EvaluationSuiteCase,
     RunReceipt,
-    evaluation_suite_from_receipts,
+    canonical_run_receipts_bytes,
+    load_canonical_run_receipts,
+)
+from tools.improvement_lab.execution_attestation import (
+    ExecutionBinding,
+    ExternalRunObservations,
+    FindingVerdict,
+    sign_execution_envelope,
+    write_signed_execution_envelope,
 )
 from tools.improvement_lab.lessons import build_improvement_brief
+from tools.improvement_lab.offline_executor import freeze_output_tree
+from tools.improvement_lab.run_receipt_adapter import finding_reference_digest
 from tools.improvement_lab.workspace import directory_tree_digest
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     import pytest
 
 _PROMOTION_REQUIRED_BUT_REJECTED = 3
+_RUNNER_IMAGE = f"example.invalid/referee@sha256:{'a' * 64}"
 
 
 def _digest(value: str) -> str:
@@ -55,83 +69,30 @@ def _source_repo(root: Path) -> None:
     _git(root, "commit", "-m", "champion")
 
 
-def _run_receipt(
-    *,
-    case_id: str,
-    repeat: int,
-    control: bool,
-    side: str,
-    detected: int,
-) -> dict[str, object]:
-    expected = 0 if control else 1
-    return {
-        "case_id": case_id,
-        "cohort": "control" if control else "capability",
-        "repeat": repeat,
-        "execution_kind": "fixture",
-        "status": "completed",
-        "is_control": control,
-        "case_success": True if control else None,
-        "expected_vulnerability_count": expected,
-        "run_id": _digest(f"run:{side}:{case_id}:{repeat}"),
-        "pair_seed_digest": _digest(f"seed:{case_id}:{repeat}"),
-        "target_snapshot_digest": _digest(f"snapshot:{case_id}:{repeat}"),
-        "model_fingerprint": _digest("model:fixed"),
-        "prompt_fingerprint": _digest(f"prompt:{side}"),
-        "metrics": {
-            "evidence_backed_vulnerability_count": detected,
-            "verified_vulnerability_count": detected,
-            "confirmed_finding_count": detected,
-            "suspected_vulnerability_count": 0,
-            "proof_integrity_failure_count": 0,
-            "false_proof_count": 0,
-            "request_accounting_mismatch_count": 0,
-            "loop_violation_count": 0,
-            "provenance_violation_count": 0,
-            "secret_leak_violation_count": 0,
-            "unmetered_action_count": 0,
-            "incomplete_request_count": 0,
-            "physical_request_count": 4,
-            "model_request_count": 2,
-            "cost_usd": 0.1,
-            "request_accounting_status": "exact",
-        },
-    }
-
-
-def _receipt_sets(*, improved: bool) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
-    champion: list[dict[str, object]] = []
-    candidate: list[dict[str, object]] = []
-    for repeat in range(1, 4):
-        champion.append(
-            _run_receipt(
-                case_id="opaque-capability",
-                repeat=repeat,
-                control=False,
-                side="champion",
-                detected=0,
-            )
+def _evaluation_suite(trusted_tests: Path) -> EvaluationSuite:
+    cases = tuple(
+        EvaluationSuiteCase(
+            case_id=case_id,
+            cohort="control" if control else "capability",
+            execution_kind="fixture",
+            repeats=3,
+            is_control=control,
+            expected_vulnerability_count=0 if control else 1,
+            target_snapshot_digests=tuple(
+                _digest(f"snapshot:{case_id}:{repeat}") for repeat in range(1, 4)
+            ),
         )
-        candidate.append(
-            _run_receipt(
-                case_id="opaque-capability",
-                repeat=repeat,
-                control=False,
-                side="candidate",
-                detected=1 if improved else 0,
-            )
+        for case_id, control in (
+            ("opaque-capability", False),
+            ("opaque-control", True),
         )
-        for side, output in (("champion", champion), ("candidate", candidate)):
-            output.append(
-                _run_receipt(
-                    case_id="opaque-control",
-                    repeat=repeat,
-                    control=True,
-                    side=side,
-                    detected=0,
-                )
-            )
-    return champion, candidate
+    )
+    return EvaluationSuite(
+        cases=cases,
+        model_fingerprint=_digest("model:fixed"),
+        trusted_tests_digest=directory_tree_digest(trusted_tests),
+        runner_command=("/usr/local/bin/python", "-I", "/trusted-tests/trusted_referee.py"),
+    )
 
 
 def _call(
@@ -146,6 +107,192 @@ def _call(
     payload = json.loads(captured.out)
     assert isinstance(payload, dict)
     return payload
+
+
+def _write_attested_artifacts(root: Path, *, finding_id: str | None) -> None:
+    case_root = root / "case-output"
+    workspace = case_root / "workspace"
+    workspace.mkdir(parents=True)
+    findings = (
+        []
+        if finding_id is None
+        else [{"finding_id": finding_id, "status": "confirmed"}]
+    )
+    _write_json(
+        case_root / "report.json",
+        {
+            "findings": findings,
+            "outcome": {"evidence": []},
+            "traffic_accounting": {
+                "status": "exact",
+                "physical_request_count": 4,
+                "incomplete_request_count": 0,
+                "unmetered_action_count": 0,
+            },
+        },
+    )
+    _write_json(
+        workspace / "traffic-policy.json",
+        {
+            "schema": "ravage.traffic-policy",
+            "physical_request_count": 4,
+            "incomplete_request_count": 0,
+            "unmetered_action_count": 0,
+        },
+    )
+
+
+def _build_attested_receipt(  # noqa: PLR0913 - exposes the complete trust binding.
+    capsys: pytest.CaptureFixture[str],
+    *,
+    archive: Path,
+    evidence_root: Path,
+    campaign: Mapping[str, object],
+    candidate: Mapping[str, object],
+    suite: EvaluationSuite,
+    evaluation_suite_object: str,
+    champion_tree: str,
+    executor_private_key: bytes,
+    suite_case: EvaluationSuiteCase,
+    repeat: int,
+    side: str,
+    detected: int,
+) -> RunReceipt:
+    candidate_id = str(candidate["candidate_id"])
+    execution_scope = (
+        candidate_id if side == "candidate" else str(campaign["campaign_id"])
+    )
+    run_root = evidence_root / side / suite_case.case_id / f"repeat-{repeat}"
+    artifact_root = run_root / "artifacts"
+    finding_id = (
+        None
+        if detected == 0
+        else f"{candidate_id}:{side}:{suite_case.case_id}:{repeat}:finding"
+    )
+    _write_attested_artifacts(artifact_root, finding_id=finding_id)
+    frozen = freeze_output_tree(artifact_root)
+    patch_object = str(candidate["patch_object"])
+    envelope = sign_execution_envelope(
+        ExecutionBinding(
+            campaign_id=str(campaign["campaign_id"]),
+            candidate_id=candidate_id if side == "candidate" else None,
+            candidate_tree_digest=(
+                champion_tree if side == "champion" else patch_object.removeprefix("sha256:")
+            ),
+            candidate_content_digest=(
+                _digest(f"champion:{champion_tree}")
+                if side == "champion"
+                else patch_object
+            ),
+            evaluation_suite_object=evaluation_suite_object,
+            trusted_tests_digest=suite.trusted_tests_digest,
+            runner_image=_RUNNER_IMAGE,
+            job_spec_digest=_digest(
+                f"job:{execution_scope}:{side}:{suite_case.case_id}:{repeat}"
+            ),
+            artifact_tree_digest=frozen.digest,
+            artifact_case_path="case-output",
+            case_id=suite_case.case_id,
+            cohort=suite_case.cohort,
+            repeat=repeat,
+            execution_kind=suite_case.execution_kind,
+            evaluation_side=side,
+            is_control=suite_case.is_control,
+            expected_vulnerability_count=suite_case.expected_vulnerability_count,
+            run_id=_digest(
+                f"run:{execution_scope}:{side}:{suite_case.case_id}:{repeat}"
+            ),
+            pair_seed_digest=_digest(f"seed:{suite_case.case_id}:{repeat}"),
+            target_snapshot_digest=suite_case.target_snapshot_digests[repeat - 1],
+            model_fingerprint=suite.model_fingerprint,
+            prompt_fingerprint=_digest(f"prompt:{side}"),
+        ),
+        ExternalRunObservations(
+            status="completed",
+            case_success=True if suite_case.is_control else bool(detected),
+            physical_request_count=4,
+            model_request_count=2,
+            cost_usd=0.1,
+            request_accounting_status="exact",
+            proof_integrity_failure_count=0,
+            false_proof_count=0,
+            request_accounting_mismatch_count=0,
+            loop_violation_count=0,
+            provenance_violation_count=0,
+            secret_leak_violation_count=0,
+            unmetered_action_count=0,
+            incomplete_request_count=0,
+        ),
+        ()
+        if finding_id is None
+        else (FindingVerdict(finding_reference_digest(finding_id), "confirmed_finding"),),
+        private_key=executor_private_key,
+    )
+    envelope_path = run_root / "execution-envelope.json"
+    receipt_path = run_root / "receipt.json"
+    write_signed_execution_envelope(envelope_path, envelope)
+    result = _call(
+        capsys,
+        "receipt-build",
+        "--archive",
+        str(archive),
+        "--candidate-id",
+        candidate_id,
+        "--artifacts",
+        str(artifact_root),
+        "--execution-envelope",
+        str(envelope_path),
+        "--output",
+        str(receipt_path),
+    )
+    receipts = load_canonical_run_receipts(receipt_path.read_bytes())
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert result["execution_attestation_digest"] == receipt.execution_attestation_digest
+    assert result["evaluation_side"] == side
+    return receipt
+
+
+def _build_attested_receipt_set(  # noqa: PLR0913 - binds one full execution matrix.
+    capsys: pytest.CaptureFixture[str],
+    *,
+    archive: Path,
+    evidence_root: Path,
+    campaign: Mapping[str, object],
+    candidate: Mapping[str, object],
+    suite: EvaluationSuite,
+    evaluation_suite_object: str,
+    champion_tree: str,
+    executor_private_key: bytes,
+    side: str,
+    improved: bool,
+) -> tuple[RunReceipt, ...]:
+    receipts: list[RunReceipt] = []
+    for suite_case in suite.cases:
+        for repeat in range(1, suite_case.repeats + 1):
+            detected = int(
+                improved
+                and side == "candidate"
+                and not suite_case.is_control
+            )
+            receipts.append(
+                _build_attested_receipt(
+                    capsys,
+                    archive=archive,
+                    evidence_root=evidence_root,
+                    campaign=campaign,
+                    candidate=candidate,
+                    suite=suite,
+                    evaluation_suite_object=evaluation_suite_object,
+                    champion_tree=champion_tree,
+                    executor_private_key=executor_private_key,
+                    suite_case=suite_case,
+                    repeat=repeat,
+                    side=side,
+                    detected=detected,
+                )
+            )
+    return tuple(receipts)
 
 
 def test_complete_cli_campaign_is_reproducible_and_recoverable(  # noqa: PLR0915
@@ -171,6 +318,14 @@ def test_complete_cli_campaign_is_reproducible_and_recoverable(  # noqa: PLR0915
         str(lab / "referee.private"),
         "--public-key",
         str(lab / "referee.public"),
+    )
+    _call(
+        capsys,
+        "referee-keygen",
+        "--private-key",
+        str(lab / "executor.private"),
+        "--public-key",
+        str(lab / "executor.public"),
     )
 
     corpus = candidate_visible_export([])
@@ -204,12 +359,7 @@ def test_complete_cli_campaign_is_reproducible_and_recoverable(  # noqa: PLR0915
         str(brief_path),
     )
 
-    champion_receipts, improved_receipts = _receipt_sets(improved=True)
-    suite = evaluation_suite_from_receipts(
-        tuple(RunReceipt.from_mapping(item) for item in champion_receipts),
-        trusted_tests_digest=directory_tree_digest(trusted_tests),
-        runner_command=("/usr/local/bin/python", "-I", "/trusted-tests/trusted_referee.py"),
-    )
+    suite = _evaluation_suite(trusted_tests)
     config_path = lab / "evaluation-config.json"
     suite_path = lab / "evaluation-suite.json"
     _write_json(config_path, EvaluationConfig().to_json())
@@ -226,9 +376,11 @@ def test_complete_cli_campaign_is_reproducible_and_recoverable(  # noqa: PLR0915
         "--evaluation-suite",
         str(suite_path),
         "--runner-image",
-        f"example.invalid/referee@sha256:{'a' * 64}",
+        _RUNNER_IMAGE,
         "--referee-public-key",
         str(lab / "referee.public"),
+        "--executor-public-key",
+        str(lab / "executor.public"),
         "--candidate-artifact-id",
         str(corpus_artifact["artifact_id"]),
         "--candidate-artifact-id",
@@ -313,10 +465,51 @@ def test_complete_cli_campaign_is_reproducible_and_recoverable(  # noqa: PLR0915
     champion_path = lab / "champion-receipts.json"
     improved_path = lab / "improved-receipts.json"
     unchanged_path = lab / "unchanged-receipts.json"
-    _write_json(champion_path, champion_receipts)
-    _write_json(improved_path, improved_receipts)
-    _champion_again, unchanged_receipts = _receipt_sets(improved=False)
-    _write_json(unchanged_path, unchanged_receipts)
+    suite_object = f"sha256:{hashlib.sha256(suite_path.read_bytes()).hexdigest()}"
+    champion_tree = _git(source, "rev-parse", "HEAD^{tree}")
+    executor_private_key = (lab / "executor.private").read_bytes()
+    champion_receipts = _build_attested_receipt_set(
+        capsys,
+        archive=archive,
+        evidence_root=lab / "champion-execution-evidence",
+        campaign=campaign,
+        candidate=good,
+        suite=suite,
+        evaluation_suite_object=suite_object,
+        champion_tree=champion_tree,
+        executor_private_key=executor_private_key,
+        side="champion",
+        improved=False,
+    )
+    improved_receipts = _build_attested_receipt_set(
+        capsys,
+        archive=archive,
+        evidence_root=lab / "good-execution-evidence",
+        campaign=campaign,
+        candidate=good,
+        suite=suite,
+        evaluation_suite_object=suite_object,
+        champion_tree=champion_tree,
+        executor_private_key=executor_private_key,
+        side="candidate",
+        improved=True,
+    )
+    unchanged_receipts = _build_attested_receipt_set(
+        capsys,
+        archive=archive,
+        evidence_root=lab / "bad-execution-evidence",
+        campaign=campaign,
+        candidate=bad,
+        suite=suite,
+        evaluation_suite_object=suite_object,
+        champion_tree=champion_tree,
+        executor_private_key=executor_private_key,
+        side="candidate",
+        improved=False,
+    )
+    champion_path.write_bytes(canonical_run_receipts_bytes(champion_receipts))
+    improved_path.write_bytes(canonical_run_receipts_bytes(improved_receipts))
+    unchanged_path.write_bytes(canonical_run_receipts_bytes(unchanged_receipts))
 
     good_signed = lab / "good.signed.json"
     good_result = _call(

--- a/tests/improvement_lab/test_evaluation.py
+++ b/tests/improvement_lab/test_evaluation.py
@@ -11,6 +11,8 @@ import pytest
 
 from tools.improvement_lab.evaluation import (
     EVALUATION_SCHEMA_VERSION,
+    RUN_RECEIPT_SCHEMA_VERSION,
+    RUN_RECEIPT_SET_SCHEMA_VERSION,
     EvaluationConfig,
     RunReceipt,
     canonical_run_receipts_bytes,
@@ -59,6 +61,9 @@ def _receipt(  # noqa: PLR0913 - the receipt fixture mirrors the public schema.
         "case_success": success,
         "expected_vulnerability_count": expected,
         "run_id": digest(f"run:{side}:{case_id}:{repeat}"),
+        "execution_attestation_digest": digest(
+            f"attestation:{side}:{case_id}:{repeat}"
+        ),
         "pair_seed_digest": digest(f"seed:{case_id}:{repeat}"),
         "target_snapshot_digest": digest(f"target:{case_id}:{repeat}"),
         "model_fingerprint": digest("model:fixed"),
@@ -152,6 +157,16 @@ def _metrics(item: dict[str, object]) -> dict[str, object]:
     metrics = item["metrics"]
     assert isinstance(metrics, dict)
     return metrics
+
+
+def _canonical_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
 
 
 def test_repeated_evidence_backed_improvement_promotes() -> None:
@@ -381,6 +396,18 @@ def test_repeat_labels_cannot_reuse_execution_or_seed_attestations() -> None:
     assert "duplicate_execution_attestation" in _codes(receipt)
 
 
+def test_repeat_labels_cannot_reuse_signed_execution_attestations() -> None:
+    champion, candidate = _passing_panel()
+    first = _candidate_item(candidate, case_id="capability-case", repeat=1)
+    second = _candidate_item(candidate, case_id="capability-case", repeat=2)
+    second["execution_attestation_digest"] = first["execution_attestation_digest"]
+
+    receipt = evaluate_candidate(champion, candidate)
+
+    assert receipt.accepted is False
+    assert "duplicate_execution_attestation" in _codes(receipt)
+
+
 def test_matched_runs_require_same_seed_snapshot_and_distinct_sessions() -> None:
     champion, candidate = _passing_panel()
     champion_item = _candidate_item(champion, case_id="capability-case", repeat=1)
@@ -470,6 +497,51 @@ def test_run_receipt_loader_uses_the_same_fail_closed_schema(tmp_path: Path) -> 
         load_run_receipts(path)
 
 
+@pytest.mark.parametrize("execution_kind", ["fixture", "live"])
+@pytest.mark.parametrize("attestation_field", ["missing", "null"])
+def test_promotable_run_receipt_requires_execution_attestation_digest(
+    execution_kind: str,
+    attestation_field: str,
+) -> None:
+    payload = _receipt(
+        "promotable-case",
+        1,
+        cohort="development_failure",
+        control=False,
+        side="candidate",
+        execution_kind=execution_kind,
+    )
+    if attestation_field == "null":
+        payload["execution_attestation_digest"] = None
+    else:
+        del payload["execution_attestation_digest"]
+
+    with pytest.raises(ValueError, match="execution_attestation_digest"):
+        RunReceipt.from_mapping(payload)
+
+
+@pytest.mark.parametrize("attestation_field", ["missing", "null"])
+def test_historical_run_receipt_accepts_missing_or_null_execution_attestation(
+    attestation_field: str,
+) -> None:
+    payload = _receipt(
+        "historical-case",
+        1,
+        cohort="historical_failure",
+        control=False,
+        side="candidate",
+        execution_kind="historical_replay",
+    )
+    if attestation_field == "null":
+        payload["execution_attestation_digest"] = None
+    else:
+        del payload["execution_attestation_digest"]
+
+    receipt = RunReceipt.from_mapping(payload)
+
+    assert receipt.execution_attestation_digest is None
+
+
 def test_campaign_suite_rejects_a_favorable_subset() -> None:
     champion, candidate = _passing_panel()
     parsed_champion = tuple(RunReceipt.from_mapping(item) for item in champion)
@@ -504,16 +576,69 @@ def test_campaign_suite_rejects_a_path_resolved_runner() -> None:
         )
 
 
-def test_retained_receipt_set_is_byte_canonical_and_replayable() -> None:
+def test_v2_retained_receipt_set_is_byte_canonical_and_replayable() -> None:
     champion, _candidate = _passing_panel()
     parsed = tuple(RunReceipt.from_mapping(item) for item in champion)
     encoded = canonical_run_receipts_bytes(parsed)
+    payload = json.loads(encoded)
 
+    assert payload["schema_version"] == RUN_RECEIPT_SET_SCHEMA_VERSION
+    assert {item["schema_version"] for item in payload["receipts"]} == {
+        RUN_RECEIPT_SCHEMA_VERSION
+    }
     assert load_canonical_run_receipts(encoded) == tuple(
         sorted(parsed, key=lambda item: (item.key, item.run_id))
     )
     with pytest.raises(ValueError, match="byte-canonical"):
         load_canonical_run_receipts(encoded + b"\n")
+
+
+def test_canonical_v1_historical_receipt_set_remains_replayable() -> None:
+    historical = _receipt(
+        "historical-case",
+        1,
+        cohort="historical_failure",
+        control=False,
+        side="champion",
+        execution_kind="historical_replay",
+    )
+    historical["schema_version"] = "ravage.improvement-run.v1"
+    del historical["execution_attestation_digest"]
+    encoded = _canonical_bytes(
+        {
+            "schema_version": "ravage.improvement-run-set.v1",
+            "receipts": [historical],
+        }
+    )
+
+    loaded = load_canonical_run_receipts(encoded)
+
+    assert len(loaded) == 1
+    assert loaded[0].execution_kind == "historical_replay"
+    assert loaded[0].execution_attestation_digest is None
+
+
+@pytest.mark.parametrize("execution_kind", ["fixture", "live"])
+def test_canonical_v1_promotable_receipt_set_is_rejected(execution_kind: str) -> None:
+    promotable = _receipt(
+        "promotable-case",
+        1,
+        cohort="development_failure",
+        control=False,
+        side="candidate",
+        execution_kind=execution_kind,
+    )
+    promotable["schema_version"] = "ravage.improvement-run.v1"
+    del promotable["execution_attestation_digest"]
+    encoded = _canonical_bytes(
+        {
+            "schema_version": "ravage.improvement-run-set.v1",
+            "receipts": [promotable],
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"execution_attestation_digest|legacy promotable"):
+        load_canonical_run_receipts(encoded)
 
 
 def test_config_enforces_three_or_more_repeats() -> None:

--- a/tests/improvement_lab/test_execution_attestation.py
+++ b/tests/improvement_lab/test_execution_attestation.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from copy import deepcopy
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tools.improvement_lab import execution_attestation as module
+from tools.improvement_lab.attestation import generate_referee_keypair, referee_key_id
+from tools.improvement_lab.evaluation import canonical_json
+from tools.improvement_lab.execution_attestation import (
+    EXECUTION_ATTESTATION_SCHEMA_VERSION,
+    ExecutionAttestationError,
+    ExecutionBinding,
+    ExternalRunObservations,
+    FindingVerdict,
+    SignedExecutionEnvelope,
+    execution_envelope_digest,
+    load_signed_execution_envelope,
+    sign_execution_envelope,
+    verify_signed_execution_envelope,
+    write_signed_execution_envelope,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_EXPECTED_EVIDENCE_BACKED = 3
+_EXPECTED_VERIFIED = 2
+_EXPECTED_PHYSICAL_REQUESTS = 17
+_PRIVATE_MODE = 0o600
+
+
+def _digest(character: str) -> str:
+    return f"sha256:{character * 64}"
+
+
+def _binding() -> ExecutionBinding:
+    return ExecutionBinding(
+        campaign_id=f"campaign_{'a' * 24}",
+        candidate_id=f"candidate_{'b' * 24}",
+        candidate_tree_digest="c" * 40,
+        candidate_content_digest=_digest("1"),
+        evaluation_suite_object=_digest("2"),
+        trusted_tests_digest=_digest("3"),
+        runner_image=f"example.invalid/evaluator@{_digest('4')}",
+        job_spec_digest=_digest("5"),
+        artifact_tree_digest=_digest("6"),
+        artifact_case_path="cases/capability-1/repeat-1",
+        case_id="capability-1",
+        cohort="sealed",
+        repeat=1,
+        execution_kind="live",
+        is_control=False,
+        expected_vulnerability_count=3,
+        run_id=_digest("7"),
+        pair_seed_digest=_digest("8"),
+        target_snapshot_digest=_digest("9"),
+        model_fingerprint=_digest("a"),
+        prompt_fingerprint=_digest("b"),
+    )
+
+
+def _observations() -> ExternalRunObservations:
+    return ExternalRunObservations(
+        status="completed",
+        case_success=None,
+        physical_request_count=17,
+        model_request_count=4,
+        cost_usd=0.125,
+        request_accounting_status="exact",
+        proof_integrity_failure_count=0,
+        false_proof_count=0,
+        request_accounting_mismatch_count=0,
+        loop_violation_count=0,
+        provenance_violation_count=0,
+        secret_leak_violation_count=0,
+        unmetered_action_count=0,
+        incomplete_request_count=0,
+    )
+
+
+def _verdicts() -> tuple[FindingVerdict, ...]:
+    return (
+        FindingVerdict(_digest("1"), "suspected_vulnerability"),
+        FindingVerdict(_digest("2"), "evidence_backed_vulnerability"),
+        FindingVerdict(_digest("3"), "verified_vulnerability"),
+        FindingVerdict(_digest("4"), "confirmed_finding"),
+    )
+
+
+def _signed() -> tuple[SignedExecutionEnvelope, bytes, bytes]:
+    private, public = generate_referee_keypair()
+    signed = sign_execution_envelope(
+        _binding(),
+        _observations(),
+        _verdicts(),
+        private_key=private,
+    )
+    return signed, private, public
+
+
+def test_round_trip_binds_every_identity_and_derives_receipt_metrics() -> None:
+    signed, _private, public = _signed()
+
+    verified = verify_signed_execution_envelope(signed.to_json(), public_key=public)
+    receipt = verified.to_run_receipt()
+
+    assert verified == signed
+    assert verified.signing_key_id == referee_key_id(public)
+    assert verified.binding.to_json() == _binding().to_json()
+    assert verified.observations.to_json() == _observations().to_json()
+    assert verified.finding_verdicts == _verdicts()
+    assert receipt.evidence_backed_vulnerability_count == _EXPECTED_EVIDENCE_BACKED
+    assert receipt.verified_vulnerability_count == _EXPECTED_VERIFIED
+    assert receipt.confirmed_finding_count == 1
+    assert receipt.suspected_vulnerability_count == 1
+    assert receipt.physical_request_count == _EXPECTED_PHYSICAL_REQUESTS
+    assert receipt.run_id == _digest("7")
+
+
+_BINDING_TAMPERS = {
+    "campaign_id": f"campaign_{'d' * 24}",
+    "candidate_id": f"candidate_{'e' * 24}",
+    "candidate_tree_digest": "d" * 40,
+    "candidate_content_digest": _digest("c"),
+    "evaluation_suite_object": _digest("d"),
+    "trusted_tests_digest": _digest("e"),
+    "runner_image": f"other.invalid/evaluator@{_digest('f')}",
+    "job_spec_digest": _digest("c"),
+    "artifact_tree_digest": _digest("d"),
+    "artifact_case_path": "cases/other/repeat-1",
+    "case_id": "other-case",
+    "cohort": "control",
+    "repeat": 2,
+    "execution_kind": "fixture",
+    "is_control": True,
+    "expected_vulnerability_count": 4,
+    "run_id": _digest("c"),
+    "pair_seed_digest": _digest("d"),
+    "target_snapshot_digest": _digest("e"),
+    "model_fingerprint": _digest("f"),
+    "prompt_fingerprint": _digest("0"),
+}
+
+
+@pytest.mark.parametrize(("field", "replacement"), _BINDING_TAMPERS.items())
+def test_every_execution_binding_substitution_breaks_the_signature(
+    field: str,
+    replacement: object,
+) -> None:
+    signed, _private, public = _signed()
+    payload = deepcopy(signed.to_json())
+    payload["binding"][field] = replacement  # type: ignore[index]
+
+    with pytest.raises(ExecutionAttestationError, match="signature verification"):
+        verify_signed_execution_envelope(payload, public_key=public)
+
+
+_OBSERVATION_TAMPERS = {
+    "status": "failed",
+    "case_success": True,
+    "physical_request_count": 18,
+    "model_request_count": 5,
+    "cost_usd": 0.25,
+    "request_accounting_status": "reported",
+    "proof_integrity_failure_count": 1,
+    "false_proof_count": 1,
+    "request_accounting_mismatch_count": 1,
+    "loop_violation_count": 1,
+    "provenance_violation_count": 1,
+    "secret_leak_violation_count": 1,
+    "unmetered_action_count": 1,
+    "incomplete_request_count": 1,
+}
+
+
+@pytest.mark.parametrize(("field", "replacement"), _OBSERVATION_TAMPERS.items())
+def test_every_external_observation_substitution_breaks_the_signature(
+    field: str,
+    replacement: object,
+) -> None:
+    signed, _private, public = _signed()
+    payload = deepcopy(signed.to_json())
+    payload["observations"][field] = replacement  # type: ignore[index]
+
+    with pytest.raises(ExecutionAttestationError, match="signature verification"):
+        verify_signed_execution_envelope(payload, public_key=public)
+
+
+def test_finding_verdict_substitution_breaks_the_signature() -> None:
+    signed, _private, public = _signed()
+    payload = deepcopy(signed.to_json())
+    payload["finding_verdicts"][1]["stage"] = "verified_vulnerability"  # type: ignore[index]
+
+    with pytest.raises(ExecutionAttestationError, match="signature verification"):
+        verify_signed_execution_envelope(payload, public_key=public)
+
+
+def test_wrong_key_key_id_and_signature_are_rejected() -> None:
+    signed, _private, _public = _signed()
+    _other_private, other_public = generate_referee_keypair()
+
+    with pytest.raises(ExecutionAttestationError, match="wrong key"):
+        verify_signed_execution_envelope(signed.to_json(), public_key=other_public)
+
+    bad_key_id = deepcopy(signed.to_json())
+    bad_key_id["signing_key_id"] = _digest("f")
+    with pytest.raises(ExecutionAttestationError, match="wrong key"):
+        verify_signed_execution_envelope(bad_key_id, public_key=_public)
+
+    bad_signature = deepcopy(signed.to_json())
+    bad_signature["signature"] = "0" * 128
+    with pytest.raises(ExecutionAttestationError, match="signature verification"):
+        verify_signed_execution_envelope(bad_signature, public_key=_public)
+
+
+@pytest.mark.parametrize("container", ["top", "binding", "observations", "verdict"])
+@pytest.mark.parametrize("operation", ["missing", "extra"])
+def test_exact_schemas_reject_missing_or_extra_fields(container: str, operation: str) -> None:
+    signed, _private, public = _signed()
+    payload = deepcopy(signed.to_json())
+    selected: dict[str, object]
+    if container == "top":
+        selected = payload
+    elif container == "verdict":
+        selected = payload["finding_verdicts"][0]  # type: ignore[assignment,index]
+    else:
+        selected = payload[container]  # type: ignore[assignment]
+    if operation == "missing":
+        selected.pop(next(iter(selected)))
+    else:
+        selected["unexpected"] = True
+
+    with pytest.raises(ExecutionAttestationError, match=r"fields|schema"):
+        verify_signed_execution_envelope(payload, public_key=public)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/absolute",
+        "../escape",
+        "case/../escape",
+        "case/./report",
+        "case//report",
+        "case/",
+        "case\\report",
+    ],
+)
+def test_artifact_case_path_must_be_normalized_relative_posix(path: str) -> None:
+    with pytest.raises(ExecutionAttestationError, match="artifact_case_path"):
+        replace(_binding(), artifact_case_path=path)
+
+    assert replace(_binding(), artifact_case_path=".").artifact_case_path == "."
+
+
+def test_types_bounds_accounting_and_verdict_identity_fail_closed() -> None:
+    with pytest.raises(ExecutionAttestationError, match="repeat"):
+        replace(_binding(), repeat=True)
+    with pytest.raises(ExecutionAttestationError, match="expected_vulnerability_count"):
+        replace(_binding(), expected_vulnerability_count=-1)
+    with pytest.raises(ExecutionAttestationError, match="pinned"):
+        replace(_binding(), runner_image="example.invalid/evaluator:latest")
+    with pytest.raises(ExecutionAttestationError, match="physical request"):
+        replace(_observations(), physical_request_count=None)
+    with pytest.raises(ExecutionAttestationError, match="cost_usd"):
+        replace(_observations(), cost_usd=float("inf"))
+    with pytest.raises(ExecutionAttestationError, match="outside"):
+        replace(_observations(), loop_violation_count=-1)
+    with pytest.raises(ExecutionAttestationError, match="distinct"):
+        sign_execution_envelope(
+            _binding(),
+            _observations(),
+            (_verdicts()[0], _verdicts()[0]),
+            private_key=generate_referee_keypair()[0],
+        )
+    with pytest.raises(ExecutionAttestationError, match="canonical digest order"):
+        sign_execution_envelope(
+            _binding(),
+            _observations(),
+            tuple(reversed(_verdicts())),
+            private_key=generate_referee_keypair()[0],
+        )
+
+
+def test_nullable_external_metrics_remain_explicit() -> None:
+    observations = replace(
+        _observations(),
+        physical_request_count=None,
+        model_request_count=None,
+        cost_usd=None,
+        request_accounting_status="unavailable",
+    )
+    private, public = generate_referee_keypair()
+    signed = sign_execution_envelope(
+        _binding(), observations, (), private_key=private
+    )
+
+    receipt = verify_signed_execution_envelope(signed.to_json(), public_key=public).to_run_receipt()
+
+    assert receipt.physical_request_count is None
+    assert receipt.model_request_count is None
+    assert receipt.cost_usd is None
+    assert receipt.request_accounting_status == "unavailable"
+
+
+def test_file_round_trip_is_private_byte_canonical_and_non_overwriting(
+    tmp_path: Path,
+) -> None:
+    signed, _private, public = _signed()
+    path = tmp_path / "sealed" / "execution.json"
+
+    write_signed_execution_envelope(path, signed)
+    loaded = load_signed_execution_envelope(path, public_key=public)
+
+    assert loaded == signed
+    assert stat.S_IMODE(path.stat().st_mode) == _PRIVATE_MODE
+    assert path.read_bytes() == (canonical_json(signed.to_json()) + "\n").encode()
+    assert execution_envelope_digest(loaded) == execution_envelope_digest(signed)
+    with pytest.raises(ExecutionAttestationError, match="already exists"):
+        write_signed_execution_envelope(path, signed)
+
+
+def test_loader_rejects_noncanonical_duplicate_nonfinite_and_oversize_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private, public = generate_referee_keypair()
+    path = tmp_path / "execution.json"
+    path.write_text('{"schema_version":1, "schema_version":2}\n', encoding="utf-8")
+    with pytest.raises(ExecutionAttestationError, match="duplicate"):
+        load_signed_execution_envelope(path, public_key=public)
+
+    path.write_text('{"cost":NaN}\n', encoding="utf-8")
+    with pytest.raises(ExecutionAttestationError, match="unsupported NaN"):
+        load_signed_execution_envelope(path, public_key=public)
+
+    path.write_text(json.dumps({"schema_version": 1}, indent=2) + "\n", encoding="utf-8")
+    with pytest.raises(ExecutionAttestationError, match="byte-canonical"):
+        load_signed_execution_envelope(path, public_key=public)
+
+    path.write_bytes(b"x" * 65)
+    monkeypatch.setattr(module, "_MAX_SIGNED_BYTES", 64)
+    with pytest.raises(ExecutionAttestationError, match="byte cap"):
+        load_signed_execution_envelope(path, public_key=public)
+
+
+def test_loader_rejects_symlinks_and_hardlinks(tmp_path: Path) -> None:
+    signed, _private, public = _signed()
+    original = tmp_path / "original.json"
+    write_signed_execution_envelope(original, signed)
+    symlink = tmp_path / "symlink.json"
+    symlink.symlink_to(original)
+    with pytest.raises(ExecutionAttestationError, match="single-link"):
+        load_signed_execution_envelope(symlink, public_key=public)
+
+    hardlink = tmp_path / "hardlink.json"
+    os.link(original, hardlink)
+    with pytest.raises(ExecutionAttestationError, match="single-link"):
+        load_signed_execution_envelope(hardlink, public_key=public)
+
+
+def test_raw_key_sizes_and_strict_lowercase_digests_are_required() -> None:
+    with pytest.raises(ExecutionAttestationError, match="private key"):
+        sign_execution_envelope(_binding(), _observations(), (), private_key=b"short")
+    signed, _private, _public = _signed()
+    with pytest.raises(ExecutionAttestationError, match="public key"):
+        verify_signed_execution_envelope(signed.to_json(), public_key=b"short")
+    with pytest.raises(ExecutionAttestationError, match="digest"):
+        replace(_binding(), run_id=f"sha256:{'A' * 64}")
+
+
+def test_schema_version_is_signed_and_strict() -> None:
+    signed, _private, public = _signed()
+    payload = signed.to_json()
+    assert payload["schema_version"] == EXECUTION_ATTESTATION_SCHEMA_VERSION
+    payload["schema_version"] = "ravage.improvement-execution-attestation.v2"
+
+    with pytest.raises(ExecutionAttestationError, match="unsupported"):
+        verify_signed_execution_envelope(payload, public_key=public)

--- a/tests/improvement_lab/test_execution_attestation.py
+++ b/tests/improvement_lab/test_execution_attestation.py
@@ -150,7 +150,6 @@ _BINDING_TAMPERS = {
     "cohort": "control",
     "repeat": 2,
     "execution_kind": "fixture",
-    "evaluation_side": "champion",
     "is_control": True,
     "expected_vulnerability_count": 4,
     "run_id": _digest("c"),
@@ -169,6 +168,16 @@ def test_every_execution_binding_substitution_breaks_the_signature(
     signed, _private, public = _signed()
     payload = deepcopy(signed.to_json())
     payload["binding"][field] = replacement  # type: ignore[index]
+
+    with pytest.raises(ExecutionAttestationError, match="signature verification"):
+        verify_signed_execution_envelope(payload, public_key=public)
+
+
+def test_campaign_scoped_champion_side_is_signed() -> None:
+    signed, _private, public = _signed()
+    payload = deepcopy(signed.to_json())
+    payload["binding"]["evaluation_side"] = "champion"  # type: ignore[index]
+    payload["binding"]["candidate_id"] = None  # type: ignore[index]
 
     with pytest.raises(ExecutionAttestationError, match="signature verification"):
         verify_signed_execution_envelope(payload, public_key=public)
@@ -274,10 +283,16 @@ def test_artifact_case_path_must_be_normalized_relative_posix(path: str) -> None
 
 
 def test_evaluation_side_is_explicit_and_bounded() -> None:
-    assert replace(_binding(), evaluation_side="champion").evaluation_side == "champion"
+    champion = replace(_binding(), evaluation_side="champion", candidate_id=None)
+    assert champion.evaluation_side == "champion"
+    assert champion.candidate_id is None
 
     with pytest.raises(ExecutionAttestationError, match="evaluation_side"):
         replace(_binding(), evaluation_side="baseline")
+    with pytest.raises(ExecutionAttestationError, match="campaign-scoped"):
+        replace(_binding(), evaluation_side="champion")
+    with pytest.raises(ExecutionAttestationError, match="candidate execution identity"):
+        replace(_binding(), candidate_id=None)
 
 
 def test_types_bounds_accounting_and_verdict_identity_fail_closed() -> None:

--- a/tests/improvement_lab/test_execution_attestation.py
+++ b/tests/improvement_lab/test_execution_attestation.py
@@ -20,6 +20,7 @@ from tools.improvement_lab.execution_attestation import (
     FindingVerdict,
     SignedExecutionEnvelope,
     execution_envelope_digest,
+    load_canonical_execution_envelope_bytes,
     load_signed_execution_envelope,
     sign_execution_envelope,
     verify_signed_execution_envelope,
@@ -55,6 +56,7 @@ def _binding() -> ExecutionBinding:
         cohort="sealed",
         repeat=1,
         execution_kind="live",
+        evaluation_side="candidate",
         is_control=False,
         expected_vulnerability_count=3,
         run_id=_digest("7"),
@@ -123,6 +125,16 @@ def test_round_trip_binds_every_identity_and_derives_receipt_metrics() -> None:
     assert receipt.run_id == _digest("7")
 
 
+def test_canonical_envelope_bytes_can_be_verified_without_a_file() -> None:
+    signed, _private, public = _signed()
+    content = (canonical_json(signed.to_json()) + "\n").encode()
+
+    assert load_canonical_execution_envelope_bytes(content, public_key=public) == signed
+
+    with pytest.raises(ExecutionAttestationError, match="byte-canonical"):
+        load_canonical_execution_envelope_bytes(content.rstrip(), public_key=public)
+
+
 _BINDING_TAMPERS = {
     "campaign_id": f"campaign_{'d' * 24}",
     "candidate_id": f"candidate_{'e' * 24}",
@@ -138,6 +150,7 @@ _BINDING_TAMPERS = {
     "cohort": "control",
     "repeat": 2,
     "execution_kind": "fixture",
+    "evaluation_side": "champion",
     "is_control": True,
     "expected_vulnerability_count": 4,
     "run_id": _digest("c"),
@@ -258,6 +271,13 @@ def test_artifact_case_path_must_be_normalized_relative_posix(path: str) -> None
         replace(_binding(), artifact_case_path=path)
 
     assert replace(_binding(), artifact_case_path=".").artifact_case_path == "."
+
+
+def test_evaluation_side_is_explicit_and_bounded() -> None:
+    assert replace(_binding(), evaluation_side="champion").evaluation_side == "champion"
+
+    with pytest.raises(ExecutionAttestationError, match="evaluation_side"):
+        replace(_binding(), evaluation_side="baseline")
 
 
 def test_types_bounds_accounting_and_verdict_identity_fail_closed() -> None:

--- a/tests/improvement_lab/test_offline_executor.py
+++ b/tests/improvement_lab/test_offline_executor.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+
+import tools.improvement_lab.offline_executor as executor
+from tools.improvement_lab.offline_executor import (
+    MAX_TIMEOUT_SECONDS,
+    OfflineExecutionError,
+    execute_offline_job,
+    freeze_output_tree,
+)
+from tools.improvement_lab.workspace import (
+    CandidateWorkspace,
+    OfflineContainerJob,
+    build_offline_container_job,
+    capture_source_state,
+    directory_tree_digest,
+    materialize_candidate,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(  # noqa: S603
+        ("git", "-C", str(root), *args),  # noqa: S607
+        check=True,
+        capture_output=True,
+    )
+
+
+def _candidate(tmp_path: Path) -> CandidateWorkspace:
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init")
+    _git(source, "config", "user.email", "executor@example.invalid")
+    _git(source, "config", "user.name", "Executor Test")
+    (source / "app.txt").write_text("candidate\n", encoding="utf-8")
+    _git(source, "add", "app.txt")
+    _git(source, "commit", "-m", "candidate")
+    state = capture_source_state(source)
+    return materialize_candidate(
+        source_root=source,
+        lab_root=tmp_path / "lab",
+        candidate_id="candidate-1",
+        base_commit=state.head_commit,
+        patch=b"",
+    )
+
+
+def _candidate_view(root: Path) -> None:
+    content = b'{"capsules":[],"schema_version":"ravage.improvement-corpus.v1"}\n'
+    artifact_id = f"artifact_{'c' * 24}"
+    filename = f"{artifact_id}-development_corpus.json"
+    (root / filename).write_bytes(content)
+    (root / ".improvement-candidate-view.json").write_text(
+        json.dumps(
+            {
+                "archive_id": f"archive_{'d' * 24}",
+                "entries": [
+                    {
+                        "artifact_id": artifact_id,
+                        "content_object": f"sha256:{hashlib.sha256(content).hexdigest()}",
+                        "filename": filename,
+                        "kind": "development_corpus",
+                    }
+                ],
+                "schema_version": 1,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _job(tmp_path: Path) -> OfflineContainerJob:
+    candidate = _candidate(tmp_path)
+    episodes = tmp_path / "episodes"
+    trusted_tests = tmp_path / "trusted-tests"
+    episodes.mkdir()
+    trusted_tests.mkdir()
+    _candidate_view(episodes)
+    return build_offline_container_job(
+        image=f"example.invalid/evaluator@sha256:{'a' * 64}",
+        candidate=candidate,
+        episodes_root=episodes,
+        trusted_tests_root=trusted_tests,
+        expected_trusted_tests_digest=directory_tree_digest(trusted_tests),
+        output_root=tmp_path / "output",
+        command=("python", "-m", "pytest", "-q"),
+    )
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        exit_code: int = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        timed_out: bool = False,
+        on_wait: Callable[[], None] | None = None,
+    ) -> None:
+        self.stdout = io.BytesIO(stdout)
+        self.stderr = io.BytesIO(stderr)
+        self.returncode: int | None = None
+        self._exit_code = exit_code
+        self._timed_out = timed_out
+        self._on_wait = on_wait
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is not None:
+            return self.returncode
+        if self._timed_out:
+            raise subprocess.TimeoutExpired(("docker", "run"), timeout or 0.0)
+        if self._on_wait is not None:
+            self._on_wait()
+            self._on_wait = None
+        self.returncode = self._exit_code
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._timed_out = False
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self._timed_out = False
+        self.returncode = -9
+
+
+class _FakeRunner:
+    def __init__(self, *processes: _FakeProcess) -> None:
+        self.processes = list(processes)
+        self.calls: list[tuple[tuple[str, ...], dict[str, object]]] = []
+
+    def __call__(self, argv: tuple[str, ...], **kwargs: object) -> _FakeProcess:
+        self.calls.append((argv, kwargs))
+        return self.processes.pop(0)
+
+
+def test_execute_records_exit_and_frozen_output_without_raw_logs(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    expected_exit_code = 7
+
+    def write_output() -> None:
+        (job.output_root / "report.json").write_text('{"passed":true}\n', encoding="utf-8")
+
+    runner = _FakeRunner(
+        _FakeProcess(
+            exit_code=expected_exit_code,
+            stdout=b"bounded stdout",
+            stderr=b"bounded stderr",
+            on_wait=write_output,
+        )
+    )
+
+    result = execute_offline_job(job, timeout_seconds=20, runner=runner)
+
+    assert result.status == "exited"
+    assert result.exit_code == expected_exit_code
+    assert result.output_file_count == 1
+    assert result.output_bytes == len(b'{"passed":true}\n')
+    assert result.output_digest == freeze_output_tree(job.output_root).digest
+    assert result.stdout_digest.startswith("sha256:")
+    assert result.stderr_digest.startswith("sha256:")
+    assert not hasattr(result, "stdout")
+    assert runner.calls[0][0] == job.argv
+    assert runner.calls[0][1]["shell"] is False
+
+
+def test_timeout_cleans_only_the_validated_container_name(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    primary = _FakeProcess(timed_out=True, stdout=b"before timeout")
+    runner = _FakeRunner(primary, _FakeProcess(exit_code=0))
+
+    result = execute_offline_job(job, timeout_seconds=1, runner=runner)
+
+    assert result.status == "timed_out"
+    assert result.exit_code is None
+    assert primary.terminated
+    assert runner.calls[1][0] == (
+        "docker",
+        "rm",
+        "--force",
+        "--",
+        "ravage-improvement-check",
+    )
+    assert runner.calls[1][1]["shell"] is False
+
+
+def test_executor_rejects_tampered_job_before_calling_runner(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    argv = list(job.argv)
+    argv[argv.index("--network") + 1] = "bridge"
+    runner = _FakeRunner()
+
+    with pytest.raises(OfflineExecutionError, match="hardened job contract"):
+        execute_offline_job(replace(job, argv=tuple(argv)), runner=runner)
+
+    assert runner.calls == []
+
+
+def test_executor_revalidates_candidate_identity_before_launch(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    (job.candidate_workspace / "app.txt").write_text("substituted\n", encoding="utf-8")
+    runner = _FakeRunner()
+
+    with pytest.raises(OfflineExecutionError, match="inputs changed"):
+        execute_offline_job(job, runner=runner)
+
+    assert runner.calls == []
+
+
+def test_executor_refuses_overlapping_and_symlink_roots(tmp_path: Path) -> None:
+    job = _job(tmp_path)
+    runner = _FakeRunner()
+
+    with pytest.raises(OfflineExecutionError, match="disjoint"):
+        execute_offline_job(replace(job, output_root=job.episodes_root), runner=runner)
+
+    linked = tmp_path / "linked-episodes"
+    linked.symlink_to(job.episodes_root, target_is_directory=True)
+    with pytest.raises(OfflineExecutionError, match="symlinks"):
+        execute_offline_job(replace(job, episodes_root=linked), runner=runner)
+
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo", "sparse"])
+def test_freeze_rejects_unsafe_output_entries(tmp_path: Path, kind: str) -> None:
+    root = tmp_path / "output"
+    root.mkdir()
+    source = root / "source"
+    source.write_bytes(b"safe")
+    unsafe = root / "unsafe"
+    if kind == "symlink":
+        unsafe.symlink_to(source)
+    elif kind == "hardlink":
+        os.link(source, unsafe)
+    elif kind == "fifo":
+        os.mkfifo(unsafe)
+    else:
+        with unsafe.open("wb") as stream:
+            stream.seek(1024 * 1024)
+            stream.write(b"x")
+
+    with pytest.raises(OfflineExecutionError):
+        freeze_output_tree(root)
+
+
+def test_freeze_enforces_entry_depth_and_byte_bounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "output"
+    root.mkdir()
+    (root / "one").write_bytes(b"1")
+    (root / "two").write_bytes(b"2")
+    monkeypatch.setattr(executor, "_MAX_OUTPUT_ENTRIES", 1)
+    with pytest.raises(OfflineExecutionError, match="too many"):
+        freeze_output_tree(root)
+
+    monkeypatch.setattr(executor, "_MAX_OUTPUT_ENTRIES", 10)
+    nested = root / "nested"
+    nested.mkdir()
+    (nested / "deep").write_bytes(b"3")
+    monkeypatch.setattr(executor, "_MAX_OUTPUT_DEPTH", 1)
+    with pytest.raises(OfflineExecutionError, match="depth"):
+        freeze_output_tree(root)
+
+    monkeypatch.setattr(executor, "_MAX_OUTPUT_DEPTH", 16)
+    monkeypatch.setattr(executor, "_MAX_OUTPUT_FILE_BYTES", 0)
+    with pytest.raises(OfflineExecutionError, match="file exceeds"):
+        freeze_output_tree(root)
+
+
+def test_timeout_and_stream_capture_are_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _job(tmp_path)
+    monkeypatch.setattr(executor, "_STREAM_LIMIT_BYTES", 4)
+    runner = _FakeRunner(_FakeProcess(stdout=b"longer than four bytes"))
+
+    result = execute_offline_job(job, runner=runner)
+
+    expected = hashlib.sha256(b"ravage-offline-stream-v1\0long\0truncated").hexdigest()
+    assert result.stdout_digest == f"sha256:{expected}"
+    with pytest.raises(OfflineExecutionError, match="timeout"):
+        execute_offline_job(job, timeout_seconds=MAX_TIMEOUT_SECONDS + 1, runner=_FakeRunner())

--- a/tests/improvement_lab/test_run_receipt_adapter.py
+++ b/tests/improvement_lab/test_run_receipt_adapter.py
@@ -14,6 +14,7 @@ from tools.improvement_lab.execution_attestation import (
     ExternalRunObservations,
     FindingVerdict,
     SignedExecutionEnvelope,
+    execution_envelope_digest,
     sign_execution_envelope,
 )
 from tools.improvement_lab.offline_executor import FrozenOutputTree, freeze_output_tree
@@ -84,12 +85,14 @@ def _artifact_root(
     return root.resolve()
 
 
-def _envelope(
+def _envelope(  # noqa: PLR0913 - test fixture exposes independent signed counters.
     root: Path,
     *,
     verdicts: tuple[tuple[str, str], ...] = (),
     physical_requests: int | None = 7,
     case_success: bool | None = None,
+    proof_integrity_failures: int = 0,
+    accounting_mismatches: int = 0,
 ) -> _AttestedRun:
     frozen = freeze_output_tree(root)
     binding = ExecutionBinding(
@@ -107,6 +110,7 @@ def _envelope(
         cohort="development",
         repeat=1,
         execution_kind="fixture",
+        evaluation_side="candidate",
         is_control=False,
         expected_vulnerability_count=None,
         run_id=_digest("6"),
@@ -122,9 +126,9 @@ def _envelope(
         model_request_count=2,
         cost_usd=0.25,
         request_accounting_status="exact",
-        proof_integrity_failure_count=0,
+        proof_integrity_failure_count=proof_integrity_failures,
         false_proof_count=0,
-        request_accounting_mismatch_count=0,
+        request_accounting_mismatch_count=accounting_mismatches,
         loop_violation_count=0,
         provenance_violation_count=0,
         secret_leak_violation_count=0,
@@ -178,6 +182,10 @@ def test_no_flag_confirmed_vulnerability_still_counts(tmp_path: Path) -> None:
     assert receipt.verified_vulnerability_count == 1
     assert receipt.confirmed_finding_count == 1
     assert receipt.proof_integrity_failure_count == 0
+    assert receipt.execution_attestation_digest == execution_envelope_digest(
+        envelope.envelope
+    )
+    assert receipt == envelope.envelope.to_run_receipt()
 
 
 def test_self_reported_confirmed_finding_does_not_count_without_signed_verdict(
@@ -185,12 +193,19 @@ def test_self_reported_confirmed_finding_does_not_count_without_signed_verdict(
 ) -> None:
     root = _artifact_root(tmp_path)
 
-    receipt = _derive(root, _envelope(root))
+    receipt = _derive(root, _envelope(root, proof_integrity_failures=1))
 
     assert receipt.evidence_backed_vulnerability_count == 0
     assert receipt.verified_vulnerability_count == 0
     assert receipt.confirmed_finding_count == 0
     assert receipt.proof_integrity_failure_count == 1
+
+
+def test_unaccounted_self_reported_confirmation_is_rejected(tmp_path: Path) -> None:
+    root = _artifact_root(tmp_path)
+
+    with pytest.raises(RunReceiptAdapterError, match="proof-integrity failures"):
+        _derive(root, _envelope(root))
 
 
 def test_unknown_signed_finding_verdict_is_rejected(tmp_path: Path) -> None:
@@ -229,11 +244,27 @@ def test_traffic_report_and_external_count_mismatches_are_counted(
 
     receipt = _derive(
         root,
-        _envelope(root, physical_requests=_EXTERNAL_PHYSICAL_REQUESTS),
+        _envelope(
+            root,
+            physical_requests=_EXTERNAL_PHYSICAL_REQUESTS,
+            accounting_mismatches=_EXPECTED_ACCOUNTING_MISMATCHES,
+        ),
     )
 
     assert receipt.physical_request_count == _EXTERNAL_PHYSICAL_REQUESTS
     assert receipt.request_accounting_mismatch_count == _EXPECTED_ACCOUNTING_MISMATCHES
+
+
+def test_unaccounted_traffic_mismatches_are_rejected(tmp_path: Path) -> None:
+    root = _artifact_root(
+        tmp_path,
+        finding_ids=(),
+        report_requests=4,
+        ledger_requests=3,
+    )
+
+    with pytest.raises(RunReceiptAdapterError, match="request-accounting mismatches"):
+        _derive(root, _envelope(root, physical_requests=_EXTERNAL_PHYSICAL_REQUESTS))
 
 
 def test_artifact_tampering_after_signature_is_rejected(tmp_path: Path) -> None:
@@ -253,7 +284,7 @@ def test_artifact_mutation_during_derivation_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = _artifact_root(tmp_path)
-    attested = _envelope(root)
+    attested = _envelope(root, proof_integrity_failures=1)
     original_freeze = freeze_output_tree
     freeze_calls = 0
 
@@ -278,7 +309,7 @@ def test_canonical_receipt_write_is_deterministic_private_and_non_overwriting(
     tmp_path: Path,
 ) -> None:
     root = _artifact_root(tmp_path)
-    receipt = _derive(root, _envelope(root))
+    receipt = _derive(root, _envelope(root, proof_integrity_failures=1))
     first = tmp_path / "receipts-a" / "receipt.json"
     second = tmp_path / "receipts-b" / "receipt.json"
 

--- a/tests/improvement_lab/test_run_receipt_adapter.py
+++ b/tests/improvement_lab/test_run_receipt_adapter.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+import tools.improvement_lab.run_receipt_adapter as adapter
+from tools.improvement_lab.attestation import generate_referee_keypair
+from tools.improvement_lab.evaluation import RunReceipt, canonical_run_receipts_bytes
+from tools.improvement_lab.execution_attestation import (
+    ExecutionBinding,
+    ExternalRunObservations,
+    FindingVerdict,
+    SignedExecutionEnvelope,
+    sign_execution_envelope,
+)
+from tools.improvement_lab.offline_executor import FrozenOutputTree, freeze_output_tree
+from tools.improvement_lab.run_receipt_adapter import (
+    RunReceiptAdapterError,
+    derive_run_receipt,
+    finding_reference_digest,
+    write_run_receipt,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_EXTERNAL_PHYSICAL_REQUESTS = 5
+_EXPECTED_ACCOUNTING_MISMATCHES = 3
+
+
+@dataclass(frozen=True)
+class _AttestedRun:
+    envelope: SignedExecutionEnvelope
+    public_key: bytes
+
+
+def _digest(character: str) -> str:
+    return f"sha256:{character * 64}"
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+
+
+def _artifact_root(
+    tmp_path: Path,
+    *,
+    finding_ids: tuple[str, ...] = ("finding-one",),
+    report_requests: int = 7,
+    ledger_requests: int = 7,
+) -> Path:
+    root = tmp_path / "artifacts"
+    case = root / "case-one"
+    _write_json(
+        case / "report.json",
+        {
+            "captured_proofs": {"count": 0, "masked": []},
+            "findings": [
+                {"finding_id": finding_id, "status": "confirmed"}
+                for finding_id in finding_ids
+            ],
+            "outcome": {"evidence": []},
+            "traffic_accounting": {
+                "status": "exact",
+                "physical_request_count": report_requests,
+                "incomplete_request_count": 0,
+                "unmetered_action_count": 0,
+            },
+        },
+    )
+    _write_json(
+        case / "workspace" / "traffic-policy.json",
+        {
+            "schema": "ravage.traffic-policy",
+            "physical_request_count": ledger_requests,
+            "incomplete_request_count": 0,
+            "unmetered_action_count": 0,
+        },
+    )
+    return root.resolve()
+
+
+def _envelope(
+    root: Path,
+    *,
+    verdicts: tuple[tuple[str, str], ...] = (),
+    physical_requests: int | None = 7,
+    case_success: bool | None = None,
+) -> _AttestedRun:
+    frozen = freeze_output_tree(root)
+    binding = ExecutionBinding(
+        campaign_id=f"campaign_{'a' * 24}",
+        candidate_id=f"candidate_{'b' * 24}",
+        candidate_tree_digest="c" * 40,
+        candidate_content_digest=_digest("1"),
+        evaluation_suite_object=_digest("2"),
+        trusted_tests_digest=_digest("3"),
+        runner_image=f"example.invalid/referee@{_digest('4')}",
+        job_spec_digest=_digest("5"),
+        artifact_tree_digest=frozen.digest,
+        artifact_case_path="case-one",
+        case_id="case-one",
+        cohort="development",
+        repeat=1,
+        execution_kind="fixture",
+        is_control=False,
+        expected_vulnerability_count=None,
+        run_id=_digest("6"),
+        pair_seed_digest=_digest("7"),
+        target_snapshot_digest=_digest("8"),
+        model_fingerprint=_digest("9"),
+        prompt_fingerprint=_digest("a"),
+    )
+    observations = ExternalRunObservations(
+        status="completed",
+        case_success=case_success,
+        physical_request_count=physical_requests,
+        model_request_count=2,
+        cost_usd=0.25,
+        request_accounting_status="exact",
+        proof_integrity_failure_count=0,
+        false_proof_count=0,
+        request_accounting_mismatch_count=0,
+        loop_violation_count=0,
+        provenance_violation_count=0,
+        secret_leak_violation_count=0,
+        unmetered_action_count=0,
+        incomplete_request_count=0,
+    )
+    finding_verdicts = tuple(
+        sorted(
+            (
+                FindingVerdict(
+                    finding_reference_digest(finding_id),
+                    stage,
+                )
+                for finding_id, stage in verdicts
+            ),
+            key=lambda item: item.finding_digest,
+        )
+    )
+    private_key, public_key = generate_referee_keypair()
+    return _AttestedRun(
+        envelope=sign_execution_envelope(
+            binding,
+            observations,
+            finding_verdicts,
+            private_key=private_key,
+        ),
+        public_key=public_key,
+    )
+
+
+def _derive(root: Path, attested: _AttestedRun) -> RunReceipt:
+    return derive_run_receipt(
+        root,
+        envelope=attested.envelope,
+        executor_public_key=attested.public_key,
+    )
+
+
+def test_no_flag_confirmed_vulnerability_still_counts(tmp_path: Path) -> None:
+    root = _artifact_root(tmp_path)
+    envelope = _envelope(
+        root,
+        verdicts=(("finding-one", "confirmed_finding"),),
+        case_success=None,
+    )
+
+    receipt = _derive(root, envelope)
+
+    assert receipt.case_success is None
+    assert receipt.evidence_backed_vulnerability_count == 1
+    assert receipt.verified_vulnerability_count == 1
+    assert receipt.confirmed_finding_count == 1
+    assert receipt.proof_integrity_failure_count == 0
+
+
+def test_self_reported_confirmed_finding_does_not_count_without_signed_verdict(
+    tmp_path: Path,
+) -> None:
+    root = _artifact_root(tmp_path)
+
+    receipt = _derive(root, _envelope(root))
+
+    assert receipt.evidence_backed_vulnerability_count == 0
+    assert receipt.verified_vulnerability_count == 0
+    assert receipt.confirmed_finding_count == 0
+    assert receipt.proof_integrity_failure_count == 1
+
+
+def test_unknown_signed_finding_verdict_is_rejected(tmp_path: Path) -> None:
+    root = _artifact_root(tmp_path)
+    envelope = _envelope(
+        root,
+        verdicts=(("not-in-the-report", "confirmed_finding"),),
+    )
+
+    with pytest.raises(RunReceiptAdapterError, match="does not match"):
+        _derive(root, envelope)
+
+
+def test_unverified_envelope_or_wrong_executor_key_is_rejected(tmp_path: Path) -> None:
+    root = _artifact_root(tmp_path)
+    attested = _envelope(root)
+    _unused_private, wrong_public = generate_referee_keypair()
+
+    with pytest.raises(RunReceiptAdapterError, match="envelope is invalid"):
+        derive_run_receipt(
+            root,
+            envelope=attested.envelope,
+            executor_public_key=wrong_public,
+        )
+
+
+def test_traffic_report_and_external_count_mismatches_are_counted(
+    tmp_path: Path,
+) -> None:
+    root = _artifact_root(
+        tmp_path,
+        finding_ids=(),
+        report_requests=4,
+        ledger_requests=3,
+    )
+
+    receipt = _derive(
+        root,
+        _envelope(root, physical_requests=_EXTERNAL_PHYSICAL_REQUESTS),
+    )
+
+    assert receipt.physical_request_count == _EXTERNAL_PHYSICAL_REQUESTS
+    assert receipt.request_accounting_mismatch_count == _EXPECTED_ACCOUNTING_MISMATCHES
+
+
+def test_artifact_tampering_after_signature_is_rejected(tmp_path: Path) -> None:
+    root = _artifact_root(tmp_path)
+    envelope = _envelope(root)
+    report_path = root / "case-one" / "report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["findings"] = []
+    _write_json(report_path, report)
+
+    with pytest.raises(RunReceiptAdapterError, match="differs from the signed execution"):
+        _derive(root, envelope)
+
+
+def test_artifact_mutation_during_derivation_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _artifact_root(tmp_path)
+    attested = _envelope(root)
+    original_freeze = freeze_output_tree
+    freeze_calls = 0
+
+    def mutating_freeze(path: Path) -> FrozenOutputTree:
+        nonlocal freeze_calls
+        frozen = original_freeze(path)
+        freeze_calls += 1
+        if freeze_calls == 1:
+            report_path = root / "case-one" / "report.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["candidate_changed_after_freeze"] = True
+            _write_json(report_path, report)
+        return frozen
+
+    monkeypatch.setattr(adapter, "freeze_output_tree", mutating_freeze)
+
+    with pytest.raises(RunReceiptAdapterError, match="changed while deriving"):
+        _derive(root, attested)
+
+
+def test_canonical_receipt_write_is_deterministic_private_and_non_overwriting(
+    tmp_path: Path,
+) -> None:
+    root = _artifact_root(tmp_path)
+    receipt = _derive(root, _envelope(root))
+    first = tmp_path / "receipts-a" / "receipt.json"
+    second = tmp_path / "receipts-b" / "receipt.json"
+
+    write_run_receipt(first, receipt)
+    write_run_receipt(second, receipt)
+
+    assert first.read_bytes() == second.read_bytes()
+    assert first.read_bytes() == canonical_run_receipts_bytes((receipt,))
+    assert first.stat().st_mode & 0o077 == 0
+    with pytest.raises(RunReceiptAdapterError, match="overwrite"):
+        write_run_receipt(first, receipt)
+
+
+@pytest.mark.parametrize(
+    "report_text",
+    [
+        (
+            '{"findings":[],"findings":[],"outcome":{"evidence":[]},'
+            '"traffic_accounting":{}}'
+        ),
+        (
+            '{"findings":[],"outcome":{"evidence":[]},'
+            '"traffic_accounting":{},"not_a_number":NaN}'
+        ),
+    ],
+    ids=("duplicate-key", "non-finite"),
+)
+def test_duplicate_and_non_finite_artifact_json_is_rejected(
+    tmp_path: Path,
+    report_text: str,
+) -> None:
+    root = _artifact_root(tmp_path, finding_ids=())
+    (root / "case-one" / "report.json").write_text(report_text, encoding="utf-8")
+    envelope = _envelope(root)
+
+    with pytest.raises(RunReceiptAdapterError, match="invalid JSON"):
+        _derive(root, envelope)

--- a/tools/improvement_lab/archive.py
+++ b/tools/improvement_lab/archive.py
@@ -38,6 +38,14 @@ from tools.improvement_lab.evaluation import (
     evaluate_candidate,
     load_canonical_run_receipts,
 )
+from tools.improvement_lab.execution_attestation import (
+    ExecutionAttestationError,
+    SignedExecutionEnvelope,
+    canonical_execution_envelope_bytes,
+    execution_envelope_digest,
+    load_canonical_execution_envelope_bytes,
+    verify_signed_execution_envelope,
+)
 from tools.improvement_lab.lessons import (
     ImprovementBriefError,
     build_improvement_brief,
@@ -51,7 +59,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 ARCHIVE_SCHEMA_VERSION: Final = "ravage.improvement-archive.v1"
-CAMPAIGN_SCHEMA_VERSION: Final = "ravage.improvement-campaign.v3"
+CAMPAIGN_SCHEMA_VERSION: Final = "ravage.improvement-campaign.v4"
 CANDIDATE_SCHEMA_VERSION: Final = "ravage.improvement-candidate.v2"
 EVALUATION_RECORD_SCHEMA_VERSION: Final = "ravage.improvement-evaluation-record.v3"
 APPROVAL_SCHEMA_VERSION: Final = "ravage.improvement-human-approval.v1"
@@ -257,6 +265,7 @@ class LabArchive:
         evaluation_suite: bytes,
         runner_image: str,
         referee_public_key: bytes,
+        executor_public_key: bytes,
         proposal_input_artifact_ids: Sequence[str],
         expected_previous_ref: str | None = None,
     ) -> dict[str, object]:
@@ -269,6 +278,9 @@ class LabArchive:
         try:
             validated_config = EvaluationConfig.from_mapping(evaluation_config)
             key_id = referee_key_id(referee_public_key)
+            executor_key_id = referee_key_id(executor_public_key)
+            if executor_key_id == key_id:
+                raise ArchiveError("campaign executor and referee keys must be distinct")
             EvaluationBinding(
                 campaign_id=f"campaign_{'0' * 24}",
                 candidate_id=f"candidate_{'0' * 24}",
@@ -294,6 +306,7 @@ class LabArchive:
         config_object = self.put_json(validated_config.to_json())
         suite_object = self.put_json(validated_suite.to_json())
         public_key_object = self.put_bytes(referee_public_key)
+        executor_public_key_object = self.put_bytes(executor_public_key)
         validated_inputs = self._validated_candidate_input_artifacts(proposal_input_artifact_ids)
         input_set_object = self.put_json(
             {"schema_version": 1, "artifact_ids": list(validated_inputs)}
@@ -307,6 +320,8 @@ class LabArchive:
             "runner_image": runner_image,
             "referee_public_key_object": public_key_object.digest,
             "referee_key_id": key_id,
+            "executor_public_key_object": executor_public_key_object.digest,
+            "executor_key_id": executor_key_id,
             "proposal_input_set_object": input_set_object.digest,
         }
         campaign_id = f"campaign_{_digest_json(identity)[:24]}"
@@ -384,6 +399,55 @@ class LabArchive:
             if metadata is not None and metadata != {}:
                 raise ArchiveError("candidate-visible artifact metadata must be empty")
             content = _canonicalize_candidate_artifact(kind=kind, content=content)
+        return self._record_artifact(
+            kind=kind,
+            visibility=visibility,
+            content=content,
+            metadata=metadata,
+        )
+
+    def retain_execution_envelope(
+        self,
+        candidate_id: str,
+        *,
+        signed_envelope: SignedExecutionEnvelope,
+    ) -> dict[str, object]:
+        """Verify and retain one canonical executor envelope as a sealed artifact."""
+        self.recover()
+        _archive_id(candidate_id, "candidate")
+        public_key = self.campaign_executor_public_key(candidate_id)
+        try:
+            verified = verify_signed_execution_envelope(
+                signed_envelope.to_json(),
+                public_key=public_key,
+            )
+        except (AttributeError, ExecutionAttestationError) as exc:
+            raise ArchiveError("execution envelope is not a valid executor attestation") from exc
+        self._validate_execution_envelope_binding(candidate_id, verified)
+        content = canonical_execution_envelope_bytes(verified)
+        expected_digest = execution_envelope_digest(verified)
+        manifest = self._record_artifact(
+            kind="execution_attestation",
+            visibility="sealed_evaluator",
+            content=content,
+            metadata={
+                "candidate_id": candidate_id,
+                "evaluation_side": verified.binding.evaluation_side,
+                "run_id": verified.binding.run_id,
+            },
+        )
+        if manifest.get("content_object") != expected_digest:
+            raise ArchiveError("retained execution envelope has an unexpected CAS identity")
+        return manifest
+
+    def _record_artifact(
+        self,
+        *,
+        kind: str,
+        visibility: str,
+        content: bytes,
+        metadata: object | None,
+    ) -> dict[str, object]:
         content_object = self.put_bytes(content)
         metadata_object = self.put_json(metadata or {})
         identity = {
@@ -567,6 +631,11 @@ class LabArchive:
             raise ArchiveError("evaluation binding receipt objects are invalid") from exc
         if not champion or not candidate_receipts:
             raise ArchiveError("evaluation binding receipt objects are empty")
+        self._verify_receipt_execution_envelopes(
+            candidate_id,
+            champion_receipts=champion,
+            candidate_receipts=candidate_receipts,
+        )
         try:
             return EvaluationBinding(
                 campaign_id=str(candidate["campaign_id"]),
@@ -594,6 +663,11 @@ class LabArchive:
     ) -> EvaluationBinding:
         """Retain canonical raw receipt sets before a referee signs their result."""
         self.recover()
+        self._verify_receipt_execution_envelopes(
+            candidate_id,
+            champion_receipts=champion_receipts,
+            candidate_receipts=candidate_receipts,
+        )
         champion_object = self.put_bytes(canonical_run_receipts_bytes(champion_receipts))
         candidate_object = self.put_bytes(canonical_run_receipts_bytes(candidate_receipts))
         return self.evaluation_binding(
@@ -639,6 +713,11 @@ class LabArchive:
             )
         except ValueError as exc:
             raise ArchiveError("archived evaluation receipt sets are invalid") from exc
+        self._verify_receipt_execution_envelopes(
+            binding.candidate_id,
+            champion_receipts=champion,
+            candidate_receipts=candidate,
+        )
         selected = config or self.campaign_evaluation_config(binding.candidate_id)
         suite = self.campaign_evaluation_suite(binding.candidate_id)
         return evaluate_candidate(champion, candidate, config=selected, suite=suite)
@@ -647,6 +726,82 @@ class LabArchive:
         candidate = self._load_manifest("candidates", candidate_id)
         campaign = self._load_manifest("campaigns", str(candidate["campaign_id"]))
         return self.read_object(str(campaign["referee_public_key_object"]))
+
+    def campaign_executor_public_key(self, candidate_id: str) -> bytes:
+        candidate = self._load_manifest("candidates", candidate_id)
+        campaign = self._load_manifest("campaigns", str(candidate["campaign_id"]))
+        return self.read_object(str(campaign["executor_public_key_object"]))
+
+    def _verify_receipt_execution_envelopes(
+        self,
+        candidate_id: str,
+        *,
+        champion_receipts: Sequence[RunReceipt],
+        candidate_receipts: Sequence[RunReceipt],
+    ) -> None:
+        public_key = self.campaign_executor_public_key(candidate_id)
+        seen: set[str] = set()
+        for side, receipts in (
+            ("champion", champion_receipts),
+            ("candidate", candidate_receipts),
+        ):
+            for receipt in receipts:
+                if receipt.execution_kind not in {"fixture", "live"}:
+                    continue
+                digest = receipt.execution_attestation_digest
+                if digest is None:
+                    raise ArchiveError("promotable receipt lacks an execution attestation")
+                if digest in seen:
+                    raise ArchiveError(
+                        "execution envelope is reused across promotion receipt sets"
+                    )
+                seen.add(digest)
+                content = self.read_object(digest)
+                try:
+                    signed = load_canonical_execution_envelope_bytes(
+                        content,
+                        public_key=public_key,
+                    )
+                except ExecutionAttestationError as exc:
+                    raise ArchiveError(
+                        "receipt execution envelope is not a valid executor attestation"
+                    ) from exc
+                if execution_envelope_digest(signed) != digest:
+                    raise ArchiveError("receipt execution envelope CAS identity is invalid")
+                self._validate_execution_envelope_binding(candidate_id, signed)
+                if signed.binding.evaluation_side != side:
+                    raise ArchiveError("receipt execution envelope is bound to the wrong side")
+                if signed.to_run_receipt().to_json() != receipt.to_json():
+                    raise ArchiveError(
+                        "receipt differs from its signed execution attestation"
+                    )
+
+    def _validate_execution_envelope_binding(
+        self,
+        candidate_id: str,
+        signed: SignedExecutionEnvelope,
+    ) -> None:
+        candidate = self._load_manifest("candidates", candidate_id)
+        campaign = self._load_manifest("campaigns", str(candidate["campaign_id"]))
+        suite = self.campaign_evaluation_suite(candidate_id)
+        binding = signed.binding
+        if (
+            binding.campaign_id != candidate["campaign_id"]
+            or binding.candidate_id != candidate_id
+            or binding.evaluation_suite_object != campaign["evaluation_suite_object"]
+            or binding.trusted_tests_digest != suite.trusted_tests_digest
+            or binding.runner_image != campaign["runner_image"]
+        ):
+            raise ArchiveError(
+                "execution envelope does not match the archived candidate campaign"
+            )
+        if (
+            binding.evaluation_side == "champion"
+            and binding.candidate_tree_digest != campaign["champion_tree"]
+        ):
+            raise ArchiveError(
+                "champion execution envelope does not match the campaign tree"
+            )
 
     def candidate_runner_image(self, candidate_id: str) -> str:
         candidate = self._load_manifest("candidates", candidate_id)
@@ -1549,6 +1704,8 @@ def _verify_manifest_payload(
             "runner_image",
             "referee_public_key_object",
             "referee_key_id",
+            "executor_public_key_object",
+            "executor_key_id",
             "proposal_input_set_object",
         ),
         "candidates": (
@@ -1588,6 +1745,22 @@ def _verify_manifest_payload(
     for field, value in payload.items():
         if field.endswith("_object"):
             archive.read_object(str(value or ""))
+    if kind == "campaigns":
+        try:
+            referee_id = referee_key_id(
+                archive.read_object(str(payload["referee_public_key_object"]))
+            )
+            executor_id = referee_key_id(
+                archive.read_object(str(payload["executor_public_key_object"]))
+            )
+        except AttestationError as exc:
+            raise ArchiveError("archive campaign public key is invalid") from exc
+        if (
+            payload.get("referee_key_id") != referee_id
+            or payload.get("executor_key_id") != executor_id
+            or referee_id == executor_id
+        ):
+            raise ArchiveError("archive campaign key identities are invalid")
 
 
 def _create_archive_root(path: Path) -> Path:

--- a/tools/improvement_lab/archive.py
+++ b/tools/improvement_lab/archive.py
@@ -785,9 +785,10 @@ class LabArchive:
         campaign = self._load_manifest("campaigns", str(candidate["campaign_id"]))
         suite = self.campaign_evaluation_suite(candidate_id)
         binding = signed.binding
+        expected_subject = candidate_id if binding.evaluation_side == "candidate" else None
         if (
             binding.campaign_id != candidate["campaign_id"]
-            or binding.candidate_id != candidate_id
+            or binding.candidate_id != expected_subject
             or binding.evaluation_suite_object != campaign["evaluation_suite_object"]
             or binding.trusted_tests_digest != suite.trusted_tests_digest
             or binding.runner_image != campaign["runner_image"]

--- a/tools/improvement_lab/cli.py
+++ b/tools/improvement_lab/cli.py
@@ -37,7 +37,16 @@ from tools.improvement_lab.evaluation import (
     evaluate_candidate,
     load_run_receipts,
 )
+from tools.improvement_lab.execution_attestation import (
+    ExecutionAttestationError,
+    load_signed_execution_envelope,
+)
 from tools.improvement_lab.lessons import ImprovementBriefError, build_improvement_brief
+from tools.improvement_lab.run_receipt_adapter import (
+    RunReceiptAdapterError,
+    derive_run_receipt,
+    write_run_receipt,
+)
 from tools.improvement_lab.tournament import (
     TournamentCandidate,
     TournamentError,
@@ -91,6 +100,14 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 - explicit subco
     referee_keygen.add_argument("--public-key", type=Path, required=True)
     referee_keygen.set_defaults(handler=_referee_keygen)
 
+    executor_keygen = subparsers.add_parser(
+        "executor-keygen",
+        help="create a separate Ed25519 execution-attestation keypair",
+    )
+    executor_keygen.add_argument("--private-key", type=Path, required=True)
+    executor_keygen.add_argument("--public-key", type=Path, required=True)
+    executor_keygen.set_defaults(handler=_executor_keygen)
+
     ingest = subparsers.add_parser(
         "ingest",
         help="project prior events into secret-safe structural trajectory capsules",
@@ -136,6 +153,17 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 - explicit subco
     evaluate.add_argument("--output", type=Path, required=True)
     evaluate.add_argument("--require-promotion", action="store_true")
     evaluate.set_defaults(handler=_evaluate)
+
+    receipt_build = subparsers.add_parser(
+        "receipt-build",
+        help="derive one receipt from frozen output and a signed executor envelope",
+    )
+    receipt_build.add_argument("--archive", type=Path, required=True)
+    receipt_build.add_argument("--candidate-id", required=True)
+    receipt_build.add_argument("--artifacts", type=Path, required=True)
+    receipt_build.add_argument("--execution-envelope", type=Path, required=True)
+    receipt_build.add_argument("--output", type=Path, required=True)
+    receipt_build.set_defaults(handler=_receipt_build)
 
     source_check = subparsers.add_parser(
         "source-check",
@@ -210,6 +238,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 - explicit subco
     campaign.add_argument("--evaluation-suite", type=Path, required=True)
     campaign.add_argument("--runner-image", required=True)
     campaign.add_argument("--referee-public-key", type=Path, required=True)
+    campaign.add_argument("--executor-public-key", type=Path, required=True)
     campaign.add_argument("--candidate-artifact-id", action="append", required=True)
     campaign.add_argument("--expected-previous-ref")
     campaign.set_defaults(handler=_campaign_create)
@@ -301,8 +330,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         CandidateWorkspaceError,
         ArchiveError,
         CorpusError,
+        ExecutionAttestationError,
         ImprovementCliError,
         ImprovementBriefError,
+        RunReceiptAdapterError,
         TrustedReplayError,
         TournamentError,
         ValueError,
@@ -321,6 +352,14 @@ def _keygen(args: argparse.Namespace) -> int:
 
 
 def _referee_keygen(args: argparse.Namespace) -> int:
+    return _ed25519_keygen(args)
+
+
+def _executor_keygen(args: argparse.Namespace) -> int:
+    return _ed25519_keygen(args)
+
+
+def _ed25519_keygen(args: argparse.Namespace) -> int:
     private_key, public_key = generate_referee_keypair()
     write_referee_key(args.private_key, private_key, public=False)
     try:
@@ -432,6 +471,39 @@ def _evaluate(args: argparse.Namespace) -> int:
         }
     )
     return 3 if args.require_promotion and not receipt.accepted else 0
+
+
+def _receipt_build(args: argparse.Namespace) -> int:
+    archive = _verified_archive(args.archive)
+    public_key = archive.campaign_executor_public_key(args.candidate_id)
+    envelope = load_signed_execution_envelope(
+        args.execution_envelope,
+        public_key=public_key,
+    )
+    receipt = derive_run_receipt(
+        args.artifacts,
+        envelope=envelope,
+        executor_public_key=public_key,
+    )
+    retained = archive.retain_execution_envelope(
+        args.candidate_id,
+        signed_envelope=envelope,
+    )
+    if retained.get("content_object") != receipt.execution_attestation_digest:
+        raise ImprovementCliError(
+            "retained execution envelope does not match the derived receipt"
+        )
+    write_run_receipt(args.output, receipt)
+    _print_json(
+        {
+            "artifact_id": retained["artifact_id"],
+            "case_id": receipt.case_id,
+            "evaluation_side": envelope.binding.evaluation_side,
+            "execution_attestation_digest": receipt.execution_attestation_digest,
+            "output": str(args.output),
+        }
+    )
+    return 0
 
 
 def _brief(args: argparse.Namespace) -> int:
@@ -576,6 +648,7 @@ def _campaign_create(args: argparse.Namespace) -> int:
         evaluation_suite=suite,
         runner_image=args.runner_image,
         referee_public_key=read_public_key(args.referee_public_key),
+        executor_public_key=read_public_key(args.executor_public_key),
         proposal_input_artifact_ids=tuple(args.candidate_artifact_id),
         expected_previous_ref=args.expected_previous_ref,
     )

--- a/tools/improvement_lab/evaluation.py
+++ b/tools/improvement_lab/evaluation.py
@@ -27,8 +27,10 @@ from pathlib import Path
 from typing import Final
 
 EVALUATION_SCHEMA_VERSION: Final = "ravage.improvement-evaluation.v1"
-RUN_RECEIPT_SCHEMA_VERSION: Final = "ravage.improvement-run.v1"
-RUN_RECEIPT_SET_SCHEMA_VERSION: Final = "ravage.improvement-run-set.v1"
+RUN_RECEIPT_SCHEMA_VERSION: Final = "ravage.improvement-run.v2"
+RUN_RECEIPT_SET_SCHEMA_VERSION: Final = "ravage.improvement-run-set.v2"
+_LEGACY_RUN_RECEIPT_SCHEMA_VERSION: Final = "ravage.improvement-run.v1"
+_LEGACY_RUN_RECEIPT_SET_SCHEMA_VERSION: Final = "ravage.improvement-run-set.v1"
 EVALUATION_SUITE_SCHEMA_VERSION: Final = "ravage.improvement-suite.v1"
 
 _PROMOTABLE_EXECUTION_KINDS = ("fixture", "live")
@@ -393,6 +395,7 @@ class RunReceipt:
     cost_usd: float | None
     request_accounting_status: str = "unspecified"
     run_id: str = ""
+    execution_attestation_digest: str | None = None
     pair_seed_digest: str = ""
     target_snapshot_digest: str = ""
     model_fingerprint: str = ""
@@ -407,6 +410,14 @@ class RunReceipt:
             "prompt_fingerprint",
         ):
             _required_sha256(getattr(self, name), name)
+        if (
+            self.execution_kind in _PROMOTABLE_EXECUTION_KINDS
+            or self.execution_attestation_digest is not None
+        ):
+            _required_sha256(
+                self.execution_attestation_digest,
+                "execution_attestation_digest",
+            )
         if not (
             self.confirmed_finding_count
             <= self.verified_vulnerability_count
@@ -584,6 +595,15 @@ class RunReceipt:
                 _lookup(payload, metric_payload, "run_id"),
                 "run_id",
             ),
+            execution_attestation_digest=_optional_sha256(
+                _lookup(
+                    payload,
+                    metric_payload,
+                    "execution_attestation_digest",
+                    default=None,
+                ),
+                "execution_attestation_digest",
+            ),
             pair_seed_digest=_required_sha256(
                 _lookup(payload, metric_payload, "pair_seed_digest"),
                 "pair_seed_digest",
@@ -615,6 +635,7 @@ class RunReceipt:
             "case_success": self.case_success,
             "expected_vulnerability_count": self.expected_vulnerability_count,
             "run_id": self.run_id,
+            "execution_attestation_digest": self.execution_attestation_digest,
             "pair_seed_digest": self.pair_seed_digest,
             "target_snapshot_digest": self.target_snapshot_digest,
             "model_fingerprint": self.model_fingerprint,
@@ -1045,7 +1066,11 @@ def load_canonical_run_receipts(content: bytes) -> tuple[RunReceipt, ...]:
         raise ValueError("retained run receipt set JSON is invalid") from exc
     if not isinstance(payload, Mapping) or set(payload) != {"schema_version", "receipts"}:
         raise ValueError("retained run receipt set fields are invalid")
-    if payload.get("schema_version") != RUN_RECEIPT_SET_SCHEMA_VERSION:
+    schema_version = payload.get("schema_version")
+    if schema_version not in {
+        RUN_RECEIPT_SET_SCHEMA_VERSION,
+        _LEGACY_RUN_RECEIPT_SET_SCHEMA_VERSION,
+    }:
         raise ValueError("retained run receipt set schema is unsupported")
     raw_receipts = payload.get("receipts")
     if not isinstance(raw_receipts, list):
@@ -1054,6 +1079,16 @@ def load_canonical_run_receipts(content: bytes) -> tuple[RunReceipt, ...]:
         RunReceipt.from_mapping(item) if isinstance(item, Mapping) else _raise_invalid_run_receipt()
         for item in raw_receipts
     )
+    if not receipts:
+        raise ValueError("retained run receipt set cannot be empty")
+    if schema_version == _LEGACY_RUN_RECEIPT_SET_SCHEMA_VERSION:
+        if any(item.execution_kind != _HISTORICAL_EXECUTION_KIND for item in receipts):
+            raise ValueError("legacy promotable run receipts lack execution attestations")
+        if any(item.execution_attestation_digest is not None for item in receipts):
+            raise ValueError("legacy historical receipts cannot add v2 attestation fields")
+        if content != _legacy_canonical_run_receipts_bytes(receipts):
+            raise ValueError("retained legacy run receipt set is not byte-canonical")
+        return receipts
     if content != canonical_run_receipts_bytes(receipts):
         raise ValueError("retained run receipt set is not byte-canonical")
     return receipts
@@ -1067,6 +1102,22 @@ def canonical_json(value: object) -> str:
         separators=(",", ":"),
         sort_keys=True,
     )
+
+
+def _legacy_canonical_run_receipts_bytes(receipts: Sequence[RunReceipt]) -> bytes:
+    ordered = sorted(receipts, key=lambda item: (item.key, item.run_id))
+    legacy_receipts: list[dict[str, object]] = []
+    for receipt in ordered:
+        payload = receipt.to_json()
+        payload["schema_version"] = _LEGACY_RUN_RECEIPT_SCHEMA_VERSION
+        del payload["execution_attestation_digest"]
+        legacy_receipts.append(payload)
+    return canonical_json(
+        {
+            "schema_version": _LEGACY_RUN_RECEIPT_SET_SCHEMA_VERSION,
+            "receipts": legacy_receipts,
+        }
+    ).encode()
 
 
 def _parse_receipts(
@@ -1226,8 +1277,10 @@ def _validate_execution_attestations(
     for side, receipts in (("champion", champion), ("candidate", candidate)):
         seen_runs: set[str] = set()
         seen_seeds: set[tuple[tuple[str, str, str], str]] = set()
+        seen_attestations: set[str] = set()
         duplicate_runs: list[dict[str, object]] = []
         duplicate_seeds: list[dict[str, object]] = []
+        duplicate_attestations: list[dict[str, object]] = []
         for receipt in receipts:
             if receipt.run_id in seen_runs:
                 duplicate_runs.append({"key": _key_json(receipt.key)})
@@ -1236,7 +1289,12 @@ def _validate_execution_attestations(
             if seed_key in seen_seeds:
                 duplicate_seeds.append({"key": _key_json(receipt.key)})
             seen_seeds.add(seed_key)
-        if duplicate_runs or duplicate_seeds:
+            attestation = receipt.execution_attestation_digest
+            if attestation is not None:
+                if attestation in seen_attestations:
+                    duplicate_attestations.append({"key": _key_json(receipt.key)})
+                seen_attestations.add(attestation)
+        if duplicate_runs or duplicate_seeds or duplicate_attestations:
             _reject(
                 rejections,
                 gate="input_and_matching",
@@ -1246,6 +1304,7 @@ def _validate_execution_attestations(
                     "side": side,
                     "duplicate_runs": duplicate_runs,
                     "duplicate_pair_seeds": duplicate_seeds,
+                    "duplicate_execution_envelopes": duplicate_attestations,
                 },
             )
 
@@ -1258,7 +1317,14 @@ def _validate_execution_attestations(
             or champion_item.model_fingerprint != candidate_item.model_fingerprint
         ):
             mismatches.append({"key": _key_json(champion_item.key)})
-        if champion_item.run_id == candidate_item.run_id:
+        if (
+            champion_item.run_id == candidate_item.run_id
+            or (
+                champion_item.execution_attestation_digest is not None
+                and champion_item.execution_attestation_digest
+                == candidate_item.execution_attestation_digest
+            )
+        ):
             reused_sessions.append({"key": _key_json(champion_item.key)})
     if mismatches:
         _reject(
@@ -2001,6 +2067,12 @@ def _required_sha256(value: object, label: str) -> str:
     if _SHA256_RE.fullmatch(digest) is None:
         raise ValueError(f"{label} must be a sha256 digest")
     return digest
+
+
+def _optional_sha256(value: object, label: str) -> str | None:
+    if value is None:
+        return None
+    return _required_sha256(value, label)
 
 
 def _boolean(value: object, label: str) -> bool:

--- a/tools/improvement_lab/execution_attestation.py
+++ b/tools/improvement_lab/execution_attestation.py
@@ -1,0 +1,854 @@
+"""Strict external-executor attestations for promotion-grade run receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import secrets
+import stat
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Final
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from tools.improvement_lab.attestation import (
+    AttestationError,
+    public_key_from_private,
+    referee_key_id,
+)
+from tools.improvement_lab.evaluation import RunReceipt, canonical_json
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Errors crossing this trust boundary are deliberately bounded and content-free.
+# ruff: noqa: EM101, EM102, TRY003, TRY300, TRY301
+
+EXECUTION_ATTESTATION_SCHEMA_VERSION: Final = (
+    "ravage.improvement-execution-attestation.v1"
+)
+EXECUTION_BINDING_SCHEMA_VERSION: Final = "ravage.improvement-execution-binding.v1"
+EXECUTION_OBSERVATIONS_SCHEMA_VERSION: Final = (
+    "ravage.improvement-execution-observations.v1"
+)
+
+_ID_RE: Final = re.compile(r"(?:campaign|candidate)_[0-9a-f]{24}")
+_GIT_TREE_RE: Final = re.compile(r"[0-9a-f]{40,64}")
+_SHA256_RE: Final = re.compile(r"sha256:[0-9a-f]{64}")
+_IMAGE_RE: Final = re.compile(r"[^\s@]+@sha256:[0-9a-f]{64}")
+_OPAQUE_ID_RE: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+_SIGNATURE_RE: Final = re.compile(r"[0-9a-f]{128}")
+
+_KEY_BYTES: Final = 32
+_MAX_SIGNED_BYTES: Final = 16 * 1024 * 1024
+_MAX_VERDICTS: Final = 100_000
+_MAX_COUNT: Final = 1_000_000_000
+_MAX_COST_USD: Final = 1_000_000_000.0
+_MAX_REPEAT: Final = 100
+_MAX_ARTIFACT_CASE_PATH_CHARS: Final = 512
+_MAX_TEXT_CHARS: Final = 1024
+_EXECUTION_KINDS: Final = frozenset({"fixture", "live"})
+_STATUSES: Final = frozenset({"completed", "failed", "timeout", "error"})
+_ACCOUNTING_STATUSES: Final = frozenset(
+    {"invalid", "unavailable", "unspecified", "lower_bound", "reported", "exact"}
+)
+_COUNTED_ACCOUNTING_STATUSES: Final = frozenset({"lower_bound", "reported", "exact"})
+_FINDING_STAGES: Final = (
+    "suspected_vulnerability",
+    "evidence_backed_vulnerability",
+    "verified_vulnerability",
+    "confirmed_finding",
+)
+_FINDING_STAGE_RANK: Final = {
+    stage: rank for rank, stage in enumerate(_FINDING_STAGES, start=1)
+}
+
+
+class ExecutionAttestationError(AttestationError):
+    """Raised when an external execution envelope is malformed or unverifiable."""
+
+
+@dataclass(frozen=True)
+class ExecutionBinding:
+    """Evaluator-owned identities that pin one exact external execution."""
+
+    campaign_id: str
+    candidate_id: str
+    candidate_tree_digest: str
+    candidate_content_digest: str
+    evaluation_suite_object: str
+    trusted_tests_digest: str
+    runner_image: str
+    job_spec_digest: str
+    artifact_tree_digest: str
+    artifact_case_path: str
+    case_id: str
+    cohort: str
+    repeat: int
+    execution_kind: str
+    is_control: bool
+    expected_vulnerability_count: int | None
+    run_id: str
+    pair_seed_digest: str
+    target_snapshot_digest: str
+    model_fingerprint: str
+    prompt_fingerprint: str
+
+    def __post_init__(self) -> None:
+        if (
+            _ID_RE.fullmatch(self.campaign_id) is None
+            or not self.campaign_id.startswith("campaign_")
+        ):
+            raise ExecutionAttestationError("execution campaign identity is invalid")
+        if (
+            _ID_RE.fullmatch(self.candidate_id) is None
+            or not self.candidate_id.startswith("candidate_")
+        ):
+            raise ExecutionAttestationError("execution candidate identity is invalid")
+        if _GIT_TREE_RE.fullmatch(self.candidate_tree_digest) is None:
+            raise ExecutionAttestationError("execution candidate tree digest is invalid")
+        for label, value in (
+            ("candidate content", self.candidate_content_digest),
+            ("evaluation suite object", self.evaluation_suite_object),
+            ("trusted tests", self.trusted_tests_digest),
+            ("job specification", self.job_spec_digest),
+            ("artifact tree", self.artifact_tree_digest),
+            ("run", self.run_id),
+            ("pair seed", self.pair_seed_digest),
+            ("target snapshot", self.target_snapshot_digest),
+            ("model", self.model_fingerprint),
+            ("prompt", self.prompt_fingerprint),
+        ):
+            if _SHA256_RE.fullmatch(value) is None:
+                raise ExecutionAttestationError(f"execution {label} digest is invalid")
+        if _IMAGE_RE.fullmatch(self.runner_image) is None:
+            raise ExecutionAttestationError("execution runner image must be pinned by sha256")
+        _validate_artifact_case_path(self.artifact_case_path)
+        _validate_opaque_id(self.case_id, "case_id")
+        _validate_opaque_id(self.cohort, "cohort")
+        _validate_int(self.repeat, "repeat", minimum=1, maximum=_MAX_REPEAT)
+        if self.execution_kind not in _EXECUTION_KINDS:
+            raise ExecutionAttestationError("execution kind must be fixture or live")
+        if not isinstance(self.is_control, bool):
+            raise ExecutionAttestationError("is_control must be a boolean")
+        _validate_optional_int(
+            self.expected_vulnerability_count,
+            "expected_vulnerability_count",
+        )
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "schema_version": EXECUTION_BINDING_SCHEMA_VERSION,
+            "campaign_id": self.campaign_id,
+            "candidate_id": self.candidate_id,
+            "candidate_tree_digest": self.candidate_tree_digest,
+            "candidate_content_digest": self.candidate_content_digest,
+            "evaluation_suite_object": self.evaluation_suite_object,
+            "trusted_tests_digest": self.trusted_tests_digest,
+            "runner_image": self.runner_image,
+            "job_spec_digest": self.job_spec_digest,
+            "artifact_tree_digest": self.artifact_tree_digest,
+            "artifact_case_path": self.artifact_case_path,
+            "case_id": self.case_id,
+            "cohort": self.cohort,
+            "repeat": self.repeat,
+            "execution_kind": self.execution_kind,
+            "is_control": self.is_control,
+            "expected_vulnerability_count": self.expected_vulnerability_count,
+            "run_id": self.run_id,
+            "pair_seed_digest": self.pair_seed_digest,
+            "target_snapshot_digest": self.target_snapshot_digest,
+            "model_fingerprint": self.model_fingerprint,
+            "prompt_fingerprint": self.prompt_fingerprint,
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: object) -> ExecutionBinding:
+        if not isinstance(payload, dict):
+            raise ExecutionAttestationError("execution binding must be an object")
+        expected = {
+            "schema_version",
+            "campaign_id",
+            "candidate_id",
+            "candidate_tree_digest",
+            "candidate_content_digest",
+            "evaluation_suite_object",
+            "trusted_tests_digest",
+            "runner_image",
+            "job_spec_digest",
+            "artifact_tree_digest",
+            "artifact_case_path",
+            "case_id",
+            "cohort",
+            "repeat",
+            "execution_kind",
+            "is_control",
+            "expected_vulnerability_count",
+            "run_id",
+            "pair_seed_digest",
+            "target_snapshot_digest",
+            "model_fingerprint",
+            "prompt_fingerprint",
+        }
+        if set(payload) != expected:
+            raise ExecutionAttestationError(
+                "execution binding fields do not match the canonical schema"
+            )
+        if payload.get("schema_version") != EXECUTION_BINDING_SCHEMA_VERSION:
+            raise ExecutionAttestationError("execution binding schema is unsupported")
+        return cls(
+            campaign_id=_text(payload["campaign_id"], "campaign_id"),
+            candidate_id=_text(payload["candidate_id"], "candidate_id"),
+            candidate_tree_digest=_text(
+                payload["candidate_tree_digest"], "candidate_tree_digest"
+            ),
+            candidate_content_digest=_text(
+                payload["candidate_content_digest"], "candidate_content_digest"
+            ),
+            evaluation_suite_object=_text(
+                payload["evaluation_suite_object"], "evaluation_suite_object"
+            ),
+            trusted_tests_digest=_text(
+                payload["trusted_tests_digest"], "trusted_tests_digest"
+            ),
+            runner_image=_text(payload["runner_image"], "runner_image"),
+            job_spec_digest=_text(payload["job_spec_digest"], "job_spec_digest"),
+            artifact_tree_digest=_text(
+                payload["artifact_tree_digest"], "artifact_tree_digest"
+            ),
+            artifact_case_path=_text(
+                payload["artifact_case_path"], "artifact_case_path"
+            ),
+            case_id=_text(payload["case_id"], "case_id"),
+            cohort=_text(payload["cohort"], "cohort"),
+            repeat=_integer(payload["repeat"], "repeat"),
+            execution_kind=_text(payload["execution_kind"], "execution_kind"),
+            is_control=_boolean(payload["is_control"], "is_control"),
+            expected_vulnerability_count=_optional_integer(
+                payload["expected_vulnerability_count"],
+                "expected_vulnerability_count",
+            ),
+            run_id=_text(payload["run_id"], "run_id"),
+            pair_seed_digest=_text(payload["pair_seed_digest"], "pair_seed_digest"),
+            target_snapshot_digest=_text(
+                payload["target_snapshot_digest"], "target_snapshot_digest"
+            ),
+            model_fingerprint=_text(payload["model_fingerprint"], "model_fingerprint"),
+            prompt_fingerprint=_text(payload["prompt_fingerprint"], "prompt_fingerprint"),
+        )
+
+
+@dataclass(frozen=True)
+class FindingVerdict:
+    """One secret-free finding identity and its highest evaluator-approved stage."""
+
+    finding_digest: str
+    stage: str
+
+    def __post_init__(self) -> None:
+        if _SHA256_RE.fullmatch(self.finding_digest) is None:
+            raise ExecutionAttestationError("finding verdict digest is invalid")
+        if self.stage not in _FINDING_STAGE_RANK:
+            raise ExecutionAttestationError("finding verdict stage is unsupported")
+
+    def to_json(self) -> dict[str, object]:
+        return {"finding_digest": self.finding_digest, "stage": self.stage}
+
+    @classmethod
+    def from_mapping(cls, payload: object) -> FindingVerdict:
+        if not isinstance(payload, dict) or set(payload) != {"finding_digest", "stage"}:
+            raise ExecutionAttestationError(
+                "finding verdict fields do not match the canonical schema"
+            )
+        return cls(
+            finding_digest=_text(payload["finding_digest"], "finding_digest"),
+            stage=_text(payload["stage"], "stage"),
+        )
+
+
+@dataclass(frozen=True)
+class ExternalRunObservations:
+    """Evaluator-owned, secret-free observations from one frozen run artifact tree."""
+
+    status: str
+    case_success: bool | None
+    physical_request_count: int | None
+    model_request_count: int | None
+    cost_usd: float | None
+    request_accounting_status: str
+    proof_integrity_failure_count: int
+    false_proof_count: int
+    request_accounting_mismatch_count: int
+    loop_violation_count: int
+    provenance_violation_count: int
+    secret_leak_violation_count: int
+    unmetered_action_count: int
+    incomplete_request_count: int
+
+    def __post_init__(self) -> None:
+        if self.status not in _STATUSES:
+            raise ExecutionAttestationError("execution status is unsupported")
+        if self.case_success is not None and not isinstance(self.case_success, bool):
+            raise ExecutionAttestationError("case_success must be a boolean or null")
+        _validate_optional_int(self.physical_request_count, "physical_request_count")
+        _validate_optional_int(self.model_request_count, "model_request_count")
+        _validate_optional_cost(self.cost_usd)
+        if self.request_accounting_status not in _ACCOUNTING_STATUSES:
+            raise ExecutionAttestationError("request accounting status is unsupported")
+        if (
+            self.request_accounting_status in _COUNTED_ACCOUNTING_STATUSES
+            and self.physical_request_count is None
+        ):
+            raise ExecutionAttestationError(
+                "counted request accounting requires a physical request count"
+            )
+        for name in _SAFETY_COUNTER_NAMES:
+            _validate_int(getattr(self, name), name, minimum=0, maximum=_MAX_COUNT)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "schema_version": EXECUTION_OBSERVATIONS_SCHEMA_VERSION,
+            "status": self.status,
+            "case_success": self.case_success,
+            "physical_request_count": self.physical_request_count,
+            "model_request_count": self.model_request_count,
+            "cost_usd": self.cost_usd,
+            "request_accounting_status": self.request_accounting_status,
+            **{name: getattr(self, name) for name in _SAFETY_COUNTER_NAMES},
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: object) -> ExternalRunObservations:
+        if not isinstance(payload, dict):
+            raise ExecutionAttestationError("execution observations must be an object")
+        expected = {
+            "schema_version",
+            "status",
+            "case_success",
+            "physical_request_count",
+            "model_request_count",
+            "cost_usd",
+            "request_accounting_status",
+            *_SAFETY_COUNTER_NAMES,
+        }
+        if set(payload) != expected:
+            raise ExecutionAttestationError(
+                "execution observation fields do not match the canonical schema"
+            )
+        if payload.get("schema_version") != EXECUTION_OBSERVATIONS_SCHEMA_VERSION:
+            raise ExecutionAttestationError("execution observation schema is unsupported")
+        return cls(
+            status=_text(payload["status"], "status"),
+            case_success=_optional_boolean(payload["case_success"], "case_success"),
+            physical_request_count=_optional_integer(
+                payload["physical_request_count"], "physical_request_count"
+            ),
+            model_request_count=_optional_integer(
+                payload["model_request_count"], "model_request_count"
+            ),
+            cost_usd=_optional_float(payload["cost_usd"], "cost_usd"),
+            request_accounting_status=_text(
+                payload["request_accounting_status"], "request_accounting_status"
+            ),
+            **{
+                name: _integer(payload[name], name)
+                for name in _SAFETY_COUNTER_NAMES
+            },
+        )
+
+
+_SAFETY_COUNTER_NAMES: Final = (
+    "proof_integrity_failure_count",
+    "false_proof_count",
+    "request_accounting_mismatch_count",
+    "loop_violation_count",
+    "provenance_violation_count",
+    "secret_leak_violation_count",
+    "unmetered_action_count",
+    "incomplete_request_count",
+)
+
+
+@dataclass(frozen=True)
+class SignedExecutionEnvelope:
+    """A canonical execution binding and observations signed by a trusted executor."""
+
+    binding: ExecutionBinding
+    observations: ExternalRunObservations
+    finding_verdicts: tuple[FindingVerdict, ...]
+    signing_key_id: str
+    signature: str
+
+    def __post_init__(self) -> None:
+        _validate_finding_verdicts(self.finding_verdicts)
+        _validated_key_id(self.signing_key_id)
+        _validated_signature(self.signature)
+
+    def unsigned_json(self) -> dict[str, object]:
+        return {
+            "schema_version": EXECUTION_ATTESTATION_SCHEMA_VERSION,
+            "binding": self.binding.to_json(),
+            "observations": self.observations.to_json(),
+            "finding_verdicts": [item.to_json() for item in self.finding_verdicts],
+            "signing_key_id": self.signing_key_id,
+        }
+
+    def to_json(self) -> dict[str, object]:
+        return {**self.unsigned_json(), "signature": self.signature}
+
+    def to_run_receipt(self) -> RunReceipt:
+        """Derive the referee receipt without accepting caller-supplied detection totals."""
+        stage_counts = _finding_stage_counts(self.finding_verdicts)
+        return RunReceipt(
+            case_id=self.binding.case_id,
+            cohort=self.binding.cohort,
+            repeat=self.binding.repeat,
+            execution_kind=self.binding.execution_kind,
+            status=self.observations.status,
+            is_control=self.binding.is_control,
+            case_success=self.observations.case_success,
+            expected_vulnerability_count=self.binding.expected_vulnerability_count,
+            evidence_backed_vulnerability_count=stage_counts[
+                "evidence_backed_vulnerability"
+            ],
+            verified_vulnerability_count=stage_counts["verified_vulnerability"],
+            confirmed_finding_count=stage_counts["confirmed_finding"],
+            suspected_vulnerability_count=stage_counts["suspected_vulnerability"],
+            proof_integrity_failure_count=self.observations.proof_integrity_failure_count,
+            false_proof_count=self.observations.false_proof_count,
+            request_accounting_mismatch_count=(
+                self.observations.request_accounting_mismatch_count
+            ),
+            loop_violation_count=self.observations.loop_violation_count,
+            provenance_violation_count=self.observations.provenance_violation_count,
+            secret_leak_violation_count=self.observations.secret_leak_violation_count,
+            unmetered_action_count=self.observations.unmetered_action_count,
+            incomplete_request_count=self.observations.incomplete_request_count,
+            physical_request_count=self.observations.physical_request_count,
+            model_request_count=self.observations.model_request_count,
+            cost_usd=self.observations.cost_usd,
+            request_accounting_status=self.observations.request_accounting_status,
+            run_id=self.binding.run_id,
+            pair_seed_digest=self.binding.pair_seed_digest,
+            target_snapshot_digest=self.binding.target_snapshot_digest,
+            model_fingerprint=self.binding.model_fingerprint,
+            prompt_fingerprint=self.binding.prompt_fingerprint,
+        )
+
+
+def sign_execution_envelope(
+    binding: ExecutionBinding,
+    observations: ExternalRunObservations,
+    finding_verdicts: tuple[FindingVerdict, ...],
+    *,
+    private_key: bytes,
+) -> SignedExecutionEnvelope:
+    """Sign one exact execution envelope with a raw Ed25519 private key."""
+    private = _load_private_key(private_key)
+    public_bytes = public_key_from_private(private_key)
+    key_id = referee_key_id(public_bytes)
+    verdicts = _validate_finding_verdicts(finding_verdicts)
+    unsigned = {
+        "schema_version": EXECUTION_ATTESTATION_SCHEMA_VERSION,
+        "binding": binding.to_json(),
+        "observations": observations.to_json(),
+        "finding_verdicts": [item.to_json() for item in verdicts],
+        "signing_key_id": key_id,
+    }
+    encoded = canonical_json(unsigned).encode()
+    if len(encoded) > _MAX_SIGNED_BYTES:
+        raise ExecutionAttestationError("execution attestation exceeds the byte cap")
+    return SignedExecutionEnvelope(
+        binding=binding,
+        observations=observations,
+        finding_verdicts=verdicts,
+        signing_key_id=key_id,
+        signature=private.sign(encoded).hex(),
+    )
+
+
+def verify_signed_execution_envelope(
+    payload: object,
+    *,
+    public_key: bytes,
+) -> SignedExecutionEnvelope:
+    """Validate exact schemas, key identity, and signature before exposing observations."""
+    if not isinstance(payload, dict):
+        raise ExecutionAttestationError("signed execution attestation must be an object")
+    expected = {
+        "schema_version",
+        "binding",
+        "observations",
+        "finding_verdicts",
+        "signing_key_id",
+        "signature",
+    }
+    if set(payload) != expected:
+        raise ExecutionAttestationError(
+            "signed execution attestation fields do not match the canonical schema"
+        )
+    if payload.get("schema_version") != EXECUTION_ATTESTATION_SCHEMA_VERSION:
+        raise ExecutionAttestationError("signed execution attestation schema is unsupported")
+    public = _load_public_key(public_key)
+    key_id = _text(payload["signing_key_id"], "signing_key_id")
+    if key_id != referee_key_id(public_key):
+        raise ExecutionAttestationError("signed execution attestation uses the wrong key")
+    signature = _text(payload["signature"], "signature")
+    if _SIGNATURE_RE.fullmatch(signature) is None:
+        raise ExecutionAttestationError("signed execution attestation signature is invalid")
+    binding = ExecutionBinding.from_mapping(payload.get("binding"))
+    observations = ExternalRunObservations.from_mapping(payload.get("observations"))
+    raw_verdicts = payload.get("finding_verdicts")
+    if not isinstance(raw_verdicts, list):
+        raise ExecutionAttestationError("finding_verdicts must be a list")
+    verdicts = _validate_finding_verdicts(
+        tuple(FindingVerdict.from_mapping(item) for item in raw_verdicts)
+    )
+    unsigned = {
+        "schema_version": EXECUTION_ATTESTATION_SCHEMA_VERSION,
+        "binding": binding.to_json(),
+        "observations": observations.to_json(),
+        "finding_verdicts": [item.to_json() for item in verdicts],
+        "signing_key_id": key_id,
+    }
+    encoded = canonical_json(unsigned).encode()
+    if len(encoded) > _MAX_SIGNED_BYTES:
+        raise ExecutionAttestationError("execution attestation exceeds the byte cap")
+    try:
+        public.verify(bytes.fromhex(signature), encoded)
+    except InvalidSignature as exc:
+        raise ExecutionAttestationError(
+            "signed execution attestation signature verification failed"
+        ) from exc
+    return SignedExecutionEnvelope(binding, observations, verdicts, key_id, signature)
+
+
+def write_signed_execution_envelope(
+    path: Path,
+    signed: SignedExecutionEnvelope,
+) -> None:
+    """Write one owner-only canonical envelope without overwriting an existing path."""
+    verified_shape = SignedExecutionEnvelope(
+        ExecutionBinding.from_mapping(signed.binding.to_json()),
+        ExternalRunObservations.from_mapping(signed.observations.to_json()),
+        _validate_finding_verdicts(signed.finding_verdicts),
+        _validated_key_id(signed.signing_key_id),
+        _validated_signature(signed.signature),
+    )
+    encoded = (canonical_json(verified_shape.to_json()) + "\n").encode()
+    if len(encoded) > _MAX_SIGNED_BYTES:
+        raise ExecutionAttestationError("execution attestation exceeds the byte cap")
+    _private_atomic_write(path, encoded)
+
+
+def load_signed_execution_envelope(
+    path: Path,
+    *,
+    public_key: bytes,
+) -> SignedExecutionEnvelope:
+    """Read, byte-canonicalize, and verify one bounded external execution envelope."""
+    raw = _read_bounded(path, label="signed execution attestation", maximum=_MAX_SIGNED_BYTES)
+    try:
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ExecutionAttestationError("signed execution attestation JSON is invalid") from exc
+    if not isinstance(payload, dict):
+        raise ExecutionAttestationError("signed execution attestation must be an object")
+    try:
+        canonical = (canonical_json(payload) + "\n").encode()
+    except (TypeError, ValueError) as exc:
+        raise ExecutionAttestationError("signed execution attestation JSON is invalid") from exc
+    if raw != canonical:
+        raise ExecutionAttestationError("signed execution attestation is not byte-canonical")
+    return verify_signed_execution_envelope(payload, public_key=public_key)
+
+
+def execution_envelope_digest(signed: SignedExecutionEnvelope) -> str:
+    """Return the digest of the exact canonical signed envelope (without file newline)."""
+    encoded = canonical_json(signed.to_json()).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _finding_stage_counts(verdicts: tuple[FindingVerdict, ...]) -> dict[str, int]:
+    return {
+        "suspected_vulnerability": sum(
+            item.stage == "suspected_vulnerability" for item in verdicts
+        ),
+        "evidence_backed_vulnerability": sum(
+            _FINDING_STAGE_RANK[item.stage]
+            >= _FINDING_STAGE_RANK["evidence_backed_vulnerability"]
+            for item in verdicts
+        ),
+        "verified_vulnerability": sum(
+            _FINDING_STAGE_RANK[item.stage]
+            >= _FINDING_STAGE_RANK["verified_vulnerability"]
+            for item in verdicts
+        ),
+        "confirmed_finding": sum(item.stage == "confirmed_finding" for item in verdicts),
+    }
+
+
+def _validate_finding_verdicts(
+    verdicts: tuple[FindingVerdict, ...],
+) -> tuple[FindingVerdict, ...]:
+    if not isinstance(verdicts, tuple):
+        raise ExecutionAttestationError("finding_verdicts must be a tuple")
+    if len(verdicts) > _MAX_VERDICTS:
+        raise ExecutionAttestationError("finding verdict count exceeds the supported bound")
+    if any(not isinstance(item, FindingVerdict) for item in verdicts):
+        raise ExecutionAttestationError("finding verdict entry is invalid")
+    digests = tuple(item.finding_digest for item in verdicts)
+    if len(digests) != len(set(digests)):
+        raise ExecutionAttestationError("finding verdict digests must be distinct")
+    if digests != tuple(sorted(digests)):
+        raise ExecutionAttestationError("finding verdicts must use canonical digest order")
+    return verdicts
+
+
+def _validate_artifact_case_path(value: object) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_ARTIFACT_CASE_PATH_CHARS
+        or "\\" in value
+        or "\0" in value
+    ):
+        raise ExecutionAttestationError("artifact_case_path is invalid")
+    if value == ".":
+        return
+    if value.startswith("/") or value.endswith("/"):
+        raise ExecutionAttestationError("artifact_case_path must be relative and normalized")
+    components = value.split("/")
+    if any(component in {"", ".", ".."} for component in components):
+        raise ExecutionAttestationError("artifact_case_path must be relative and normalized")
+    if PurePosixPath(value).as_posix() != value:
+        raise ExecutionAttestationError("artifact_case_path must be relative and normalized")
+
+
+def _validate_opaque_id(value: object, label: str) -> None:
+    if not isinstance(value, str) or _OPAQUE_ID_RE.fullmatch(value) is None:
+        raise ExecutionAttestationError(f"execution {label} is invalid")
+
+
+def _validate_int(
+    value: object,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ExecutionAttestationError(f"{label} is outside the supported bounds")
+
+
+def _validate_optional_int(value: object, label: str) -> None:
+    if value is not None:
+        _validate_int(value, label, minimum=0, maximum=_MAX_COUNT)
+
+
+def _validate_optional_cost(value: object) -> None:
+    if value is None:
+        return
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(float(value))
+        or not 0 <= float(value) <= _MAX_COST_USD
+    ):
+        raise ExecutionAttestationError("cost_usd is outside the supported bounds")
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip() or "\0" in value:
+        raise ExecutionAttestationError(f"{label} is invalid")
+    if len(value) > _MAX_TEXT_CHARS:
+        raise ExecutionAttestationError(f"{label} exceeds the character cap")
+    return value
+
+
+def _integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ExecutionAttestationError(f"{label} must be an integer")
+    return value
+
+
+def _optional_integer(value: object, label: str) -> int | None:
+    return None if value is None else _integer(value, label)
+
+
+def _boolean(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ExecutionAttestationError(f"{label} must be a boolean")
+    return value
+
+
+def _optional_boolean(value: object, label: str) -> bool | None:
+    return None if value is None else _boolean(value, label)
+
+
+def _optional_float(value: object, label: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ExecutionAttestationError(f"{label} must be numeric or null")
+    return float(value)
+
+
+def _validated_key_id(value: object) -> str:
+    key_id = _text(value, "signing_key_id")
+    if _SHA256_RE.fullmatch(key_id) is None:
+        raise ExecutionAttestationError("signing key identity is invalid")
+    return key_id
+
+
+def _validated_signature(value: object) -> str:
+    signature = _text(value, "signature")
+    if _SIGNATURE_RE.fullmatch(signature) is None:
+        raise ExecutionAttestationError("signed execution attestation signature is invalid")
+    return signature
+
+
+def _load_private_key(content: bytes) -> Ed25519PrivateKey:
+    if not isinstance(content, bytes) or len(content) != _KEY_BYTES:
+        raise ExecutionAttestationError("executor private key must contain 32 raw bytes")
+    try:
+        return Ed25519PrivateKey.from_private_bytes(content)
+    except ValueError as exc:
+        raise ExecutionAttestationError("executor private key is invalid") from exc
+
+
+def _load_public_key(content: bytes) -> Ed25519PublicKey:
+    if not isinstance(content, bytes) or len(content) != _KEY_BYTES:
+        raise ExecutionAttestationError("executor public key must contain 32 raw bytes")
+    try:
+        return Ed25519PublicKey.from_public_bytes(content)
+    except ValueError as exc:
+        raise ExecutionAttestationError("executor public key is invalid") from exc
+
+
+def _read_bounded(path: Path, *, label: str, maximum: int) -> bytes:
+    candidate = path.expanduser()
+    descriptor = -1
+    try:
+        before = candidate.lstat()
+        if (
+            stat.S_ISLNK(before.st_mode)
+            or not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+        ):
+            raise ExecutionAttestationError(f"{label} must be a regular single-link file")
+        if before.st_size > maximum:
+            raise ExecutionAttestationError(f"{label} exceeds the byte cap")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(candidate, flags)
+        opened = os.fstat(descriptor)
+        if _file_version(before) != _file_version(opened):
+            raise ExecutionAttestationError(f"{label} changed while it was opened")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            raw = stream.read(maximum + 1)
+            after = os.fstat(stream.fileno())
+        if len(raw) > maximum:
+            raise ExecutionAttestationError(f"{label} exceeds the byte cap")
+        if _file_version(opened) != _file_version(after):
+            raise ExecutionAttestationError(f"{label} changed while it was read")
+        return raw
+    except ExecutionAttestationError:
+        raise
+    except OSError as exc:
+        raise ExecutionAttestationError(f"cannot read {label}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _private_atomic_write(path: Path, content: bytes) -> None:
+    target = path.expanduser()
+    if target.exists() or target.is_symlink():
+        raise ExecutionAttestationError("execution attestation output already exists")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        parent = target.parent.lstat()
+        if stat.S_ISLNK(parent.st_mode) or not stat.S_ISDIR(parent.st_mode):
+            raise ExecutionAttestationError(
+                "execution attestation output parent must be a real directory"
+            )
+        temporary = target.with_name(f".{target.name}.{os.getpid()}.{secrets.token_hex(4)}")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = -1
+        try:
+            descriptor = os.open(temporary, flags, 0o600)
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary.replace(target)
+            target.chmod(0o600)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+    except ExecutionAttestationError:
+        raise
+    except OSError as exc:
+        raise ExecutionAttestationError("cannot write execution attestation") from exc
+
+
+def _file_version(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ExecutionAttestationError(
+                "signed execution attestation contains a duplicate JSON key"
+            )
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> object:
+    raise ExecutionAttestationError(
+        f"signed execution attestation contains unsupported {value}"
+    )
+
+
+__all__ = [
+    "EXECUTION_ATTESTATION_SCHEMA_VERSION",
+    "EXECUTION_BINDING_SCHEMA_VERSION",
+    "EXECUTION_OBSERVATIONS_SCHEMA_VERSION",
+    "ExecutionAttestationError",
+    "ExecutionBinding",
+    "ExternalRunObservations",
+    "FindingVerdict",
+    "SignedExecutionEnvelope",
+    "execution_envelope_digest",
+    "load_signed_execution_envelope",
+    "sign_execution_envelope",
+    "verify_signed_execution_envelope",
+    "write_signed_execution_envelope",
+]

--- a/tools/improvement_lab/execution_attestation.py
+++ b/tools/improvement_lab/execution_attestation.py
@@ -83,7 +83,7 @@ class ExecutionBinding:
     """Evaluator-owned identities that pin one exact external execution."""
 
     campaign_id: str
-    candidate_id: str
+    candidate_id: str | None
     candidate_tree_digest: str
     candidate_content_digest: str
     evaluation_suite_object: str
@@ -111,11 +111,7 @@ class ExecutionBinding:
             or not self.campaign_id.startswith("campaign_")
         ):
             raise ExecutionAttestationError("execution campaign identity is invalid")
-        if (
-            _ID_RE.fullmatch(self.candidate_id) is None
-            or not self.candidate_id.startswith("candidate_")
-        ):
-            raise ExecutionAttestationError("execution candidate identity is invalid")
+        _validate_execution_subject(self.evaluation_side, self.candidate_id)
         if _GIT_TREE_RE.fullmatch(self.candidate_tree_digest) is None:
             raise ExecutionAttestationError("execution candidate tree digest is invalid")
         for label, value in (
@@ -140,10 +136,6 @@ class ExecutionBinding:
         _validate_int(self.repeat, "repeat", minimum=1, maximum=_MAX_REPEAT)
         if self.execution_kind not in _EXECUTION_KINDS:
             raise ExecutionAttestationError("execution kind must be fixture or live")
-        if self.evaluation_side not in _EVALUATION_SIDES:
-            raise ExecutionAttestationError(
-                "evaluation_side must be champion or candidate"
-            )
         if not isinstance(self.is_control, bool):
             raise ExecutionAttestationError("is_control must be a boolean")
         _validate_optional_int(
@@ -215,7 +207,11 @@ class ExecutionBinding:
             raise ExecutionAttestationError("execution binding schema is unsupported")
         return cls(
             campaign_id=_text(payload["campaign_id"], "campaign_id"),
-            candidate_id=_text(payload["candidate_id"], "candidate_id"),
+            candidate_id=(
+                None
+                if payload["candidate_id"] is None
+                else _text(payload["candidate_id"], "candidate_id")
+            ),
             candidate_tree_digest=_text(
                 payload["candidate_tree_digest"], "candidate_tree_digest"
             ),
@@ -643,6 +639,22 @@ def _validate_finding_verdicts(
     if digests != tuple(sorted(digests)):
         raise ExecutionAttestationError("finding verdicts must use canonical digest order")
     return verdicts
+
+
+def _validate_execution_subject(side: object, candidate_id: object) -> None:
+    if side not in _EVALUATION_SIDES:
+        raise ExecutionAttestationError(
+            "evaluation_side must be champion or candidate"
+        )
+    if side == "candidate":
+        if (
+            not isinstance(candidate_id, str)
+            or _ID_RE.fullmatch(candidate_id) is None
+            or not candidate_id.startswith("candidate_")
+        ):
+            raise ExecutionAttestationError("candidate execution identity is invalid")
+    elif candidate_id is not None:
+        raise ExecutionAttestationError("champion execution must be campaign-scoped")
 
 
 def _validate_artifact_case_path(value: object) -> None:

--- a/tools/improvement_lab/execution_attestation.py
+++ b/tools/improvement_lab/execution_attestation.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 EXECUTION_ATTESTATION_SCHEMA_VERSION: Final = (
     "ravage.improvement-execution-attestation.v1"
 )
-EXECUTION_BINDING_SCHEMA_VERSION: Final = "ravage.improvement-execution-binding.v1"
+EXECUTION_BINDING_SCHEMA_VERSION: Final = "ravage.improvement-execution-binding.v2"
 EXECUTION_OBSERVATIONS_SCHEMA_VERSION: Final = (
     "ravage.improvement-execution-observations.v1"
 )
@@ -57,6 +57,7 @@ _MAX_REPEAT: Final = 100
 _MAX_ARTIFACT_CASE_PATH_CHARS: Final = 512
 _MAX_TEXT_CHARS: Final = 1024
 _EXECUTION_KINDS: Final = frozenset({"fixture", "live"})
+_EVALUATION_SIDES: Final = frozenset({"champion", "candidate"})
 _STATUSES: Final = frozenset({"completed", "failed", "timeout", "error"})
 _ACCOUNTING_STATUSES: Final = frozenset(
     {"invalid", "unavailable", "unspecified", "lower_bound", "reported", "exact"}
@@ -95,6 +96,7 @@ class ExecutionBinding:
     cohort: str
     repeat: int
     execution_kind: str
+    evaluation_side: str
     is_control: bool
     expected_vulnerability_count: int | None
     run_id: str
@@ -138,6 +140,10 @@ class ExecutionBinding:
         _validate_int(self.repeat, "repeat", minimum=1, maximum=_MAX_REPEAT)
         if self.execution_kind not in _EXECUTION_KINDS:
             raise ExecutionAttestationError("execution kind must be fixture or live")
+        if self.evaluation_side not in _EVALUATION_SIDES:
+            raise ExecutionAttestationError(
+                "evaluation_side must be champion or candidate"
+            )
         if not isinstance(self.is_control, bool):
             raise ExecutionAttestationError("is_control must be a boolean")
         _validate_optional_int(
@@ -162,6 +168,7 @@ class ExecutionBinding:
             "cohort": self.cohort,
             "repeat": self.repeat,
             "execution_kind": self.execution_kind,
+            "evaluation_side": self.evaluation_side,
             "is_control": self.is_control,
             "expected_vulnerability_count": self.expected_vulnerability_count,
             "run_id": self.run_id,
@@ -191,6 +198,7 @@ class ExecutionBinding:
             "cohort",
             "repeat",
             "execution_kind",
+            "evaluation_side",
             "is_control",
             "expected_vulnerability_count",
             "run_id",
@@ -232,6 +240,7 @@ class ExecutionBinding:
             cohort=_text(payload["cohort"], "cohort"),
             repeat=_integer(payload["repeat"], "repeat"),
             execution_kind=_text(payload["execution_kind"], "execution_kind"),
+            evaluation_side=_text(payload["evaluation_side"], "evaluation_side"),
             is_control=_boolean(payload["is_control"], "is_control"),
             expected_vulnerability_count=_optional_integer(
                 payload["expected_vulnerability_count"],
@@ -438,6 +447,7 @@ class SignedExecutionEnvelope:
             cost_usd=self.observations.cost_usd,
             request_accounting_status=self.observations.request_accounting_status,
             run_id=self.binding.run_id,
+            execution_attestation_digest=execution_envelope_digest(self),
             pair_seed_digest=self.binding.pair_seed_digest,
             target_snapshot_digest=self.binding.target_snapshot_digest,
             model_fingerprint=self.binding.model_fingerprint,
@@ -544,7 +554,7 @@ def write_signed_execution_envelope(
         _validated_key_id(signed.signing_key_id),
         _validated_signature(signed.signature),
     )
-    encoded = (canonical_json(verified_shape.to_json()) + "\n").encode()
+    encoded = canonical_execution_envelope_bytes(verified_shape)
     if len(encoded) > _MAX_SIGNED_BYTES:
         raise ExecutionAttestationError("execution attestation exceeds the byte cap")
     _private_atomic_write(path, encoded)
@@ -557,9 +567,22 @@ def load_signed_execution_envelope(
 ) -> SignedExecutionEnvelope:
     """Read, byte-canonicalize, and verify one bounded external execution envelope."""
     raw = _read_bounded(path, label="signed execution attestation", maximum=_MAX_SIGNED_BYTES)
+    return load_canonical_execution_envelope_bytes(raw, public_key=public_key)
+
+
+def load_canonical_execution_envelope_bytes(
+    content: bytes,
+    *,
+    public_key: bytes,
+) -> SignedExecutionEnvelope:
+    """Strictly parse canonical retained bytes and verify the executor signature."""
+    if not isinstance(content, bytes) or not content or len(content) > _MAX_SIGNED_BYTES:
+        raise ExecutionAttestationError(
+            "signed execution attestation is empty or exceeds the byte cap"
+        )
     try:
         payload = json.loads(
-            raw,
+            content,
             object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_constant,
         )
@@ -571,15 +594,19 @@ def load_signed_execution_envelope(
         canonical = (canonical_json(payload) + "\n").encode()
     except (TypeError, ValueError) as exc:
         raise ExecutionAttestationError("signed execution attestation JSON is invalid") from exc
-    if raw != canonical:
+    if content != canonical:
         raise ExecutionAttestationError("signed execution attestation is not byte-canonical")
     return verify_signed_execution_envelope(payload, public_key=public_key)
 
 
 def execution_envelope_digest(signed: SignedExecutionEnvelope) -> str:
-    """Return the digest of the exact canonical signed envelope (without file newline)."""
-    encoded = canonical_json(signed.to_json()).encode()
-    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+    """Return the CAS digest of the exact canonical signed-envelope bytes."""
+    return f"sha256:{hashlib.sha256(canonical_execution_envelope_bytes(signed)).hexdigest()}"
+
+
+def canonical_execution_envelope_bytes(signed: SignedExecutionEnvelope) -> bytes:
+    """Return the byte form written to disk and retained by the archive."""
+    return (canonical_json(signed.to_json()) + "\n").encode()
 
 
 def _finding_stage_counts(verdicts: tuple[FindingVerdict, ...]) -> dict[str, int]:
@@ -846,7 +873,9 @@ __all__ = [
     "ExternalRunObservations",
     "FindingVerdict",
     "SignedExecutionEnvelope",
+    "canonical_execution_envelope_bytes",
     "execution_envelope_digest",
+    "load_canonical_execution_envelope_bytes",
     "load_signed_execution_envelope",
     "sign_execution_envelope",
     "verify_signed_execution_envelope",

--- a/tools/improvement_lab/offline_executor.py
+++ b/tools/improvement_lab/offline_executor.py
@@ -1,0 +1,583 @@
+"""Bounded host-side execution for trusted offline candidate jobs."""
+
+# These messages are the fail-closed operator diagnostics for the executor.
+# ruff: noqa: C901, EM101, EM102, PLR0913, S108, TRY003
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import stat
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, Literal, Protocol
+
+from tools.improvement_lab.workspace import (
+    CandidateWorkspace,
+    CandidateWorkspaceError,
+    GitSourceState,
+    OfflineContainerJob,
+    _decode_canonical_json_object,
+    _verify_candidate_marker,
+    _verify_candidate_view,
+    directory_tree_digest,
+)
+
+if TYPE_CHECKING:
+    from typing import IO
+
+
+_IMAGE_RE: Final = re.compile(r"[^\s@]+@sha256:[0-9a-f]{64}")
+_NAME_RE: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}")
+_OBJECT_RE: Final = re.compile(r"[0-9a-f]{40,64}")
+_SHA256_RE: Final = re.compile(r"sha256:[0-9a-f]{64}")
+_HEX_SHA256_RE: Final = re.compile(r"[0-9a-f]{64}")
+
+DEFAULT_TIMEOUT_SECONDS = 900.0
+MAX_TIMEOUT_SECONDS = 3600.0
+_CLEANUP_TIMEOUT_SECONDS = 30.0
+_STOP_TIMEOUT_SECONDS = 5.0
+_STREAM_LIMIT_BYTES = 1024 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
+_MAX_MARKER_BYTES = 4096
+_MIN_JOB_ARGV = 35
+
+# These are deliberately module-level so evaluator deployments can lower them,
+# but the executor never accepts caller-supplied values that raise the bounds.
+_MAX_OUTPUT_ENTRIES = 4096
+_MAX_OUTPUT_DEPTH = 16
+_MAX_OUTPUT_FILE_BYTES = 16 * 1024 * 1024
+_MAX_OUTPUT_BYTES = 64 * 1024 * 1024
+
+
+class OfflineExecutionError(RuntimeError):
+    """Raised when an offline job cannot be executed or frozen safely."""
+
+
+@dataclass(frozen=True)
+class FrozenOutputTree:
+    """A deterministic description of a validated output tree."""
+
+    digest: str
+    file_count: int
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class OfflineExecutionResult:
+    """Externally recordable execution and output evidence without raw logs."""
+
+    status: Literal["exited", "timed_out"]
+    exit_code: int | None
+    output_digest: str
+    output_file_count: int
+    output_bytes: int
+    stdout_digest: str
+    stderr_digest: str
+
+
+class RunningProcess(Protocol):
+    @property
+    def stdout(self) -> IO[bytes] | None: ...
+
+    @property
+    def stderr(self) -> IO[bytes] | None: ...
+
+    @property
+    def returncode(self) -> int | None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
+class ProcessRunner(Protocol):
+    """A Popen-compatible injectable process launcher."""
+
+    def __call__(
+        self,
+        argv: tuple[str, ...],
+        *,
+        cwd: Path,
+        stdin: int,
+        stdout: int,
+        stderr: int,
+        shell: bool,
+        close_fds: bool,
+    ) -> RunningProcess: ...
+
+
+@dataclass
+class _StreamCapture:
+    stream: IO[bytes]
+    digest: hashlib._Hash
+    captured_bytes: int = 0
+    truncated: bool = False
+    error: BaseException | None = None
+    thread: threading.Thread | None = None
+
+    @classmethod
+    def start(cls, stream: IO[bytes]) -> _StreamCapture:
+        digest = hashlib.sha256(b"ravage-offline-stream-v1\0")
+        capture = cls(stream=stream, digest=digest)
+        thread = threading.Thread(target=capture._consume, daemon=True)
+        capture.thread = thread
+        thread.start()
+        return capture
+
+    def _consume(self) -> None:
+        try:
+            while chunk := self.stream.read(_READ_CHUNK_BYTES):
+                remaining = _STREAM_LIMIT_BYTES - self.captured_bytes
+                if remaining > 0:
+                    accepted = chunk[:remaining]
+                    self.digest.update(accepted)
+                    self.captured_bytes += len(accepted)
+                if len(chunk) > remaining:
+                    self.truncated = True
+        except (OSError, ValueError) as exc:  # pragma: no cover - defensive I/O boundary
+            self.error = exc
+
+    def finish(self) -> str:
+        if self.thread is None:  # pragma: no cover - construction invariant
+            raise OfflineExecutionError("process output stream was not started")
+        self.thread.join(timeout=_STOP_TIMEOUT_SECONDS)
+        if self.thread.is_alive():
+            raise OfflineExecutionError("process output stream did not close")
+        if self.error is not None:
+            raise OfflineExecutionError("process output stream could not be read") from self.error
+        digest = self.digest.copy()
+        digest.update(b"\0truncated" if self.truncated else b"\0complete")
+        return f"sha256:{digest.hexdigest()}"
+
+
+def execute_offline_job(
+    job: OfflineContainerJob,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    runner: ProcessRunner | None = None,
+) -> OfflineExecutionResult:
+    """Revalidate, execute, stop if needed, and freeze one offline job."""
+    timeout = _validated_timeout(timeout_seconds)
+    container_name = _revalidate_job(job)
+    launch = runner or _default_runner
+    process = _launch(
+        launch,
+        job.argv,
+        cwd=job.candidate_workspace,
+        capture_streams=True,
+    )
+    if process.stdout is None or process.stderr is None:
+        _stop_process(process)
+        raise OfflineExecutionError("process runner did not provide output streams")
+    stdout = _StreamCapture.start(process.stdout)
+    stderr = _StreamCapture.start(process.stderr)
+
+    status: Literal["exited", "timed_out"] = "exited"
+    exit_code: int | None
+    try:
+        exit_code = process.wait(timeout=timeout)
+    except (subprocess.TimeoutExpired, TimeoutError):
+        status = "timed_out"
+        exit_code = None
+        try:
+            _clean_timed_out_container(launch, container_name, cwd=job.output_root)
+        finally:
+            _stop_process(process)
+
+    stdout_digest = stdout.finish()
+    stderr_digest = stderr.finish()
+    frozen = freeze_output_tree(job.output_root)
+    return OfflineExecutionResult(
+        status=status,
+        exit_code=exit_code,
+        output_digest=frozen.digest,
+        output_file_count=frozen.file_count,
+        output_bytes=frozen.total_bytes,
+        stdout_digest=stdout_digest,
+        stderr_digest=stderr_digest,
+    )
+
+
+def freeze_output_tree(root: Path) -> FrozenOutputTree:
+    """Validate and hash a bounded, stable, symlink-free output tree."""
+    directory = _canonical_directory(root, label="job output")
+    records: list[dict[str, object]] = []
+    state = {"entries": 0, "files": 0, "bytes": 0}
+    try:
+        _freeze_directory(
+            directory,
+            root=directory,
+            depth=0,
+            records=records,
+            state=state,
+        )
+    except OfflineExecutionError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise OfflineExecutionError("cannot freeze job output") from exc
+    encoded = json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
+    return FrozenOutputTree(
+        digest=f"sha256:{hashlib.sha256(encoded).hexdigest()}",
+        file_count=state["files"],
+        total_bytes=state["bytes"],
+    )
+
+
+def _validated_timeout(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OfflineExecutionError("offline timeout must be a finite number")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0 or timeout > MAX_TIMEOUT_SECONDS:
+        raise OfflineExecutionError("offline timeout is outside the allowed bound")
+    return timeout
+
+
+def _revalidate_job(job: OfflineContainerJob) -> str:
+    if not isinstance(job, OfflineContainerJob):
+        raise OfflineExecutionError("offline job has an unsupported type")
+    if _IMAGE_RE.fullmatch(job.image) is None:
+        raise OfflineExecutionError("offline image is not pinned by sha256 digest")
+    if (
+        _NAME_RE.fullmatch(job.candidate_id) is None
+        or _OBJECT_RE.fullmatch(job.candidate_tree_digest) is None
+        or _SHA256_RE.fullmatch(job.candidate_content_digest) is None
+        or _SHA256_RE.fullmatch(job.trusted_tests_digest) is None
+    ):
+        raise OfflineExecutionError("offline job identity is invalid")
+
+    roots = {
+        "candidate workspace": _canonical_directory(
+            job.candidate_workspace, label="candidate workspace"
+        ),
+        "episode directory": _canonical_directory(job.episodes_root, label="episode directory"),
+        "trusted test directory": _canonical_directory(
+            job.trusted_tests_root, label="trusted test directory"
+        ),
+        "job output": _canonical_directory(job.output_root, label="job output"),
+    }
+    _require_disjoint_roots(roots)
+    if any(job.output_root.iterdir()):
+        raise OfflineExecutionError("job output must be empty before launch")
+
+    container_name = _validate_argv(job, roots)
+    try:
+        marker = _read_candidate_marker(job.candidate_workspace)
+        expected = CandidateWorkspace(
+            candidate_id=job.candidate_id,
+            path=job.candidate_workspace,
+            base_commit=str(marker["base_commit"]),
+            patch_sha256=str(marker["patch_sha256"]),
+            candidate_tree_digest=job.candidate_tree_digest,
+            candidate_content_digest=job.candidate_content_digest,
+            source_state=GitSourceState(
+                root=job.candidate_workspace,
+                head_commit=str(marker["base_commit"]),
+                tree_digest=job.candidate_tree_digest,
+                status_digest="",
+                dirty_entries=0,
+            ),
+        )
+        _verify_candidate_marker(job.candidate_workspace, expected=expected)
+        _verify_candidate_view(job.episodes_root)
+        if directory_tree_digest(job.trusted_tests_root) != job.trusted_tests_digest:
+            raise OfflineExecutionError("trusted test tree changed before launch")
+    except CandidateWorkspaceError as exc:
+        raise OfflineExecutionError("offline job inputs changed before launch") from exc
+    return container_name
+
+
+def _read_candidate_marker(root: Path) -> dict[str, object]:
+    marker = root / ".improvement-candidate.json"
+    try:
+        marker_stat = marker.lstat()
+        if (
+            stat.S_ISLNK(marker_stat.st_mode)
+            or not stat.S_ISREG(marker_stat.st_mode)
+            or marker_stat.st_nlink != 1
+            or marker_stat.st_size > _MAX_MARKER_BYTES
+        ):
+            raise OfflineExecutionError("candidate marker is unsafe")
+        payload = _decode_canonical_json_object(marker.read_bytes())
+    except (OSError, UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise OfflineExecutionError("candidate marker is unreadable") from exc
+    if (
+        _OBJECT_RE.fullmatch(str(payload.get("base_commit") or "")) is None
+        or _HEX_SHA256_RE.fullmatch(str(payload.get("patch_sha256") or "")) is None
+    ):
+        raise OfflineExecutionError("candidate marker identity is invalid")
+    return payload
+
+
+def _validate_argv(job: OfflineContainerJob, roots: dict[str, Path]) -> str:
+    argv = job.argv
+    invalid_item = any(
+        not isinstance(item, str) or not item or "\0" in item for item in argv
+    )
+    if len(argv) < _MIN_JOB_ARGV or invalid_item:
+        raise OfflineExecutionError("offline argv is invalid")
+    container_name = argv[5]
+    if _NAME_RE.fullmatch(container_name) is None:
+        raise OfflineExecutionError("offline container name is invalid")
+    uid = os.getuid() or 65532
+    gid = os.getgid() or 65532
+    expected = (
+        "docker",
+        "run",
+        "--rm",
+        "--pull=never",
+        "--name",
+        container_name,
+        "--network",
+        "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--pids-limit",
+        "256",
+        "--memory",
+        "4g",
+        "--cpus",
+        "2",
+        "--user",
+        f"{uid}:{gid}",
+        "--tmpfs",
+        "/tmp:rw,nosuid,nodev,noexec,size=512m",
+        "--mount",
+        f"type=bind,src={roots['candidate workspace']},dst=/candidate,readonly",
+        "--mount",
+        f"type=bind,src={roots['episode directory']},dst=/episodes,readonly",
+        "--mount",
+        f"type=bind,src={roots['trusted test directory']},dst=/trusted-tests,readonly",
+        "--mount",
+        f"type=bind,src={roots['job output']},dst=/out",
+        "--workdir",
+        "/candidate",
+        job.image,
+    )
+    if argv[: len(expected)] != expected or len(argv) == len(expected):
+        raise OfflineExecutionError("offline argv differs from the hardened job contract")
+    return container_name
+
+
+def _canonical_directory(path: Path, *, label: str) -> Path:
+    if not isinstance(path, Path) or not path.is_absolute():
+        raise OfflineExecutionError(f"{label} must be an absolute directory")
+    try:
+        item_stat = path.lstat()
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise OfflineExecutionError(f"cannot inspect {label}") from exc
+    if (
+        resolved != path
+        or stat.S_ISLNK(item_stat.st_mode)
+        or not stat.S_ISDIR(item_stat.st_mode)
+    ):
+        raise OfflineExecutionError(f"{label} must not use symlinks")
+    return resolved
+
+
+def _require_disjoint_roots(roots: dict[str, Path]) -> None:
+    entries = list(roots.items())
+    for index, (first_label, first) in enumerate(entries):
+        for second_label, second in entries[index + 1 :]:
+            if first == second or first.is_relative_to(second) or second.is_relative_to(first):
+                raise OfflineExecutionError(
+                    f"{first_label} and {second_label} must be disjoint"
+                )
+
+
+def _launch(
+    runner: ProcessRunner,
+    argv: tuple[str, ...],
+    *,
+    cwd: Path,
+    capture_streams: bool,
+) -> RunningProcess:
+    stdout = subprocess.PIPE if capture_streams else subprocess.DEVNULL
+    stderr = subprocess.PIPE if capture_streams else subprocess.DEVNULL
+    try:
+        return runner(
+            argv,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            shell=False,
+            close_fds=True,
+        )
+    except OSError as exc:
+        raise OfflineExecutionError("offline process could not be started") from exc
+
+
+def _default_runner(
+    argv: tuple[str, ...],
+    *,
+    cwd: Path,
+    stdin: int,
+    stdout: int,
+    stderr: int,
+    shell: bool,
+    close_fds: bool,
+) -> RunningProcess:
+    return subprocess.Popen(  # noqa: S603
+        argv,
+        cwd=cwd,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        shell=shell,
+        close_fds=close_fds,
+        text=False,
+    )
+
+
+def _clean_timed_out_container(
+    runner: ProcessRunner,
+    container_name: str,
+    *,
+    cwd: Path,
+) -> None:
+    cleanup_argv = ("docker", "rm", "--force", "--", container_name)
+    cleanup = _launch(runner, cleanup_argv, cwd=cwd, capture_streams=False)
+    try:
+        exit_code = cleanup.wait(timeout=_CLEANUP_TIMEOUT_SECONDS)
+    except (subprocess.TimeoutExpired, TimeoutError) as exc:
+        _stop_process(cleanup)
+        raise OfflineExecutionError("timed-out container cleanup did not finish") from exc
+    if exit_code != 0:
+        raise OfflineExecutionError("timed-out container cleanup failed")
+
+
+def _stop_process(process: RunningProcess) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=_STOP_TIMEOUT_SECONDS)
+    except (OSError, subprocess.TimeoutExpired, TimeoutError):
+        try:
+            process.kill()
+            process.wait(timeout=_STOP_TIMEOUT_SECONDS)
+        except (OSError, subprocess.TimeoutExpired, TimeoutError):
+            pass
+
+
+def _freeze_directory(
+    directory: Path,
+    *,
+    root: Path,
+    depth: int,
+    records: list[dict[str, object]],
+    state: dict[str, int],
+) -> None:
+    before = directory.lstat()
+    if not stat.S_ISDIR(before.st_mode):
+        raise OfflineExecutionError("output directory changed while being frozen")
+    entries = sorted(os.scandir(directory), key=lambda item: item.name)
+    for entry in entries:
+        item_depth = depth + 1
+        state["entries"] += 1
+        if state["entries"] > _MAX_OUTPUT_ENTRIES:
+            raise OfflineExecutionError("job output contains too many entries")
+        if item_depth > _MAX_OUTPUT_DEPTH:
+            raise OfflineExecutionError("job output exceeds the depth bound")
+        path = Path(entry.path)
+        relative = path.relative_to(root).as_posix()
+        item_stat = entry.stat(follow_symlinks=False)
+        if stat.S_ISLNK(item_stat.st_mode):
+            raise OfflineExecutionError("job output must not contain symlinks")
+        if stat.S_ISDIR(item_stat.st_mode):
+            records.append({"kind": "directory", "path": relative})
+            _freeze_directory(
+                path,
+                root=root,
+                depth=item_depth,
+                records=records,
+                state=state,
+            )
+            continue
+        if not stat.S_ISREG(item_stat.st_mode):
+            raise OfflineExecutionError("job output contains a non-regular file")
+        if item_stat.st_nlink != 1:
+            raise OfflineExecutionError("job output must not contain hardlinks")
+        if item_stat.st_size > _MAX_OUTPUT_FILE_BYTES:
+            raise OfflineExecutionError("job output file exceeds the byte bound")
+        if item_stat.st_size and item_stat.st_blocks * 512 < item_stat.st_size:
+            raise OfflineExecutionError("job output must not contain sparse files")
+        state["bytes"] += item_stat.st_size
+        if state["bytes"] > _MAX_OUTPUT_BYTES:
+            raise OfflineExecutionError("job output exceeds the total byte bound")
+        content_digest = _read_stable_file(path, expected=item_stat)
+        state["files"] += 1
+        records.append(
+            {
+                "kind": "file",
+                "mode": stat.S_IMODE(item_stat.st_mode),
+                "path": relative,
+                "sha256": content_digest,
+                "size": item_stat.st_size,
+            }
+        )
+    after = directory.lstat()
+    if not _same_stat(before, after, include_size=False):
+        raise OfflineExecutionError("job output mutated while being frozen")
+
+
+def _read_stable_file(path: Path, *, expected: os.stat_result) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not _same_stat(expected, opened, include_size=True):
+            raise OfflineExecutionError("job output mutated before it could be frozen")
+        digest = hashlib.sha256()
+        actual_bytes = 0
+        while chunk := os.read(descriptor, _READ_CHUNK_BYTES):
+            actual_bytes += len(chunk)
+            if actual_bytes > expected.st_size or actual_bytes > _MAX_OUTPUT_FILE_BYTES:
+                raise OfflineExecutionError("job output mutated while being frozen")
+            digest.update(chunk)
+        final = os.fstat(descriptor)
+        if actual_bytes != expected.st_size or not _same_stat(expected, final, include_size=True):
+            raise OfflineExecutionError("job output mutated while being frozen")
+        return digest.hexdigest()
+    except OSError as exc:
+        raise OfflineExecutionError("job output file could not be frozen") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _same_stat(first: os.stat_result, second: os.stat_result, *, include_size: bool) -> bool:
+    common = (
+        first.st_dev == second.st_dev,
+        first.st_ino == second.st_ino,
+        first.st_mode == second.st_mode,
+        first.st_nlink == second.st_nlink,
+        first.st_mtime_ns == second.st_mtime_ns,
+        first.st_ctime_ns == second.st_ctime_ns,
+    )
+    return all(common) and (not include_size or first.st_size == second.st_size)
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_TIMEOUT_SECONDS",
+    "FrozenOutputTree",
+    "OfflineExecutionError",
+    "OfflineExecutionResult",
+    "ProcessRunner",
+    "execute_offline_job",
+    "freeze_output_tree",
+]

--- a/tools/improvement_lab/run_receipt_adapter.py
+++ b/tools/improvement_lab/run_receipt_adapter.py
@@ -1,0 +1,389 @@
+"""
+Derive promotion receipts from externally attested Ravage executions.
+
+Candidate output is evidence nomination, never the source of truth.  This
+adapter counts only finding verdicts and resource observations signed by the
+trusted executor, then cross-checks the candidate report and traffic ledger for
+inconsistencies.  The resulting :class:`RunReceipt` contains no target paths,
+URLs, finding identities, response bodies, or proof values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import stat
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Final
+
+from tools.improvement_lab.evaluation import (
+    RunReceipt,
+    canonical_run_receipts_bytes,
+)
+from tools.improvement_lab.execution_attestation import (
+    ExecutionAttestationError,
+    verify_signed_execution_envelope,
+)
+from tools.improvement_lab.offline_executor import freeze_output_tree
+
+# These errors are safe trust-boundary diagnostics and deliberately omit paths
+# and candidate-controlled values.
+# ruff: noqa: C901, EM101, EM102, PLR0913, PLR2004, TRY003, TRY301
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tools.improvement_lab.execution_attestation import SignedExecutionEnvelope
+
+_MAX_JSON_BYTES: Final = 16 * 1024 * 1024
+_MAX_FINDINGS: Final = 10_000
+_MAX_FINDING_ID_CHARS: Final = 512
+_STAGE_RANK: Final = {
+    "suspected_vulnerability": 1,
+    "evidence_backed_vulnerability": 2,
+    "verified_vulnerability": 3,
+    "confirmed_finding": 4,
+}
+
+
+class RunReceiptAdapterError(RuntimeError):
+    """Raised when a run cannot produce a trustworthy bounded receipt."""
+
+
+def finding_reference_digest(finding_id: str) -> str:
+    """Return the opaque identifier shared by reports and evaluator verdicts."""
+    if (
+        not isinstance(finding_id, str)
+        or not finding_id.strip()
+        or len(finding_id) > _MAX_FINDING_ID_CHARS
+        or "\0" in finding_id
+    ):
+        raise RunReceiptAdapterError("report contains an invalid finding identity")
+    encoded = f"ravage.finding-reference.v1\0{finding_id.strip()}".encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def derive_run_receipt(
+    artifact_root: Path,
+    *,
+    envelope: SignedExecutionEnvelope,
+    executor_public_key: bytes,
+) -> RunReceipt:
+    """Build one fail-closed receipt from a signed execution and frozen output."""
+    try:
+        envelope = verify_signed_execution_envelope(
+            envelope.to_json(),
+            public_key=executor_public_key,
+        )
+    except ExecutionAttestationError as exc:
+        raise RunReceiptAdapterError("signed execution envelope is invalid") from exc
+    frozen = freeze_output_tree(artifact_root)
+    binding = envelope.binding
+    observations = envelope.observations
+    if frozen.digest != binding.artifact_tree_digest:
+        raise RunReceiptAdapterError("artifact tree differs from the signed execution")
+
+    case_root = _contained_case_root(artifact_root, binding.artifact_case_path)
+    report = _load_json_object(case_root / "report.json", label="Ravage report")
+    traffic = _load_json_object(
+        case_root / "workspace" / "traffic-policy.json",
+        label="traffic ledger",
+    )
+    nominations, confirmed_claims = _report_finding_references(report)
+    verdicts = envelope.finding_verdicts
+    verdict_references = {item.finding_digest for item in verdicts}
+    unknown = verdict_references - nominations
+    if unknown:
+        raise RunReceiptAdapterError(
+            "signed finding verdict does not match a nominated report finding"
+        )
+
+    ranks = [_STAGE_RANK[item.stage] for item in verdicts]
+    evidence_backed = sum(
+        rank >= _STAGE_RANK["evidence_backed_vulnerability"] for rank in ranks
+    )
+    verified = sum(rank >= _STAGE_RANK["verified_vulnerability"] for rank in ranks)
+    confirmed = sum(rank >= _STAGE_RANK["confirmed_finding"] for rank in ranks)
+    suspected = sum(rank == _STAGE_RANK["suspected_vulnerability"] for rank in ranks)
+
+    unsupported_confirmed = confirmed_claims - verdict_references
+    accounting_mismatches = _accounting_mismatches(
+        report,
+        traffic,
+        physical_request_count=observations.physical_request_count,
+        incomplete_request_count=observations.incomplete_request_count,
+        unmetered_action_count=observations.unmetered_action_count,
+        accounting_status=observations.request_accounting_status,
+    )
+    if (
+        observations.physical_request_count is None
+        or observations.request_accounting_status in {"unavailable", "unspecified", "invalid"}
+    ):
+        accounting_mismatches.add("external_accounting_unavailable")
+
+    receipt = RunReceipt(
+        case_id=binding.case_id,
+        cohort=binding.cohort,
+        repeat=binding.repeat,
+        execution_kind=binding.execution_kind,
+        status=observations.status,
+        is_control=binding.is_control,
+        case_success=observations.case_success,
+        expected_vulnerability_count=binding.expected_vulnerability_count,
+        evidence_backed_vulnerability_count=evidence_backed,
+        verified_vulnerability_count=verified,
+        confirmed_finding_count=confirmed,
+        suspected_vulnerability_count=suspected,
+        proof_integrity_failure_count=(
+            observations.proof_integrity_failure_count + len(unsupported_confirmed)
+        ),
+        false_proof_count=observations.false_proof_count,
+        request_accounting_mismatch_count=(
+            observations.request_accounting_mismatch_count + len(accounting_mismatches)
+        ),
+        loop_violation_count=observations.loop_violation_count,
+        provenance_violation_count=observations.provenance_violation_count,
+        secret_leak_violation_count=observations.secret_leak_violation_count,
+        unmetered_action_count=observations.unmetered_action_count,
+        incomplete_request_count=observations.incomplete_request_count,
+        physical_request_count=observations.physical_request_count,
+        model_request_count=observations.model_request_count,
+        cost_usd=observations.cost_usd,
+        request_accounting_status=observations.request_accounting_status,
+        run_id=binding.run_id,
+        pair_seed_digest=binding.pair_seed_digest,
+        target_snapshot_digest=binding.target_snapshot_digest,
+        model_fingerprint=binding.model_fingerprint,
+        prompt_fingerprint=binding.prompt_fingerprint,
+    )
+    if freeze_output_tree(artifact_root).digest != binding.artifact_tree_digest:
+        raise RunReceiptAdapterError("artifact tree changed while deriving the receipt")
+    return receipt
+
+
+def write_run_receipt(path: Path, receipt: RunReceipt) -> None:
+    """Atomically write a private, byte-canonical one-receipt set."""
+    content = canonical_run_receipts_bytes((receipt,))
+    target = path.expanduser()
+    if target.exists() or target.is_symlink():
+        raise RunReceiptAdapterError("refusing to overwrite an existing receipt")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if target.parent.is_symlink():
+            raise RunReceiptAdapterError("receipt parent must be a real directory")
+        temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(temporary, flags, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary.replace(target)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            temporary.unlink(missing_ok=True)
+    except OSError as exc:
+        raise RunReceiptAdapterError("cannot write canonical run receipt") from exc
+
+
+def _contained_case_root(root: Path, relative: str) -> Path:
+    try:
+        resolved_root = root.expanduser().resolve(strict=True)
+        candidate = (resolved_root / relative).resolve(strict=True)
+    except OSError as exc:
+        raise RunReceiptAdapterError("cannot inspect signed artifact case") from exc
+    if (
+        not candidate.is_relative_to(resolved_root)
+        or candidate.is_symlink()
+        or not candidate.is_dir()
+    ):
+        raise RunReceiptAdapterError("signed artifact case is not a contained directory")
+    return candidate
+
+
+def _load_json_object(path: Path, *, label: str) -> dict[str, object]:
+    descriptor = -1
+    try:
+        before = path.lstat()
+        if (
+            path.is_symlink()
+            or not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size <= 0
+            or before.st_size > _MAX_JSON_BYTES
+        ):
+            raise RunReceiptAdapterError(f"{label} is not a bounded regular file")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if _file_version(before) != _file_version(opened):
+            raise RunReceiptAdapterError(f"{label} changed while it was opened")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            content = stream.read(_MAX_JSON_BYTES + 1)
+            after = os.fstat(stream.fileno())
+        if (
+            len(content) > _MAX_JSON_BYTES
+            or len(content) != before.st_size
+            or _file_version(opened) != _file_version(after)
+        ):
+            raise RunReceiptAdapterError(f"{label} changed while it was read")
+        payload = json.loads(
+            content,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_finite,
+        )
+    except RunReceiptAdapterError:
+        raise
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise RunReceiptAdapterError(f"{label} is invalid JSON") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not isinstance(payload, dict):
+        raise RunReceiptAdapterError(f"{label} must be a JSON object")
+    _validate_json_bounds(payload)
+    return {str(key): value for key, value in payload.items()}
+
+
+def _file_version(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _report_finding_references(
+    report: Mapping[str, object],
+) -> tuple[set[str], set[str]]:
+    raw_findings = report.get("findings")
+    outcome = report.get("outcome")
+    if not isinstance(raw_findings, list) or not isinstance(outcome, Mapping):
+        raise RunReceiptAdapterError("Ravage report lacks canonical finding sections")
+    raw_evidence = outcome.get("evidence")
+    if not isinstance(raw_evidence, list):
+        raise RunReceiptAdapterError("Ravage report lacks canonical outcome evidence")
+    if len(raw_findings) + len(raw_evidence) > _MAX_FINDINGS:
+        raise RunReceiptAdapterError("Ravage report exceeds the finding cap")
+
+    nominations: set[str] = set()
+    confirmed: set[str] = set()
+    for item in raw_findings:
+        if not isinstance(item, Mapping):
+            raise RunReceiptAdapterError("Ravage report contains a malformed finding")
+        reference = finding_reference_digest(_required_finding_id(item))
+        nominations.add(reference)
+        if str(item.get("status") or "").strip().casefold() == "confirmed":
+            confirmed.add(reference)
+    for item in raw_evidence:
+        if not isinstance(item, Mapping):
+            raise RunReceiptAdapterError("Ravage report contains malformed outcome evidence")
+        reference = finding_reference_digest(_required_finding_id(item))
+        nominations.add(reference)
+        if item.get("confirmed_finding") is True:
+            confirmed.add(reference)
+    return nominations, confirmed
+
+
+def _required_finding_id(item: Mapping[str, object]) -> str:
+    value = item.get("finding_id")
+    if not isinstance(value, str):
+        raise RunReceiptAdapterError("Ravage report finding lacks an identity")
+    return value
+
+
+def _accounting_mismatches(
+    report: Mapping[str, object],
+    traffic: Mapping[str, object],
+    *,
+    physical_request_count: int | None,
+    incomplete_request_count: int,
+    unmetered_action_count: int,
+    accounting_status: str,
+) -> set[str]:
+    report_accounting = report.get("traffic_accounting")
+    if not isinstance(report_accounting, Mapping):
+        return {"report_accounting_missing"}
+    mismatches: set[str] = set()
+    expected = {
+        "physical_request_count": physical_request_count,
+        "incomplete_request_count": incomplete_request_count,
+        "unmetered_action_count": unmetered_action_count,
+    }
+    for field, external_value in expected.items():
+        ledger_value = _optional_count(traffic.get(field))
+        report_value = _optional_count(report_accounting.get(field))
+        if ledger_value != report_value:
+            mismatches.add(f"{field}_report_ledger")
+        if external_value is not None and ledger_value != external_value:
+            mismatches.add(f"{field}_external_ledger")
+        if external_value is not None and report_value != external_value:
+            mismatches.add(f"{field}_external_report")
+    report_status = str(report_accounting.get("status") or "").strip().casefold()
+    if report_status != accounting_status:
+        mismatches.add("accounting_status_external_report")
+    if traffic.get("schema") != "ravage.traffic-policy":
+        mismatches.add("traffic_schema")
+    return mismatches
+
+
+def _optional_count(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ValueError("duplicate JSON key")
+        payload[key] = value
+    return payload
+
+
+def _reject_non_finite(_value: str) -> object:
+    raise ValueError("non-finite JSON value")
+
+
+def _validate_json_bounds(value: object, *, depth: int = 0) -> None:
+    if depth > 40:
+        raise RunReceiptAdapterError("JSON artifact exceeds the nesting cap")
+    if isinstance(value, Mapping):
+        if len(value) > 50_000:
+            raise RunReceiptAdapterError("JSON artifact exceeds the member cap")
+        for key, item in value.items():
+            if not isinstance(key, str) or len(key) > 1024:
+                raise RunReceiptAdapterError("JSON artifact contains an invalid key")
+            _validate_json_bounds(item, depth=depth + 1)
+        return
+    if isinstance(value, list):
+        if len(value) > 100_000:
+            raise RunReceiptAdapterError("JSON artifact exceeds the list cap")
+        for item in value:
+            _validate_json_bounds(item, depth=depth + 1)
+        return
+    if isinstance(value, str) and len(value) > _MAX_JSON_BYTES:
+        raise RunReceiptAdapterError("JSON artifact contains an oversized string")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise RunReceiptAdapterError("JSON artifact contains a non-finite number")
+    if isinstance(value, int) and value.bit_length() > 256:
+        raise RunReceiptAdapterError("JSON artifact contains an oversized integer")
+
+
+__all__ = [
+    "RunReceiptAdapterError",
+    "derive_run_receipt",
+    "finding_reference_digest",
+    "write_run_receipt",
+]

--- a/tools/improvement_lab/run_receipt_adapter.py
+++ b/tools/improvement_lab/run_receipt_adapter.py
@@ -40,14 +40,6 @@ if TYPE_CHECKING:
 _MAX_JSON_BYTES: Final = 16 * 1024 * 1024
 _MAX_FINDINGS: Final = 10_000
 _MAX_FINDING_ID_CHARS: Final = 512
-_STAGE_RANK: Final = {
-    "suspected_vulnerability": 1,
-    "evidence_backed_vulnerability": 2,
-    "verified_vulnerability": 3,
-    "confirmed_finding": 4,
-}
-
-
 class RunReceiptAdapterError(RuntimeError):
     """Raised when a run cannot produce a trustworthy bounded receipt."""
 
@@ -100,14 +92,6 @@ def derive_run_receipt(
             "signed finding verdict does not match a nominated report finding"
         )
 
-    ranks = [_STAGE_RANK[item.stage] for item in verdicts]
-    evidence_backed = sum(
-        rank >= _STAGE_RANK["evidence_backed_vulnerability"] for rank in ranks
-    )
-    verified = sum(rank >= _STAGE_RANK["verified_vulnerability"] for rank in ranks)
-    confirmed = sum(rank >= _STAGE_RANK["confirmed_finding"] for rank in ranks)
-    suspected = sum(rank == _STAGE_RANK["suspected_vulnerability"] for rank in ranks)
-
     unsupported_confirmed = confirmed_claims - verdict_references
     accounting_mismatches = _accounting_mismatches(
         report,
@@ -122,42 +106,19 @@ def derive_run_receipt(
         or observations.request_accounting_status in {"unavailable", "unspecified", "invalid"}
     ):
         accounting_mismatches.add("external_accounting_unavailable")
+    if observations.proof_integrity_failure_count < len(unsupported_confirmed):
+        raise RunReceiptAdapterError(
+            "signed observations omit candidate proof-integrity failures"
+        )
+    if observations.request_accounting_mismatch_count < len(accounting_mismatches):
+        raise RunReceiptAdapterError(
+            "signed observations omit request-accounting mismatches"
+        )
 
-    receipt = RunReceipt(
-        case_id=binding.case_id,
-        cohort=binding.cohort,
-        repeat=binding.repeat,
-        execution_kind=binding.execution_kind,
-        status=observations.status,
-        is_control=binding.is_control,
-        case_success=observations.case_success,
-        expected_vulnerability_count=binding.expected_vulnerability_count,
-        evidence_backed_vulnerability_count=evidence_backed,
-        verified_vulnerability_count=verified,
-        confirmed_finding_count=confirmed,
-        suspected_vulnerability_count=suspected,
-        proof_integrity_failure_count=(
-            observations.proof_integrity_failure_count + len(unsupported_confirmed)
-        ),
-        false_proof_count=observations.false_proof_count,
-        request_accounting_mismatch_count=(
-            observations.request_accounting_mismatch_count + len(accounting_mismatches)
-        ),
-        loop_violation_count=observations.loop_violation_count,
-        provenance_violation_count=observations.provenance_violation_count,
-        secret_leak_violation_count=observations.secret_leak_violation_count,
-        unmetered_action_count=observations.unmetered_action_count,
-        incomplete_request_count=observations.incomplete_request_count,
-        physical_request_count=observations.physical_request_count,
-        model_request_count=observations.model_request_count,
-        cost_usd=observations.cost_usd,
-        request_accounting_status=observations.request_accounting_status,
-        run_id=binding.run_id,
-        pair_seed_digest=binding.pair_seed_digest,
-        target_snapshot_digest=binding.target_snapshot_digest,
-        model_fingerprint=binding.model_fingerprint,
-        prompt_fingerprint=binding.prompt_fingerprint,
-    )
+    # The receipt is an exact projection of the signed envelope. Candidate
+    # artifacts may invalidate that projection, but they can never add unsigned
+    # metrics that would be impossible to reproduce from retained evidence.
+    receipt = envelope.to_run_receipt()
     if freeze_output_tree(artifact_root).digest != binding.artifact_tree_digest:
         raise RunReceiptAdapterError("artifact tree changed while deriving the receipt")
     return receipt


### PR DESCRIPTION
## Summary

- Added separate executor and referee signing keys.
- Added bounded networkless executor for candidate jobs.
- Added receipt building from verified findings, artifacts, and traffic accounting.
- Stored the signed evidence in the archive and verified it again before promotion.
- Kept one signed champion baseline for fair comparison across candidates.
- Added `executor-keygen` and `receipt-build` commands.