### PR TITLE
feat(auth): add role-aware surface mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,23 @@ credentials stay inside the authenticated HTTP owner; process, Python, and
 command lanes are blocked when an identity is selected. See
 [Authentication](docs/authentication.md) for setup and limitations.
 
-With at least two configured identities, compare access to operator-supplied,
-read-only resources with a narrow authorization matrix:
+With at least two configured identities, first map which read-only routes each
+role can see:
+
+~~~bash
+ravage auth map ravage-brief.yaml \
+  --identity alice \
+  --identity bob \
+  --include-anonymous
+~~~
+
+The map follows a small, deterministic GET-only frontier across every selected
+identity. It records conservatively shaped routes and parameter names, not
+exact URLs, response bodies, or query values. Recognized IDs and ambiguous path
+segments become placeholders. A difference is only a review candidate; it is
+not a vulnerability claim.
+
+Confirm a reviewed, operator-supplied resource with the authorization matrix:
 
 ~~~bash
 ravage auth matrix ravage-brief.yaml authorization-matrix.yaml
@@ -143,8 +158,8 @@ ravage auth matrix ravage-brief.yaml authorization-matrix.yaml
 The plan names each explicit GET URL, its allowed and denied actors (including
 `anonymous`), and a secret-backed response marker. Ravage does not discover or
 guess resource IDs. See the
-[authorization matrix guide](docs/authentication.md#authorization-matrix) for
-the plan format, receipt boundary, and limitations.
+[authentication guide](docs/authentication.md#role-aware-surface-map) for map
+safety limits, the matrix plan format, receipt boundaries, and limitations.
 
 ## Authorized remote targets
 
@@ -216,7 +231,7 @@ model assertion as a confirmed finding.
 | --- | --- | --- |
 | Deterministic recon and probes | <code>ravage scan</code> | No model required |
 | Model-driven assessment | <code>ravage attack</code> | Evidence-gated and scoped |
-| Managed authentication | <code>ravage auth</code> | Form, bearer, static header |
+| Managed authentication | <code>ravage auth</code> | Sessions, role-aware map, authorization matrix |
 | Traffic inspection and replay | <code>ravage traffic</code> | Scoped artifacts |
 | Knowledge skills | <code>ravage skills</code>, <code>ravage code-bug</code> | Advisory |
 | Passive SATCOM inspection | <code>ravage satcom inspect</code> | No transmit |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -135,6 +135,69 @@ ravage auth add ravage-brief.yaml \
 
 Set the generated `RAVAGE_PARTNER_API_KEY` value in `.env.ravage`.
 
+## Role-aware surface map
+
+`ravage auth map` compares a bounded route frontier across at least two
+configured identities. It is useful when one role exposes links or endpoints
+that another role does not show.
+
+Check every selected identity first, then run:
+
+```bash
+ravage auth map ravage-brief.yaml \
+  --identity alice \
+  --identity bob \
+  --include-anonymous
+```
+
+If `--identity` is omitted, Ravage uses every configured identity. Anonymous
+traffic is excluded unless `--include-anonymous` is present. Remote targets
+still require `--authorized-remote-target`.
+
+The mapper is deliberately narrow. It processes one deterministic
+breadth-first union frontier, measures a URL across every actor before going
+deeper, sends only `GET`, and repeats possible differences in reverse actor
+order. It never submits forms, guesses or increments IDs, mutates query values,
+executes JavaScript, launches a browser or external scanner, or automatically
+follows redirects. Safe same-origin redirects are admitted as separate metered
+frontier entries.
+
+Discovered query URLs, form actions, inline JavaScript requests, and
+state-changing-looking routes are recorded only as route shapes. They are not
+dispatched. By default the frontier is eight URLs, the whole run is capped at
+200 physical requests, and traffic is paced at 0.5 requests per second. Login,
+health checks, mapping requests, and any session refresh all use that same
+ledger. Use `--max-urls`, `--max-physical-requests`, and `--traffic-max-rps` to
+tighten those bounds.
+
+The private `authorization-surface-map.json` receipt contains the canonical
+surface graph, actor and role labels, response classes and statuses, coverage
+limits, candidate reason codes, and exact traffic totals. It does not contain
+exact URLs, response bodies, body hashes, cookies, header values, or raw query
+values. Recognized IDs and ambiguous path segments are replaced with
+placeholders; ordinary short route labels can remain so the map stays useful.
+All identities share one DNS answer set and fail closed if that set changes
+during the run.
+
+Two differences can become review candidates:
+
+- `identity_visibility_difference`: a stable operation shape was declared to
+  only some actors.
+- `response_access_class_difference`: stable repeated observations differed
+  between success, redirect, and safe denial classes.
+
+These are coverage clues, not vulnerabilities. The mapper does not infer an
+owner or the intended access policy, and a `200` response alone proves nothing.
+A candidate stays non-confirming even when the run is complete. Supply the
+known concrete URL, owner, expected actors, and a secret-backed response marker
+to `ravage auth matrix` for confirmation.
+
+An incomplete map exits with status 1. Authentication generation changes,
+unstable repeats, transport errors, truncation, `429`/`5xx` responses, a policy
+halt, reused or retried responses, unmetered traffic, or inexact accounting all
+prevent candidates from being marked review-ready. A completed but
+coverage-limited map exits successfully and lists the limits in its receipt.
+
 ## Authorization matrix
 
 `ravage auth matrix` compares a small set of known resource URLs across

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -87,6 +87,7 @@ from ravage.auth import (
     read_environment_file,
     run_auth_preflight,
     run_authorization_matrix,
+    run_authorization_surface_map,
     scaffold_auth_identity,
 )
 from ravage.benchmark import BenchmarkOverrides, run_benchmark
@@ -813,7 +814,7 @@ def _top_level_help() -> None:
                 "  ravage code-bug BRIEF.yaml --skills PATH [attack/options]",
                 "  ravage code-bug xben --skills PATH [selection/options]",
                 "  ravage scan BRIEF.yaml [options]",
-                "  ravage auth {add,list,check,matrix} BRIEF.yaml",
+                "  ravage auth {add,list,check,map,matrix} BRIEF.yaml",
                 "  ravage traffic {capture,list,show,replay,diff}",
                 "  ravage xben [selection/options]",
                 "  ravage authbench [--json]",
@@ -1029,6 +1030,77 @@ def _auth(args: list[str]) -> None:
     )
     matrix.add_argument("--json", action="store_true", help="print the sanitized receipt")
 
+    surface_map = subparsers.add_parser(
+        "map",
+        help="compare discovered routes across isolated identities",
+        description=(
+            "Build a read-only, role-aware surface map. Differences are review "
+            "candidates, not confirmed vulnerabilities."
+        ),
+        epilog=(
+            "Example:\n"
+            "  ravage auth map ravage-brief.yaml --identity alice --identity bob "
+            "--env-file .env.ravage"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    surface_map.add_argument("brief", type=Path, help="engagement brief YAML")
+    surface_map.add_argument(
+        "--identity",
+        action="append",
+        dest="identities",
+        default=[],
+        help="configured identity to compare; repeatable; defaults to all",
+    )
+    surface_map.add_argument(
+        "--include-anonymous",
+        action="store_true",
+        help="also compare a separate anonymous actor",
+    )
+    surface_map.add_argument(
+        "--env-file",
+        type=Path,
+        help="secrets file; auto-detects .env.ravage when omitted",
+    )
+    surface_map.add_argument("--target-url", help="override the first HTTP(S) scoped target")
+    surface_map.add_argument(
+        "--run-dir",
+        type=Path,
+        help="fresh private output directory; defaults below runs/",
+    )
+    surface_map.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=10,
+        help="1-60 seconds per request; defaults to 10",
+    )
+    surface_map.add_argument(
+        "--max-urls",
+        type=int,
+        default=8,
+        help="bounded union frontier; 1-50, defaults to 8",
+    )
+    surface_map.add_argument(
+        "--max-physical-requests",
+        type=int,
+        default=200,
+        help="whole-run cap including login and health checks; defaults to 200",
+    )
+    surface_map.add_argument(
+        "--traffic-max-rps",
+        type=float,
+        default=0.5,
+        help="whole-run dispatch rate below 1 RPS; defaults to 0.5",
+    )
+    surface_map.add_argument(
+        "--allow-remote-target",
+        "--authorized-remote-target",
+        dest="allow_remote_target",
+        action="store_true",
+        help="confirm explicit authorization to map a remote target",
+    )
+    surface_map.add_argument("--json", action="store_true", help="print the sanitized receipt")
+
     parsed = parser.parse_args(args)
     if parsed.command == "add":
         _auth_add(add, parsed)
@@ -1038,6 +1110,9 @@ def _auth(args: list[str]) -> None:
         return
     if parsed.command == "check":
         _auth_check(check, parsed)
+        return
+    if parsed.command == "map":
+        _auth_map(surface_map, parsed)
         return
     _auth_matrix(matrix, parsed)
 
@@ -1229,6 +1304,150 @@ def _auth_check(parser: argparse.ArgumentParser, parsed: argparse.Namespace) -> 
                 include_check=False,
             )
     if not result.passed:
+        raise SystemExit(1)
+
+
+def _auth_map(parser: argparse.ArgumentParser, parsed: argparse.Namespace) -> None:
+    brief = _load_engagement_brief_for_cli(parser, parsed.brief)
+    authentication = brief.authentication
+    if authentication is None or len(authentication.identities) < 2:
+        parser.error("authorization surface map requires at least two configured identities")
+    configured_identities = tuple(
+        identity.alias for identity in authentication.identities
+    )
+    selected_identities = tuple(
+        sorted(
+            {
+                str(alias).strip()
+                for alias in (parsed.identities or configured_identities)
+                if str(alias).strip()
+            }
+        )
+    )
+    if len(selected_identities) < 2:
+        parser.error("authorization surface map requires at least two configured identities")
+    unknown_identities = tuple(
+        alias for alias in selected_identities if alias not in configured_identities
+    )
+    if unknown_identities:
+        parser.error("authorization surface map contains an unknown configured identity")
+
+    target_url = _target_url_from_brief(parsed.brief, explicit=parsed.target_url)
+    if not is_local_url(target_url) and not parsed.allow_remote_target:
+        parser.error("remote targets require --authorized-remote-target")
+    try:
+        assert_authorized_target(
+            target_url,
+            scope=brief.scope,
+            allow_remote_target=parsed.allow_remote_target,
+            agent_name="authorization surface map",
+        )
+    except ValueError:
+        parser.error("authorization surface target is invalid or outside engagement scope")
+
+    if not 1 <= parsed.timeout_seconds <= 60:
+        parser.error("--timeout-seconds must be between 1 and 60")
+    if not 1 <= parsed.max_urls <= 50:
+        parser.error("--max-urls must be between 1 and 50")
+    parsed.traffic_policy = "low-noise"
+    _resolve_traffic_policy_args(
+        parser,
+        parsed,
+        default_mode="low-noise",
+        roe_max_rps=brief.roe.max_rps,
+    )
+
+    env_file = parsed.env_file or _discover_auth_env_file(parsed.brief)
+    try:
+        secret_resolver = environment_secret_resolver(env_file=env_file)
+    except EnvironmentFileError as exc:
+        parser.error(f"cannot load authentication secrets: {_concise_cli_error(exc)}")
+
+    run_dir = parsed.run_dir or _default_run_dir(parsed.brief, "auth-surface-map")
+    if run_dir.exists() or run_dir.is_symlink():
+        parser.error("authorization surface run directory must be new and empty")
+    try:
+        run_dir.mkdir(parents=True, mode=0o700)
+        run_dir.chmod(0o700)
+        traffic_policy = TrafficPolicyController.open(
+            run_dir / "traffic-policy.json",
+            target_url=target_url,
+            config=_traffic_policy_config(parsed),
+        )
+    except (OSError, TrafficPolicyError, ValueError) as exc:
+        parser.error(f"cannot initialize authorization surface map: {_concise_cli_error(exc)}")
+
+    try:
+        with build_managed_authorization_matrix(
+            config=authentication,
+            target_url=target_url,
+            identities=selected_identities,
+            timeout_seconds=parsed.timeout_seconds,
+            allow_remote_target=parsed.allow_remote_target,
+            in_scope=brief.scope.in_scope,
+            out_of_scope=brief.scope.out_of_scope,
+            max_rps=float(parsed.traffic_max_rps),
+            secret_resolver=secret_resolver,
+            traffic_policy=traffic_policy,
+        ) as runtime:
+            result = run_authorization_surface_map(
+                target_url,
+                runtime=runtime,
+                include_anonymous=parsed.include_anonymous,
+                max_urls=parsed.max_urls,
+            )
+    except (
+        AuthorizationMatrixRuntimeError,
+        ConfiguredAuthenticationError,
+        SecretResolutionError,
+        SessionError,
+        ValueError,
+    ) as exc:
+        parser.error(f"authorization surface map could not run: {_concise_cli_error(exc)}")
+
+    receipt_path = run_dir / "authorization-surface-map.json"
+    try:
+        _atomic_write_cli_text(
+            receipt_path,
+            json.dumps(result.to_json(), indent=2, sort_keys=True) + "\n",
+            mode=0o600,
+        )
+    except OSError as exc:
+        parser.error(f"cannot write authorization surface receipt: {_concise_cli_error(exc)}")
+
+    if parsed.json:
+        _write_line(json.dumps(result.to_json(), indent=2, sort_keys=True))
+    else:
+        _write_line(banner("AUTH SURFACE MAP", "role-aware read-only discovery"))
+        _write_line(f"{'target':<12}{redacted_target_url(target_url)}")
+        state = badge("complete", "ok") if result.complete else badge("incomplete", "warn")
+        _write_line(f"{state} {len(result.candidates)} review candidates")
+        for actor in result.actors:
+            _write_line(
+                f"{'actor':<12}{actor.actor} · {actor.mapped_url_count} URLs · "
+                f"{actor.observation_count} observations"
+            )
+        for candidate in result.candidates:
+            reasons = ", ".join(candidate.reason_codes)
+            _write_line(
+                f"{badge('candidate', 'warn')} {candidate.method} "
+                f"{candidate.route_shape} · {reasons}"
+            )
+        if result.coverage_limited:
+            coverage = ", ".join(result.coverage_reason_codes)
+            _write_line(f"{badge('coverage limited', 'warn')} {coverage}")
+        traffic = result.traffic_delta
+        _write_line(
+            f"{'traffic':<12}{traffic.physical_request_count} physical requests · "
+            f"accounting={traffic.current_accounting_status}"
+        )
+        _write_line(f"{badge('receipt', 'info')} {receipt_path} · mode=0600")
+        _write_line(
+            f"{badge('next', 'info')} Candidates are not vulnerabilities. "
+            "Confirm a known resource with `ravage auth matrix`."
+        )
+
+    if not result.complete:
         raise SystemExit(1)
 
 

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/bounded_probe.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/bounded_probe.py
@@ -18,7 +18,12 @@ from ravage.probe_suite import (
     _probe_handlers,
 )
 from ravage.probe_suite_parts.result import ProbeRunResult
-from ravage.web_core.http_probe import MAX_BODY_BYTES, ProbeResponse, ProbeSession
+from ravage.web_core.http_probe import (
+    MAX_BODY_BYTES,
+    ProbeNetworkContext,
+    ProbeResponse,
+    ProbeSession,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -74,6 +79,7 @@ class BoundedGraphProbeSession(ProbeSession):
         out_of_scope: Sequence[str] = (),
         max_rps: float | None = None,
         resolver: Callable[[str, int], Sequence[str]] | None = None,
+        network_context: ProbeNetworkContext | None = None,
         _request_pacer: object | None = None,
         _dns_pins: dict[tuple[str, int], tuple[str, ...]] | None = None,
         _dns_pin_lock: threading.Lock | None = None,
@@ -89,10 +95,11 @@ class BoundedGraphProbeSession(ProbeSession):
             in_scope=in_scope,
             out_of_scope=out_of_scope,
             max_rps=max_rps,
-            resolver=resolver,
+            resolver=None if network_context is not None else resolver,
+            network_context=network_context,
             _request_pacer=_request_pacer,  # type: ignore[arg-type]
-            _dns_pins=_dns_pins,
-            _dns_pin_lock=_dns_pin_lock,
+            _dns_pins=None if network_context is not None else _dns_pins,
+            _dns_pin_lock=None if network_context is not None else _dns_pin_lock,
             traffic_observer=traffic_observer,
             traffic_policy_reference=traffic_policy_reference,
             max_body_bytes=max_body_bytes,
@@ -116,10 +123,8 @@ class BoundedGraphProbeSession(ProbeSession):
             in_scope=self.scope_in_scope,
             out_of_scope=self.scope_out_of_scope,
             max_rps=self.max_rps,
-            resolver=self._resolver,
+            network_context=self.network_context,
             _request_pacer=self._request_pacer,
-            _dns_pins=self._dns_pins,
-            _dns_pin_lock=self._dns_pin_lock,
             traffic_observer=self._traffic_observer,
             traffic_policy_reference=self.traffic_policy_reference(),
             max_body_bytes=self.max_body_bytes if max_body_bytes is None else max_body_bytes,

--- a/packages/ravage/src/ravage/auth/__init__.py
+++ b/packages/ravage/src/ravage/auth/__init__.py
@@ -24,6 +24,16 @@ from .authorization_matrix_runtime import (
     ManagedAuthorizationMatrix,
     build_managed_authorization_matrix,
 )
+from .authorization_surface_map import (
+    AUTHORIZATION_SURFACE_MAP_RESULT_SCHEMA,
+    AuthorizationSurfaceAccessClass,
+    AuthorizationSurfaceActorResult,
+    AuthorizationSurfaceCandidate,
+    AuthorizationSurfaceCandidateActor,
+    AuthorizationSurfaceMapResult,
+    AuthorizationSurfaceMapRunner,
+    run_authorization_surface_map,
+)
 from .configured import (
     ConfiguredAuthenticationError,
     UnsupportedConfiguredAuthFlowError,
@@ -82,6 +92,7 @@ __all__ = [
     "ANONYMOUS_ACTOR",
     "AUTHORIZATION_MATRIX_PLAN_SCHEMA",
     "AUTHORIZATION_MATRIX_RESULT_SCHEMA",
+    "AUTHORIZATION_SURFACE_MAP_RESULT_SCHEMA",
     "AuthArtifactRedactor",
     "AuthPreflightResult",
     "AuthPreflightStage",
@@ -100,6 +111,12 @@ __all__ = [
     "AuthorizationMatrixRuntimeError",
     "AuthorizationObservation",
     "AuthorizationObservationOutcome",
+    "AuthorizationSurfaceAccessClass",
+    "AuthorizationSurfaceActorResult",
+    "AuthorizationSurfaceCandidate",
+    "AuthorizationSurfaceCandidateActor",
+    "AuthorizationSurfaceMapResult",
+    "AuthorizationSurfaceMapRunner",
     "AuthorizationVerdict",
     "ConfiguredAuthenticationError",
     "EnvironmentFileError",
@@ -143,5 +160,6 @@ __all__ = [
     "resolve_auth_url",
     "run_auth_preflight",
     "run_authorization_matrix",
+    "run_authorization_surface_map",
     "scaffold_auth_identity",
 ]

--- a/packages/ravage/src/ravage/auth/authorization_matrix.py
+++ b/packages/ravage/src/ravage/auth/authorization_matrix.py
@@ -899,6 +899,30 @@ def _snapshot_delta(
     )
 
 
+def traffic_policy_halted(
+    runtime: AuthorizationMatrixRuntime,
+    initial: TrafficPolicySnapshot,
+) -> bool:
+    """Return whether a shared authorization traffic policy stopped dispatch."""
+    return _traffic_policy_halted(runtime, initial)
+
+
+def traffic_policy_reason_codes(
+    initial: TrafficPolicySnapshot,
+    current: TrafficPolicySnapshot,
+) -> tuple[str, ...]:
+    """Return stable fail-closed reasons for unusable authorization traffic."""
+    return _traffic_policy_reason_codes(initial, current)
+
+
+def traffic_snapshot_delta(
+    initial: TrafficPolicySnapshot,
+    current: TrafficPolicySnapshot,
+) -> TrafficSnapshotDelta:
+    """Return the whole-run traffic counters added after ``initial``."""
+    return _snapshot_delta(initial, current)
+
+
 def _aggregate_verdict(results: Sequence[AuthorizationCaseResult]) -> AuthorizationVerdict:
     if any(result.verdict is AuthorizationVerdict.CONFIRMED_VIOLATION for result in results):
         return AuthorizationVerdict.CONFIRMED_VIOLATION
@@ -1003,4 +1027,7 @@ __all__ = [
     "load_authorization_matrix_plan",
     "parse_authorization_matrix_plan",
     "run_authorization_matrix",
+    "traffic_policy_halted",
+    "traffic_policy_reason_codes",
+    "traffic_snapshot_delta",
 ]

--- a/packages/ravage/src/ravage/auth/authorization_matrix_runtime.py
+++ b/packages/ravage/src/ravage/auth/authorization_matrix_runtime.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Never, Self, SupportsIndex
 
-from ravage.web_core.http_probe import ProbeResponse, ProbeSession
+from ravage.web_core.http_probe import ProbeNetworkContext, ProbeResponse, ProbeSession
 
 from .authorization_matrix import ANONYMOUS_ACTOR, AuthorizationMatrixRuntimeError
 from .configured import ConfiguredAuthenticationError
@@ -36,6 +36,7 @@ class ManagedAuthorizationMatrix:
         "__closed",
         "__identities",
         "__initial_traffic_snapshot",
+        "__network_context",
         "__owners",
         "__roles",
         "__traffic_policy",
@@ -49,7 +50,9 @@ class ManagedAuthorizationMatrix:
         anonymous_session: ProbeSession,
         traffic_policy: TrafficPolicyController,
         initial_traffic_snapshot: TrafficPolicySnapshot,
+        network_context: ProbeNetworkContext | None = None,
     ) -> None:
+        shared_network_context = network_context or anonymous_session.network_context
         normalized_owners = dict(owners)
         identities = tuple(sorted(normalized_owners))
         if len(identities) < 2:
@@ -68,6 +71,10 @@ class ManagedAuthorizationMatrix:
             raise AuthorizationMatrixRuntimeError(
                 "anonymous matrix traffic is not bound to the shared policy"
             )
+        if anonymous_session.network_context is not shared_network_context:
+            raise AuthorizationMatrixRuntimeError(
+                "anonymous matrix traffic is not bound to the shared network context"
+            )
         for alias, owner in normalized_owners.items():
             if owner.identity != alias:
                 raise AuthorizationMatrixRuntimeError(
@@ -79,6 +86,10 @@ class ManagedAuthorizationMatrix:
                 raise AuthorizationMatrixRuntimeError(
                     "authorization matrix identities do not share one traffic policy"
                 ) from exc
+            if owner.network_context is not shared_network_context:
+                raise AuthorizationMatrixRuntimeError(
+                    "authorization matrix identities do not share one network context"
+                )
 
         self.__owners = MappingProxyType(normalized_owners)
         self.__roles = MappingProxyType(
@@ -88,6 +99,7 @@ class ManagedAuthorizationMatrix:
         self.__anonymous_session = anonymous_session
         self.__traffic_policy = traffic_policy
         self.__initial_traffic_snapshot = initial_traffic_snapshot
+        self.__network_context = shared_network_context
         self.__closed = False
 
     @property
@@ -105,6 +117,21 @@ class ManagedAuthorizationMatrix:
             return self.__roles[identity_alias]
         except KeyError:
             raise AuthorizationMatrixRuntimeError("unknown authorization matrix identity") from None
+
+    def identity_generation(self, identity_alias: str | None) -> int:
+        """Return non-secret generation metadata for stability checks."""
+        self._require_open()
+        if identity_alias is None or identity_alias == _ANONYMOUS_IDENTITY:
+            return 0
+        try:
+            return self.__owners[identity_alias].identity_generation
+        except KeyError:
+            raise AuthorizationMatrixRuntimeError("unknown authorization matrix identity") from None
+
+    def in_scope(self, url: str) -> bool:
+        """Apply the exact shared session scope without exposing credentials."""
+        self._require_open()
+        return self.__anonymous_session.in_scope(url)
 
     def request(self, identity_alias: str | None, method: str, url: str) -> ProbeResponse:
         """Issue one GET without exposing or accepting authentication material."""
@@ -173,6 +200,7 @@ def build_managed_authorization_matrix(  # noqa: PLR0913
     max_rps: float | None,
     secret_resolver: SecretResolver,
     traffic_policy: TrafficPolicyController,
+    network_context: ProbeNetworkContext | None = None,
 ) -> ManagedAuthorizationMatrix:
     """Authenticate selected identities while retaining one global request ledger."""
     selected = tuple(sorted({str(alias).strip() for alias in identities if str(alias).strip()}))
@@ -194,6 +222,7 @@ def build_managed_authorization_matrix(  # noqa: PLR0913
         )
 
     initial_snapshot = traffic_policy.snapshot()
+    shared_network_context = network_context or ProbeNetworkContext()
     owners: dict[str, ManagedAttackAuthentication] = {}
     anonymous_session: ProbeSession | None = None
     try:
@@ -209,6 +238,7 @@ def build_managed_authorization_matrix(  # noqa: PLR0913
                 max_rps=max_rps,
                 secret_resolver=secret_resolver,
                 traffic_policy=traffic_policy,
+                network_context=shared_network_context,
             )
         anonymous_session = ProbeSession(
             target_url,
@@ -218,6 +248,7 @@ def build_managed_authorization_matrix(  # noqa: PLR0913
             out_of_scope=out_of_scope,
             max_rps=max_rps,
             traffic_policy=traffic_policy,
+            network_context=shared_network_context,
         )
         return ManagedAuthorizationMatrix(
             owners=owners,
@@ -225,6 +256,7 @@ def build_managed_authorization_matrix(  # noqa: PLR0913
             anonymous_session=anonymous_session,
             traffic_policy=traffic_policy,
             initial_traffic_snapshot=initial_snapshot,
+            network_context=shared_network_context,
         )
     except Exception:
         for owner in owners.values():

--- a/packages/ravage/src/ravage/auth/authorization_surface_map.py
+++ b/packages/ravage/src/ravage/auth/authorization_surface_map.py
@@ -1,0 +1,1375 @@
+# ruff: noqa: BLE001, C901, EM101, EM102, PLR0911, PLR0912, PLR0913, PLR2004, TC003, TRY003
+"""Deterministic, role-aware surface candidates without authorization claims."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import defaultdict, deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from itertools import pairwise
+from typing import TYPE_CHECKING, Protocol
+from urllib.parse import parse_qsl, unquote, urljoin, urlsplit, urlunsplit
+
+from ravage.agent_core.surface_graph import (
+    SurfaceGraphError,
+    SurfaceGraphState,
+    SurfaceOperation,
+    SurfaceParameter,
+)
+from ravage.web_core.recon import (
+    PassiveReconOperation,
+    PassiveReconParameter,
+    parse_passive_recon_document,
+)
+from ravage.web_core.scope_policy import same_origin
+
+from .authorization_matrix import (
+    ANONYMOUS_ACTOR,
+    AuthorizationMatrixRuntimeError,
+    TrafficSnapshotDelta,
+    traffic_policy_halted,
+    traffic_policy_reason_codes,
+    traffic_snapshot_delta,
+)
+
+if TYPE_CHECKING:
+    from ravage.traffic.policy import TrafficPolicySnapshot
+
+
+AUTHORIZATION_SURFACE_MAP_RESULT_SCHEMA = "ravage.authorization-surface-map.result.v1"
+
+_SAFE_METHOD = "GET"
+_MIN_IDENTITIES = 2
+_MIN_STATUS = 100
+_MAX_STATUS = 599
+_MAX_URL_CHARS = 2_048
+_MAX_FRONTIER_URLS = 50
+_MAX_DECLARATIONS_PER_RESPONSE = 256
+_MAX_PERCENT_DECODE_ROUNDS = 8
+_MAX_RECEIPT_STATIC_SEGMENT_CHARS = 12
+_UNSAFE_URL_CHARACTERS = frozenset({"\\", "{", "}", "<", ">", "*"})
+_DENIAL_STATUSES = frozenset({401, 403, 404})
+_STANDARD_METHODS = frozenset({"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"})
+_STATIC_SUFFIXES = frozenset(
+    {
+        ".avif",
+        ".css",
+        ".gif",
+        ".ico",
+        ".jpeg",
+        ".jpg",
+        ".js",
+        ".map",
+        ".png",
+        ".svg",
+        ".webp",
+        ".woff",
+        ".woff2",
+    }
+)
+_ACTION_TOKENS = frozenset(
+    {
+        "activate",
+        "add",
+        "approve",
+        "archive",
+        "assign",
+        "ban",
+        "block",
+        "buy",
+        "callback",
+        "cancel",
+        "change",
+        "charge",
+        "checkout",
+        "close",
+        "confirm",
+        "create",
+        "deactivate",
+        "delete",
+        "deploy",
+        "destroy",
+        "disable",
+        "drop",
+        "enable",
+        "enroll",
+        "execute",
+        "generate",
+        "grant",
+        "impersonate",
+        "install",
+        "invite",
+        "issue",
+        "join",
+        "launch",
+        "lock",
+        "logoff",
+        "logout",
+        "merge",
+        "migrate",
+        "move",
+        "pay",
+        "purchase",
+        "publish",
+        "purge",
+        "rebuild",
+        "refund",
+        "regenerate",
+        "remove",
+        "rename",
+        "replace",
+        "reset",
+        "restart",
+        "revoke",
+        "rotate",
+        "run",
+        "save",
+        "schedule",
+        "send",
+        "shutdown",
+        "signout",
+        "start",
+        "stop",
+        "submit",
+        "subscribe",
+        "suspend",
+        "terminate",
+        "token",
+        "transfer",
+        "trigger",
+        "unlock",
+        "unsubscribe",
+        "unpublish",
+        "update",
+        "upgrade",
+        "upload",
+        "verify",
+        "wipe",
+        "withdraw",
+    }
+)
+_RECEIPT_SENSITIVE_PATH_PARENTS = frozenset(
+    {
+        "artifact",
+        "artifacts",
+        "attachment",
+        "attachments",
+        "blob",
+        "blobs",
+        "download",
+        "downloads",
+        "key",
+        "keys",
+        "object",
+        "objects",
+        "token",
+        "tokens",
+    }
+)
+_RECEIPT_PLACEHOLDERS = frozenset({"{id}", "{int}", "{segment}", "{uuid}"})
+_RECEIPT_STATIC_SEGMENT_RE = re.compile(rf"^[a-z]{{1,{_MAX_RECEIPT_STATIC_SEGMENT_CHARS}}}$")
+_RECEIPT_API_VERSION_RE = re.compile(r"^v[0-9]{1,2}$")
+_ACTION_COMPOUND_SUFFIXES = frozenset(
+    {
+        "account",
+        "accounts",
+        "credential",
+        "credentials",
+        "deployment",
+        "deployments",
+        "invoice",
+        "invoices",
+        "job",
+        "jobs",
+        "key",
+        "keys",
+        "member",
+        "members",
+        "order",
+        "orders",
+        "password",
+        "passwords",
+        "payment",
+        "payments",
+        "project",
+        "projects",
+        "role",
+        "roles",
+        "service",
+        "services",
+        "session",
+        "sessions",
+        "subscription",
+        "subscriptions",
+        "token",
+        "tokens",
+        "user",
+        "users",
+    }
+)
+_CAMEL_BOUNDARY_RE = re.compile(
+    r"(?<=[a-z0-9])(?=[A-Z])"
+    r"|(?<=[A-Z])(?=[A-Z][a-z])"
+    r"|(?<=[A-Za-z])(?=[0-9])"
+    r"|(?<=[0-9])(?=[A-Za-z])"
+)
+_TOKEN_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+_MALFORMED_PERCENT_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_ENCODED_SEPARATOR_RE = re.compile(r"%(?:2f|5c)", re.IGNORECASE)
+_IDENTITY_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+
+class AuthorizationSurfaceAccessClass(StrEnum):
+    SUCCESS = "success"
+    DENIED = "denied"
+    REDIRECT = "redirect"
+    INCONCLUSIVE = "inconclusive"
+
+
+class AuthorizationSurfaceMapRuntime(Protocol):
+    """Identity-isolated GET transport with one whole-run traffic ledger."""
+
+    @property
+    def identities(self) -> Sequence[str]: ...
+
+    @property
+    def initial_traffic_snapshot(self) -> TrafficPolicySnapshot: ...
+
+    def roles(self, identity_alias: str) -> Sequence[str]: ...
+
+    def identity_generation(self, identity_alias: str | None) -> int: ...
+
+    def in_scope(self, url: str) -> bool: ...
+
+    def request(
+        self,
+        identity_alias: str | None,
+        method: str,
+        url: str,
+    ) -> AuthorizationSurfaceHttpResponse: ...
+
+    def traffic_snapshot(self) -> TrafficPolicySnapshot: ...
+
+
+class AuthorizationSurfaceHttpResponse(Protocol):
+    status: int | None
+    final_url: str
+    headers: Mapping[str, str]
+    body: str
+    body_bytes: bytes
+    error: str
+    truncated: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSurfaceActorResult:
+    actor: str
+    roles: tuple[str, ...]
+    mapped_url_count: int
+    observation_count: int
+    success_count: int
+    denied_count: int
+    redirect_count: int
+    inconclusive_count: int
+    complete: bool
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "actor": self.actor,
+            "roles": list(self.roles),
+            "mapped_url_count": self.mapped_url_count,
+            "observation_count": self.observation_count,
+            "success_count": self.success_count,
+            "denied_count": self.denied_count,
+            "redirect_count": self.redirect_count,
+            "inconclusive_count": self.inconclusive_count,
+            "complete": self.complete,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSurfaceCandidateActor:
+    actor: str
+    roles: tuple[str, ...]
+    declaration_observed: bool
+    access_classes: tuple[str, ...]
+    statuses: tuple[int, ...]
+    stable: bool
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "actor": self.actor,
+            "roles": list(self.roles),
+            "declaration_observed": self.declaration_observed,
+            "access_classes": list(self.access_classes),
+            "statuses": list(self.statuses),
+            "stable": self.stable,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSurfaceCandidate:
+    candidate_id: str
+    operation_id: str
+    method: str
+    route_shape: str
+    parameters: tuple[SurfaceParameter, ...]
+    discovered_by: tuple[str, ...]
+    not_discovered_by: tuple[str, ...]
+    actor_evidence: tuple[AuthorizationSurfaceCandidateActor, ...]
+    reason_codes: tuple[str, ...]
+    review_ready: bool
+    requires_operator_input: bool = True
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "operation_id": self.operation_id,
+            "method": self.method,
+            "route_shape": self.route_shape,
+            "parameters": [parameter.to_json() for parameter in self.parameters],
+            "discovered_by": list(self.discovered_by),
+            "not_discovered_by": list(self.not_discovered_by),
+            "actor_evidence": [evidence.to_json() for evidence in self.actor_evidence],
+            "reason_codes": list(self.reason_codes),
+            "review_ready": self.review_ready,
+            "requires_operator_input": self.requires_operator_input,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationSurfaceMapResult:
+    complete: bool
+    coverage_limited: bool
+    reason_codes: tuple[str, ...]
+    coverage_reason_codes: tuple[str, ...]
+    actors: tuple[AuthorizationSurfaceActorResult, ...]
+    candidates: tuple[AuthorizationSurfaceCandidate, ...]
+    surface_graph: SurfaceGraphState
+    traffic_delta: TrafficSnapshotDelta
+    schema: str = AUTHORIZATION_SURFACE_MAP_RESULT_SCHEMA
+
+    def to_json(self) -> dict[str, object]:
+        """Return a stable receipt without bodies, header values, or exact URLs."""
+        return {
+            "schema": self.schema,
+            "complete": self.complete,
+            "coverage_limited": self.coverage_limited,
+            "reason_codes": list(self.reason_codes),
+            "coverage_reason_codes": list(self.coverage_reason_codes),
+            "actors": [actor.to_json() for actor in self.actors],
+            "candidates": [candidate.to_json() for candidate in self.candidates],
+            "surface_graph": self.surface_graph.to_json(),
+            "traffic_delta": self.traffic_delta.to_json(),
+        }
+
+
+@dataclass(slots=True)
+class _ActorCounters:
+    urls: set[str] = field(default_factory=set, repr=False)
+    observations: int = 0
+    success: int = 0
+    denied: int = 0
+    redirect: int = 0
+    inconclusive: int = 0
+
+    def record(self, url: str, access_class: AuthorizationSurfaceAccessClass) -> None:
+        self.urls.add(url)
+        self.observations += 1
+        if access_class is AuthorizationSurfaceAccessClass.SUCCESS:
+            self.success += 1
+        elif access_class is AuthorizationSurfaceAccessClass.DENIED:
+            self.denied += 1
+        elif access_class is AuthorizationSurfaceAccessClass.REDIRECT:
+            self.redirect += 1
+        else:
+            self.inconclusive += 1
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _UrlAdmission:
+    exact_url: str
+    dispatchable: bool
+    coverage_reason: str = ""
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _TransientDeclaration:
+    operation: SurfaceOperation
+    exact_url: str
+    dispatchable: bool
+    coverage_reason: str = ""
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _TransientObservation:
+    actor: str
+    roles: tuple[str, ...]
+    attempt: int
+    status: int | None
+    access_class: AuthorizationSurfaceAccessClass
+    generation_before: int | None
+    generation_after: int | None
+    declarations: tuple[_TransientDeclaration, ...] = ()
+    reason_codes: tuple[str, ...] = ()
+
+
+class AuthorizationSurfaceMapRunner:
+    """Map a breadth-first union frontier and emit review candidates only."""
+
+    def run(  # noqa: PLR0915 - the safety sequence is intentionally linear.
+        self,
+        target_url: str,
+        runtime: AuthorizationSurfaceMapRuntime,
+        *,
+        include_anonymous: bool = False,
+        max_urls: int = 8,
+    ) -> AuthorizationSurfaceMapResult:
+        if isinstance(max_urls, bool) or not 1 <= max_urls <= _MAX_FRONTIER_URLS:
+            raise AuthorizationMatrixRuntimeError(
+                f"authorization surface max_urls must be between 1 and {_MAX_FRONTIER_URLS}"
+            )
+        actors, roles = _runtime_context(runtime, include_anonymous=include_anonymous)
+        seed = _admit_url(
+            target_url,
+            base_url=target_url,
+            target_url=target_url,
+            runtime=runtime,
+            discovered=False,
+        )
+        if seed is None:
+            raise AuthorizationMatrixRuntimeError(
+                "authorization surface target is invalid or outside engagement scope"
+            )
+
+        graph = SurfaceGraphState.for_target(seed.exact_url)
+        discovered_by: dict[str, set[str]] = defaultdict(set)
+        comparisons: dict[
+            str,
+            list[Mapping[str, tuple[_TransientObservation, _TransientObservation]]],
+        ] = defaultdict(list)
+        counters = {actor: _ActorCounters() for actor in actors}
+        reason_codes: set[str] = set()
+        coverage_reasons: set[str] = set()
+
+        root = SurfaceOperation.create(
+            url=_receipt_safe_url(seed.exact_url),
+            method=_SAFE_METHOD,
+            provenance=("native_recon",),
+        )
+        for actor in actors:
+            graph.add(
+                url=root.structural_url,
+                method=root.method,
+                source_kind="native_recon",
+                identity_alias=actor,
+                access_level="declared",
+                scope_decision="allowed",
+                replayability="not_replayable",
+            )
+            discovered_by[root.operation_id].add(actor)
+
+        try:
+            initial = runtime.initial_traffic_snapshot
+        except Exception as exc:
+            raise AuthorizationMatrixRuntimeError(
+                "authorization surface traffic snapshot is unavailable"
+            ) from exc
+        initial_policy_reasons = _current_policy_reasons(runtime, initial)
+        if initial_policy_reasons:
+            reason_codes.update(initial_policy_reasons)
+            return _result(
+                complete=False,
+                coverage_reasons=coverage_reasons,
+                reason_codes=reason_codes,
+                actors=actors,
+                roles=roles,
+                counters=counters,
+                graph=graph,
+                discovered_by=discovered_by,
+                comparisons=comparisons,
+                initial=initial,
+                runtime=runtime,
+            )
+
+        queue: deque[str] = deque((seed.exact_url,))
+        queued = {seed.exact_url}
+        processed = 0
+        halted = False
+
+        while queue and processed < max_urls and not halted:
+            current_url = queue.popleft()
+            first: dict[str, _TransientObservation] = {}
+            for actor in actors:
+                observation = _observe(
+                    runtime,
+                    actor=actor,
+                    roles=roles[actor],
+                    attempt=1,
+                    url=current_url,
+                    target_url=seed.exact_url,
+                    coverage_reasons=coverage_reasons,
+                )
+                first[actor] = observation
+                counters[actor].record(current_url, observation.access_class)
+                if observation.reason_codes:
+                    reason_codes.update(observation.reason_codes)
+                if traffic_policy_halted(runtime, initial):
+                    reason_codes.update(("comparison_incomplete", "traffic_policy_halted"))
+                    halted = True
+                    break
+            if halted:
+                break
+
+            needs_repeat = _needs_repeat(tuple(first.values()))
+            repeated: dict[str, _TransientObservation] = {}
+            if needs_repeat:
+                for actor in reversed(actors):
+                    observation = _observe(
+                        runtime,
+                        actor=actor,
+                        roles=roles[actor],
+                        attempt=2,
+                        url=current_url,
+                        target_url=seed.exact_url,
+                        coverage_reasons=coverage_reasons,
+                    )
+                    repeated[actor] = observation
+                    counters[actor].record(current_url, observation.access_class)
+                    if observation.reason_codes:
+                        reason_codes.update(observation.reason_codes)
+                    if traffic_policy_halted(runtime, initial):
+                        reason_codes.update(("comparison_incomplete", "traffic_policy_halted"))
+                        halted = True
+                        break
+            if halted:
+                break
+
+            for actor in actors:
+                _record_response_observation(graph, current_url, first[actor])
+                if actor in repeated:
+                    _record_response_observation(graph, current_url, repeated[actor])
+
+            stable_declarations: dict[str, tuple[_TransientDeclaration, ...]] = {}
+            stable_pairs: dict[
+                str,
+                tuple[_TransientObservation, _TransientObservation],
+            ] = {}
+            if needs_repeat:
+                for actor in actors:
+                    pair = (first[actor], repeated[actor])
+                    if not _stable_pair(*pair):
+                        reason_codes.add("unstable_surface_observation")
+                        continue
+                    stable_pairs[actor] = pair
+                    stable_declarations[actor] = _shared_declarations(*pair)
+
+            next_urls: set[str] = set()
+            for actor in actors:
+                declarations = stable_declarations.get(actor, ())
+                for declaration in declarations:
+                    _record_declaration(graph, declaration, actor=actor)
+                    discovered_by[declaration.operation.operation_id].add(actor)
+                    if declaration.coverage_reason:
+                        coverage_reasons.add(declaration.coverage_reason)
+                    if declaration.dispatchable:
+                        next_urls.add(declaration.exact_url)
+
+            if _stable_access_difference(stable_pairs, actors=actors):
+                comparisons[
+                    root.operation_id
+                    if current_url == seed.exact_url
+                    else _operation_id(current_url)
+                ].append(dict(stable_pairs))
+
+            for next_url in sorted(next_urls):
+                if next_url in queued:
+                    continue
+                if len(queued) >= max_urls:
+                    coverage_reasons.add("frontier_limit_reached")
+                    continue
+                queued.add(next_url)
+                queue.append(next_url)
+            processed += 1
+
+        if queue:
+            coverage_reasons.add("frontier_limit_reached")
+
+        return _result(
+            complete=not reason_codes,
+            coverage_reasons=coverage_reasons,
+            reason_codes=reason_codes,
+            actors=actors,
+            roles=roles,
+            counters=counters,
+            graph=graph,
+            discovered_by=discovered_by,
+            comparisons=comparisons,
+            initial=initial,
+            runtime=runtime,
+        )
+
+
+def run_authorization_surface_map(
+    target_url: str,
+    *,
+    runtime: AuthorizationSurfaceMapRuntime,
+    include_anonymous: bool = False,
+    max_urls: int = 8,
+) -> AuthorizationSurfaceMapResult:
+    return AuthorizationSurfaceMapRunner().run(
+        target_url,
+        runtime,
+        include_anonymous=include_anonymous,
+        max_urls=max_urls,
+    )
+
+
+def _runtime_context(
+    runtime: AuthorizationSurfaceMapRuntime,
+    *,
+    include_anonymous: bool,
+) -> tuple[tuple[str, ...], Mapping[str, tuple[str, ...]]]:
+    try:
+        identities = tuple(sorted(runtime.identities))
+    except Exception as exc:
+        raise AuthorizationMatrixRuntimeError(
+            "authorization surface identities are unavailable"
+        ) from exc
+    if (
+        len(identities) < _MIN_IDENTITIES
+        or len(set(identities)) != len(identities)
+        or any(
+            not isinstance(alias, str)
+            or _IDENTITY_RE.fullmatch(alias) is None
+            or alias.casefold() in {"anon", ANONYMOUS_ACTOR}
+            for alias in identities
+        )
+    ):
+        raise AuthorizationMatrixRuntimeError(
+            "authorization surface map requires at least two valid configured identities"
+        )
+    roles: dict[str, tuple[str, ...]] = {}
+    for alias in identities:
+        try:
+            raw_roles = runtime.roles(alias)
+        except Exception as exc:
+            raise AuthorizationMatrixRuntimeError(
+                "authorization surface roles are unavailable"
+            ) from exc
+        if isinstance(raw_roles, str) or any(
+            not isinstance(role, str)
+            or not role.strip()
+            or len(role) > 128
+            or any(ord(character) < 0x20 for character in role)
+            for role in raw_roles
+        ):
+            raise AuthorizationMatrixRuntimeError("authorization surface roles must be a sequence")
+        roles[alias] = tuple(sorted({role for role in raw_roles if role}))
+    actors = identities
+    if include_anonymous:
+        actors = (*actors, ANONYMOUS_ACTOR)
+        roles[ANONYMOUS_ACTOR] = ()
+    return actors, roles
+
+
+def _observe(
+    runtime: AuthorizationSurfaceMapRuntime,
+    *,
+    actor: str,
+    roles: tuple[str, ...],
+    attempt: int,
+    url: str,
+    target_url: str,
+    coverage_reasons: set[str],
+) -> _TransientObservation:
+    lane = None if actor == ANONYMOUS_ACTOR else actor
+    try:
+        generation_before = runtime.identity_generation(lane)
+    except Exception:
+        return _TransientObservation(
+            actor=actor,
+            roles=roles,
+            attempt=attempt,
+            status=None,
+            access_class=AuthorizationSurfaceAccessClass.INCONCLUSIVE,
+            generation_before=None,
+            generation_after=None,
+            reason_codes=("identity_generation_unavailable",),
+        )
+    try:
+        response = runtime.request(lane, _SAFE_METHOD, url)
+    except Exception:
+        return _TransientObservation(
+            actor=actor,
+            roles=roles,
+            attempt=attempt,
+            status=None,
+            access_class=AuthorizationSurfaceAccessClass.INCONCLUSIVE,
+            generation_before=generation_before,
+            generation_after=None,
+            reason_codes=("authorization_surface_request_failed",),
+        )
+    try:
+        generation_after = runtime.identity_generation(lane)
+    except Exception:
+        return _TransientObservation(
+            actor=actor,
+            roles=roles,
+            attempt=attempt,
+            status=None,
+            access_class=AuthorizationSurfaceAccessClass.INCONCLUSIVE,
+            generation_before=generation_before,
+            generation_after=None,
+            reason_codes=("identity_generation_unavailable",),
+        )
+
+    status = _response_status(response.status)
+    reasons: set[str] = set()
+    if generation_before != generation_after:
+        reasons.add("identity_generation_changed")
+    if bool(response.error):
+        reasons.add("transport_error")
+    if bool(response.truncated):
+        reasons.add("response_truncated")
+    access_class = _access_class(status)
+    if access_class is AuthorizationSurfaceAccessClass.INCONCLUSIVE:
+        reasons.add("inconclusive_response_status")
+    if reasons:
+        return _TransientObservation(
+            actor=actor,
+            roles=roles,
+            attempt=attempt,
+            status=status,
+            access_class=AuthorizationSurfaceAccessClass.INCONCLUSIVE,
+            generation_before=generation_before,
+            generation_after=generation_after,
+            reason_codes=tuple(sorted(reasons)),
+        )
+
+    declarations: tuple[_TransientDeclaration, ...] = ()
+    try:
+        declarations = _response_declarations(
+            response,
+            requested_url=url,
+            target_url=target_url,
+            runtime=runtime,
+            coverage_reasons=coverage_reasons,
+        )
+    except Exception:  # Target material must never enter errors.
+        return _TransientObservation(
+            actor=actor,
+            roles=roles,
+            attempt=attempt,
+            status=status,
+            access_class=AuthorizationSurfaceAccessClass.INCONCLUSIVE,
+            generation_before=generation_before,
+            generation_after=generation_after,
+            reason_codes=("surface_parser_failed",),
+        )
+    return _TransientObservation(
+        actor=actor,
+        roles=roles,
+        attempt=attempt,
+        status=status,
+        access_class=access_class,
+        generation_before=generation_before,
+        generation_after=generation_after,
+        declarations=declarations,
+    )
+
+
+def _response_declarations(
+    response: AuthorizationSurfaceHttpResponse,
+    *,
+    requested_url: str,
+    target_url: str,
+    runtime: AuthorizationSurfaceMapRuntime,
+    coverage_reasons: set[str],
+) -> tuple[_TransientDeclaration, ...]:
+    declarations: list[_TransientDeclaration] = []
+    if response.status is not None and 300 <= response.status < 400:
+        location = _header_value(response.headers, "location")
+        if location:
+            redirect_url = urljoin(requested_url, location)
+            declaration = _project_declaration(
+                PassiveReconOperation(
+                    method="GET",
+                    url=location,
+                    parameters=tuple(
+                        PassiveReconParameter(name=name, location="query")
+                        for name, _value in parse_qsl(
+                            urlsplit(redirect_url).query,
+                            keep_blank_values=True,
+                        )[:32]
+                        if name
+                    ),
+                    hints=("redirect",),
+                ),
+                base_url=requested_url,
+                target_url=target_url,
+                runtime=runtime,
+                discovered=True,
+            )
+            if declaration is not None:
+                declarations.append(declaration)
+                if declaration.coverage_reason:
+                    coverage_reasons.add(declaration.coverage_reason)
+        return tuple(declarations)
+
+    if response.status is None or not 200 <= response.status < 300:
+        return ()
+    body = _response_body(response)
+    content_type = _header_value(response.headers, "content-type")
+    if not _looks_like_html(body, content_type):
+        return ()
+    final_url = str(response.final_url or requested_url)
+    if not same_origin(target_url, final_url) or final_url != requested_url:
+        raise AuthorizationMatrixRuntimeError("authorization surface response URL changed")
+    document = parse_passive_recon_document(final_url, response.headers, body)
+    for operation in document.operations[:_MAX_DECLARATIONS_PER_RESPONSE]:
+        declaration = _project_declaration(
+            operation,
+            base_url=final_url,
+            target_url=target_url,
+            runtime=runtime,
+            discovered=True,
+        )
+        if declaration is None:
+            coverage_reasons.add("unsafe_surface_declaration_skipped")
+            continue
+        declarations.append(declaration)
+        if declaration.coverage_reason:
+            coverage_reasons.add(declaration.coverage_reason)
+    deduplicated = {_declaration_key(item): item for item in declarations}
+    return tuple(deduplicated[key] for key in sorted(deduplicated))
+
+
+def _project_declaration(
+    declaration: PassiveReconOperation,
+    *,
+    base_url: str,
+    target_url: str,
+    runtime: AuthorizationSurfaceMapRuntime,
+    discovered: bool,
+) -> _TransientDeclaration | None:
+    method = str(declaration.method or "GET").strip().upper()
+    if method not in _STANDARD_METHODS:
+        return None
+    admission = _admit_url(
+        declaration.url,
+        base_url=base_url,
+        target_url=target_url,
+        runtime=runtime,
+        discovered=discovered,
+    )
+    if admission is None:
+        return None
+    parameters: list[SurfaceParameter] = []
+    for parameter in declaration.parameters:
+        try:
+            parameters.append(
+                SurfaceParameter.create(name=parameter.name, location=parameter.location)
+            )
+        except SurfaceGraphError:
+            continue
+    try:
+        operation = SurfaceOperation.create(
+            url=_receipt_safe_url(admission.exact_url),
+            method=method,
+            parameters=parameters,
+            header_names=declaration.header_names,
+            hints=declaration.hints,
+            provenance=(declaration.source_kind,),
+        )
+    except SurfaceGraphError:
+        return None
+    navigation = bool({"link", "redirect"} & set(operation.hints))
+    dispatchable = admission.dispatchable and method == _SAFE_METHOD and navigation
+    reason = admission.coverage_reason
+    if method != _SAFE_METHOD:
+        reason = "non_get_operation_not_dispatched"
+    elif "script" in operation.hints:
+        reason = "static_asset_not_dispatched"
+    elif not navigation:
+        reason = "declared_operation_not_dispatched"
+    return _TransientDeclaration(
+        operation=operation,
+        exact_url=admission.exact_url,
+        dispatchable=dispatchable,
+        coverage_reason=reason,
+    )
+
+
+def _admit_url(
+    value: str,
+    *,
+    base_url: str,
+    target_url: str,
+    runtime: AuthorizationSurfaceMapRuntime,
+    discovered: bool,
+) -> _UrlAdmission | None:
+    raw = str(value or "")
+    if not raw or raw != raw.strip() or len(raw) > _MAX_URL_CHARS:
+        return None
+    if any(character in raw for character in _UNSAFE_URL_CHARACTERS):
+        return None
+    if any(ord(character) < 0x20 or character.isspace() for character in raw):
+        return None
+    if _MALFORMED_PERCENT_RE.search(raw):
+        return None
+    try:
+        joined = urljoin(base_url, raw)
+        parsed = urlsplit(joined)
+        _ = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if (
+        parsed.scheme.casefold() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        return None
+    if not same_origin(target_url, joined):
+        return None
+    if not _safe_decoded_path(parsed.path):
+        return None
+    target = urlsplit(target_url)
+    exact = urlunsplit(
+        (target.scheme.casefold(), target.netloc, parsed.path or "/", parsed.query, "")
+    )
+    try:
+        if not runtime.in_scope(exact):
+            return None
+    except Exception:
+        return None
+    if not discovered:
+        return _UrlAdmission(exact_url=exact, dispatchable=True)
+    if parsed.query:
+        return _UrlAdmission(
+            exact_url=exact,
+            dispatchable=False,
+            coverage_reason="query_route_not_dispatched",
+        )
+    if _action_like(parsed.path, parsed.query):
+        return _UrlAdmission(
+            exact_url=exact,
+            dispatchable=False,
+            coverage_reason="action_route_not_dispatched",
+        )
+    if any(parsed.path.casefold().endswith(suffix) for suffix in _STATIC_SUFFIXES):
+        return _UrlAdmission(
+            exact_url=exact,
+            dispatchable=False,
+            coverage_reason="static_asset_not_dispatched",
+        )
+    return _UrlAdmission(exact_url=exact, dispatchable=True)
+
+
+def _safe_decoded_path(path: str) -> bool:
+    return _decode_to_stability(path) is not None
+
+
+def _decode_to_stability(value: str) -> str | None:
+    decoded = value
+    for _round in range(_MAX_PERCENT_DECODE_ROUNDS + 1):
+        if _MALFORMED_PERCENT_RE.search(decoded):
+            return None
+        if _ENCODED_SEPARATOR_RE.search(decoded):
+            return None
+        if any(
+            character == "\\" or ord(character) < 0x20 or character.isspace()
+            for character in decoded
+        ):
+            return None
+        if any(segment in {".", ".."} for segment in decoded.split("/")):
+            return None
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            return decoded
+        decoded = next_value
+    return None
+
+
+def _action_like(path: str, query: str) -> bool:
+    decoded = _decode_to_stability(f"{path}?{query}")
+    if decoded is None:
+        return True
+    lowered = _CAMEL_BOUNDARY_RE.sub("-", decoded).casefold()
+    ordered_tokens = tuple(token for token in _TOKEN_SPLIT_RE.split(lowered) if token)
+    tokens = set(ordered_tokens)
+    compact_parts = {
+        re.sub(r"[^a-z0-9]", "", part) for part in re.split(r"[/&=?]+", lowered) if part
+    }
+    adjacent_compounds = {first + second for first, second in pairwise(ordered_tokens)}
+    if (tokens | compact_parts | adjacent_compounds) & _ACTION_TOKENS:
+        return True
+    return any(
+        compact == f"{action}{suffix}"
+        for compact in compact_parts
+        for action in _ACTION_TOKENS
+        for suffix in _ACTION_COMPOUND_SUFFIXES
+    )
+
+
+def _record_response_observation(
+    graph: SurfaceGraphState,
+    url: str,
+    observation: _TransientObservation,
+) -> None:
+    graph.add(
+        url=_receipt_safe_url(url),
+        method=_SAFE_METHOD,
+        source_kind="probe",
+        identity_alias=observation.actor,
+        access_level="response",
+        response_status=(
+            observation.status
+            if observation.access_class is not AuthorizationSurfaceAccessClass.INCONCLUSIVE
+            else None
+        ),
+        scope_decision="allowed",
+        replayability="not_replayable",
+    )
+
+
+def _record_declaration(
+    graph: SurfaceGraphState,
+    declaration: _TransientDeclaration,
+    *,
+    actor: str,
+) -> None:
+    operation = declaration.operation
+    graph.add(
+        url=operation.structural_url,
+        method=operation.method,
+        parameters=operation.parameters,
+        header_names=operation.header_names,
+        hints=operation.hints,
+        source_kind=operation.provenance[0],
+        identity_alias=actor,
+        access_level="declared",
+        scope_decision="allowed",
+        replayability="not_replayable",
+    )
+
+
+def _needs_repeat(observations: Sequence[_TransientObservation]) -> bool:
+    items = tuple(observations)
+    if any(item.declarations for item in items):
+        return True
+    classes = {
+        item.access_class
+        for item in items
+        if item.access_class is not AuthorizationSurfaceAccessClass.INCONCLUSIVE
+    }
+    return len(classes) > 1
+
+
+def _stable_pair(first: _TransientObservation, second: _TransientObservation) -> bool:
+    return (
+        not first.reason_codes
+        and not second.reason_codes
+        and first.status == second.status
+        and first.access_class is second.access_class
+        and first.generation_before == first.generation_after
+        and first.generation_after == second.generation_before
+        and second.generation_before == second.generation_after
+        and {_declaration_key(item) for item in first.declarations}
+        == {_declaration_key(item) for item in second.declarations}
+    )
+
+
+def _shared_declarations(
+    first: _TransientObservation,
+    second: _TransientObservation,
+) -> tuple[_TransientDeclaration, ...]:
+    first_items = {_declaration_key(item): item for item in first.declarations}
+    second_keys = {_declaration_key(item) for item in second.declarations}
+    return tuple(first_items[key] for key in sorted(set(first_items) & second_keys))
+
+
+def _stable_access_difference(
+    pairs: Mapping[str, tuple[_TransientObservation, _TransientObservation]],
+    *,
+    actors: Sequence[str],
+) -> bool:
+    if set(pairs) != set(actors):
+        return False
+    classes = {pair[0].access_class for pair in pairs.values()}
+    return AuthorizationSurfaceAccessClass.INCONCLUSIVE not in classes and len(classes) > 1
+
+
+def _declaration_key(declaration: _TransientDeclaration) -> tuple[object, ...]:
+    operation = declaration.operation
+    return (
+        declaration.exact_url if declaration.dispatchable else "",
+        operation.operation_id,
+        operation.parameters,
+        operation.header_names,
+        operation.hints,
+        operation.provenance,
+        declaration.dispatchable,
+        declaration.coverage_reason,
+    )
+
+
+def _operation_id(url: str) -> str:
+    return SurfaceOperation.create(
+        url=_receipt_safe_url(url),
+        method=_SAFE_METHOD,
+        provenance=("probe",),
+    ).operation_id
+
+
+def _receipt_safe_url(url: str) -> str:
+    """Project an admitted exact URL into a conservative receipt-only route shape."""
+    operation = SurfaceOperation.create(
+        url=url,
+        method=_SAFE_METHOD,
+        provenance=("probe",),
+    )
+    shaped_segments: list[str] = []
+    previous = ""
+    for segment in operation.route_shape.split("/"):
+        if not segment:
+            shaped = ""
+        elif segment in _RECEIPT_PLACEHOLDERS:
+            shaped = segment
+        elif previous in _RECEIPT_SENSITIVE_PATH_PARENTS:
+            shaped = "{id}"
+        elif _RECEIPT_STATIC_SEGMENT_RE.fullmatch(segment) or _RECEIPT_API_VERSION_RE.fullmatch(
+            segment
+        ):
+            shaped = segment
+        else:
+            shaped = "{segment}"
+        shaped_segments.append(shaped)
+        previous = segment.casefold()
+    route_shape = "/".join(shaped_segments)
+    if not route_shape.startswith("/"):
+        route_shape = f"/{route_shape}"
+    return f"{operation.origin}{route_shape}"
+
+
+def _access_class(status: int | None) -> AuthorizationSurfaceAccessClass:
+    if status is None or status == 429 or status >= 500:
+        return AuthorizationSurfaceAccessClass.INCONCLUSIVE
+    if 200 <= status < 300:
+        return AuthorizationSurfaceAccessClass.SUCCESS
+    if 300 <= status < 400:
+        return AuthorizationSurfaceAccessClass.REDIRECT
+    if status in _DENIAL_STATUSES:
+        return AuthorizationSurfaceAccessClass.DENIED
+    return AuthorizationSurfaceAccessClass.INCONCLUSIVE
+
+
+def _response_status(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if _MIN_STATUS <= value <= _MAX_STATUS else None
+
+
+def _response_body(response: AuthorizationSurfaceHttpResponse) -> bytes | str:
+    body_bytes = response.body_bytes
+    if isinstance(body_bytes, bytes):
+        return body_bytes
+    if isinstance(body_bytes, bytearray | memoryview):
+        return bytes(body_bytes)
+    return response.body if isinstance(response.body, str) else ""
+
+
+def _header_value(headers: Mapping[str, str], wanted: str) -> str:
+    return next(
+        (str(value) for name, value in headers.items() if str(name).casefold() == wanted),
+        "",
+    )
+
+
+def _looks_like_html(body: bytes | str, content_type: str) -> bool:
+    if "html" in content_type.casefold():
+        return True
+    prefix = (
+        body[:512].decode("utf-8", errors="replace") if isinstance(body, bytes) else body[:512]
+    ).casefold()
+    return "<html" in prefix or "<!doctype html" in prefix
+
+
+def _current_policy_reasons(
+    runtime: AuthorizationSurfaceMapRuntime,
+    initial: TrafficPolicySnapshot,
+) -> tuple[str, ...]:
+    try:
+        current = runtime.traffic_snapshot()
+    except Exception:
+        return ("traffic_snapshot_unavailable",)
+    return traffic_policy_reason_codes(initial, current)
+
+
+def _result(
+    *,
+    complete: bool,
+    coverage_reasons: set[str],
+    reason_codes: set[str],
+    actors: tuple[str, ...],
+    roles: Mapping[str, tuple[str, ...]],
+    counters: Mapping[str, _ActorCounters],
+    graph: SurfaceGraphState,
+    discovered_by: Mapping[str, set[str]],
+    comparisons: Mapping[
+        str,
+        Sequence[Mapping[str, tuple[_TransientObservation, _TransientObservation]]],
+    ],
+    initial: TrafficPolicySnapshot,
+    runtime: AuthorizationSurfaceMapRuntime,
+) -> AuthorizationSurfaceMapResult:
+    policy_reasons: tuple[str, ...]
+    try:
+        current = runtime.traffic_snapshot()
+    except Exception:
+        current = initial
+        policy_reasons = ("traffic_snapshot_unavailable",)
+    else:
+        policy_reasons = traffic_policy_reason_codes(initial, current)
+    reason_codes.update(policy_reasons)
+    complete = complete and not reason_codes
+    delta = traffic_snapshot_delta(initial, current)
+    actor_results = tuple(
+        AuthorizationSurfaceActorResult(
+            actor=actor,
+            roles=roles[actor],
+            mapped_url_count=len(counters[actor].urls),
+            observation_count=counters[actor].observations,
+            success_count=counters[actor].success,
+            denied_count=counters[actor].denied,
+            redirect_count=counters[actor].redirect,
+            inconclusive_count=counters[actor].inconclusive,
+            complete=complete and counters[actor].inconclusive == 0,
+        )
+        for actor in actors
+    )
+    candidates = _candidates(
+        graph,
+        actors=actors,
+        roles=roles,
+        discovered_by=discovered_by,
+        comparisons=comparisons,
+        complete=complete,
+    )
+    return AuthorizationSurfaceMapResult(
+        complete=complete,
+        coverage_limited=bool(coverage_reasons),
+        reason_codes=tuple(sorted(reason_codes)),
+        coverage_reason_codes=tuple(sorted(coverage_reasons)),
+        actors=actor_results,
+        candidates=candidates,
+        surface_graph=graph,
+        traffic_delta=delta,
+    )
+
+
+def _candidates(
+    graph: SurfaceGraphState,
+    *,
+    actors: Sequence[str],
+    roles: Mapping[str, tuple[str, ...]],
+    discovered_by: Mapping[str, set[str]],
+    comparisons: Mapping[
+        str,
+        Sequence[Mapping[str, tuple[_TransientObservation, _TransientObservation]]],
+    ],
+    complete: bool,
+) -> tuple[AuthorizationSurfaceCandidate, ...]:
+    candidates: list[AuthorizationSurfaceCandidate] = []
+    actor_set = set(actors)
+    for operation_id, operation in sorted((graph.operations or {}).items()):
+        if operation.method != _SAFE_METHOD:
+            continue
+        if "script" in operation.hints and "link" not in operation.hints:
+            continue
+        discovered = set(discovered_by.get(operation_id, set()))
+        reasons: set[str] = set()
+        if discovered and discovered != actor_set:
+            reasons.add("identity_visibility_difference")
+        operation_comparisons = tuple(comparisons.get(operation_id, ()))
+        if operation_comparisons:
+            reasons.add("response_access_class_difference")
+        if not reasons:
+            continue
+        actor_evidence = _candidate_actor_evidence(
+            operation_comparisons,
+            actors=actors,
+            roles=roles,
+            discovered=discovered,
+        )
+        stable = all(item.stable for item in actor_evidence)
+        candidate_id = _candidate_id(operation_id, tuple(sorted(reasons)))
+        candidates.append(
+            AuthorizationSurfaceCandidate(
+                candidate_id=candidate_id,
+                operation_id=operation_id,
+                method=operation.method,
+                route_shape=operation.route_shape,
+                parameters=operation.parameters,
+                discovered_by=tuple(actor for actor in actors if actor in discovered),
+                not_discovered_by=tuple(actor for actor in actors if actor not in discovered),
+                actor_evidence=actor_evidence,
+                reason_codes=tuple(sorted(reasons)),
+                review_ready=complete and stable,
+            )
+        )
+    return tuple(sorted(candidates, key=lambda item: item.candidate_id))
+
+
+def _candidate_actor_evidence(
+    comparisons: Sequence[Mapping[str, tuple[_TransientObservation, _TransientObservation]]],
+    *,
+    actors: Sequence[str],
+    roles: Mapping[str, tuple[str, ...]],
+    discovered: set[str],
+) -> tuple[AuthorizationSurfaceCandidateActor, ...]:
+    evidence: list[AuthorizationSurfaceCandidateActor] = []
+    for actor in actors:
+        pairs = tuple(comparison[actor] for comparison in comparisons if actor in comparison)
+        statuses = {
+            status
+            for pair in pairs
+            for status in (pair[0].status, pair[1].status)
+            if status is not None
+        }
+        classes = {observation.access_class.value for pair in pairs for observation in pair}
+        evidence.append(
+            AuthorizationSurfaceCandidateActor(
+                actor=actor,
+                roles=roles[actor],
+                declaration_observed=actor in discovered,
+                access_classes=tuple(sorted(classes)),
+                statuses=tuple(sorted(statuses)),
+                stable=not pairs or all(_stable_pair(*pair) for pair in pairs),
+            )
+        )
+    return tuple(evidence)
+
+
+def _candidate_id(operation_id: str, reasons: tuple[str, ...]) -> str:
+    digest = hashlib.sha256("\x00".join((operation_id, *reasons)).encode("utf-8")).hexdigest()
+    return f"asm_{digest[:24]}"
+
+
+__all__ = [
+    "AUTHORIZATION_SURFACE_MAP_RESULT_SCHEMA",
+    "AuthorizationSurfaceAccessClass",
+    "AuthorizationSurfaceActorResult",
+    "AuthorizationSurfaceCandidate",
+    "AuthorizationSurfaceCandidateActor",
+    "AuthorizationSurfaceHttpResponse",
+    "AuthorizationSurfaceMapResult",
+    "AuthorizationSurfaceMapRunner",
+    "AuthorizationSurfaceMapRuntime",
+    "run_authorization_surface_map",
+]

--- a/packages/ravage/src/ravage/auth/runtime.py
+++ b/packages/ravage/src/ravage/auth/runtime.py
@@ -11,7 +11,7 @@ from http.cookiejar import Cookie
 from pathlib import Path
 from typing import TYPE_CHECKING, Never, Self, SupportsIndex
 
-from ravage.web_core.http_probe import ProbeResponse, ProbeSession
+from ravage.web_core.http_probe import ProbeNetworkContext, ProbeResponse, ProbeSession
 
 from .configured import (
     ConfiguredAuthenticationError,
@@ -107,6 +107,18 @@ class ManagedAttackAuthentication:
     @property
     def identity(self) -> str:
         return self.__identity
+
+    @property
+    def identity_generation(self) -> int:
+        """Return non-secret session generation metadata for paired comparisons."""
+        with self.__lock:
+            return self.__handle.generation
+
+    @property
+    def network_context(self) -> ProbeNetworkContext:
+        """Return the shared resolver and DNS pin context retained by this identity."""
+        with self.__lock:
+            return self.__handle.session.network_context
 
     @property
     def traffic_policy(self) -> TrafficPolicyController | None:
@@ -591,6 +603,7 @@ def build_authenticated_attack_runtime(  # noqa: PLR0913 - explicit public build
     secret_resolver: SecretResolver,
     traffic_policy: TrafficPolicyController | None = None,
     traffic_policy_reference: dict[str, object] | None = None,
+    network_context: ProbeNetworkContext | None = None,
 ) -> ManagedAttackAuthentication:
     """Build and authenticate one attack identity without mutating secret sources."""
     assert_secure_configured_auth_transport(
@@ -616,6 +629,7 @@ def build_authenticated_attack_runtime(  # noqa: PLR0913 - explicit public build
         in_scope=in_scope,
         out_of_scope=out_of_scope,
         max_rps=max_rps,
+        network_context=network_context,
         traffic_policy=traffic_policy,
         traffic_policy_reference=traffic_policy_reference,
     )

--- a/packages/ravage/src/ravage/web_core/http_probe.py
+++ b/packages/ravage/src/ravage/web_core/http_probe.py
@@ -507,6 +507,53 @@ class ResponseDelta:
         }
 
 
+class ProbeNetworkContext:
+    """Share one resolver and immutable DNS pin set across isolated sessions."""
+
+    __slots__ = ("_lock", "_pins", "_resolver")
+
+    def __init__(
+        self,
+        resolver: Callable[[str, int], Sequence[str]] | None = None,
+        *,
+        _pins: dict[tuple[str, int], tuple[str, ...]] | None = None,
+        _lock: threading.Lock | None = None,
+    ) -> None:
+        self._resolver = resolver or _resolve_addresses
+        self._pins = _pins if _pins is not None else {}
+        self._lock = _lock or threading.Lock()
+
+    def pin(self, host: str, port: int) -> str:
+        """Resolve and freeze one address set, returning a stable error if unsafe."""
+        try:
+            resolved = self._resolver(host, port)
+            parsed_addresses = tuple(
+                _validated_connection_address(str(address).strip()) for address in resolved
+            )
+        except OSError as exc:
+            return f"remote target DNS resolution failed: {exc}"
+        except ValueError as exc:
+            return f"remote target DNS resolution rejected an address: {exc}"
+        addresses = tuple(sorted({str(address) for address in parsed_addresses}))
+        if not addresses:
+            return "remote target DNS resolution returned no addresses"
+        key = (host.lower(), port)
+        with self._lock:
+            pinned = self._pins.setdefault(key, addresses)
+            if pinned != addresses:
+                return "remote target DNS resolution changed after pinning"
+        return ""
+
+    def pinned_addresses(self, host: str, port: int) -> tuple[str, ...]:
+        """Return a frozen address set without exposing mutable pin storage."""
+        with self._lock:
+            addresses = self._pins.get((host.lower(), port))
+        if addresses is None:
+            message = "probe connection attempted before DNS pinning"
+            raise OSError(message)
+        return addresses
+
+
 class ProbeSession:
     def __init__(  # noqa: PLR0913
         self,
@@ -519,6 +566,7 @@ class ProbeSession:
         out_of_scope: Sequence[str] = (),
         max_rps: float | None = None,
         resolver: Callable[[str, int], Sequence[str]] | None = None,
+        network_context: ProbeNetworkContext | None = None,
         _request_pacer: _RequestPacer | None = None,
         _physical_request_counter: _SharedPhysicalRequestCounter | None = None,
         _dns_pins: dict[tuple[str, int], tuple[str, ...]] | None = None,
@@ -555,9 +603,17 @@ class ProbeSession:
         self._physical_request_counter = (
             _physical_request_counter or _SharedPhysicalRequestCounter()
         )
-        self._resolver = resolver or _resolve_addresses
-        self._dns_pins = _dns_pins if _dns_pins is not None else {}
-        self._dns_pin_lock = _dns_pin_lock or threading.Lock()
+        if network_context is not None and (
+            resolver is not None or _dns_pins is not None or _dns_pin_lock is not None
+        ):
+            raise ValueError(
+                "network_context cannot be combined with resolver or private DNS state"
+            )
+        self._network_context = network_context or ProbeNetworkContext(
+            resolver,
+            _pins=_dns_pins,
+            _lock=_dns_pin_lock,
+        )
         self._traffic_observer = traffic_observer
         if traffic_policy is not None and traffic_policy_reference is not None:
             raise ValueError("traffic_policy and traffic_policy_reference are mutually exclusive")
@@ -689,6 +745,10 @@ class ProbeSession:
         return self._traffic_policy.to_reference()
 
     @property
+    def network_context(self) -> ProbeNetworkContext:
+        return self._network_context
+
+    @property
     def managed_identity_generation(self) -> int | None:
         return self._managed_identity_generation
 
@@ -739,11 +799,9 @@ class ProbeSession:
             in_scope=self.scope_in_scope,
             out_of_scope=self.scope_out_of_scope,
             max_rps=self.max_rps,
-            resolver=self._resolver,
+            network_context=self._network_context,
             _request_pacer=self._request_pacer,
             _physical_request_counter=self._physical_request_counter,
-            _dns_pins=self._dns_pins,
-            _dns_pin_lock=self._dns_pin_lock,
             traffic_observer=self._traffic_observer,
             traffic_policy=self._traffic_policy,
             traffic_lane=self._traffic_lane,
@@ -1390,33 +1448,10 @@ class ProbeSession:
         parsed = urlsplit(url)
         host = parsed.hostname or ""
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        try:
-            resolved = self._resolver(host, port)
-            parsed_addresses = tuple(
-                _validated_connection_address(str(address).strip()) for address in resolved
-            )
-        except OSError as exc:
-            return f"remote target DNS resolution failed: {exc}"
-        except ValueError as exc:
-            return f"remote target DNS resolution rejected an address: {exc}"
-        addresses = tuple(sorted({str(address) for address in parsed_addresses}))
-        if not addresses:
-            return "remote target DNS resolution returned no addresses"
-        key = (host.lower(), port)
-        with self._dns_pin_lock:
-            pinned = self._dns_pins.setdefault(key, addresses)
-            if pinned != addresses:
-                return "remote target DNS resolution changed after pinning"
-        return ""
+        return self._network_context.pin(host, port)
 
     def _pinned_addresses_for_connection(self, host: str, port: int) -> tuple[str, ...]:
-        key = (host.lower(), port)
-        with self._dns_pin_lock:
-            addresses = self._dns_pins.get(key)
-        if addresses is None:
-            message = "probe connection attempted before DNS pinning"
-            raise OSError(message)
-        return addresses
+        return self._network_context.pinned_addresses(host, port)
 
 
 def _validated_timeout(value: object) -> float:

--- a/packages/ravage/src/ravage/web_core/recon.py
+++ b/packages/ravage/src/ravage/web_core/recon.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import secrets
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from html.parser import HTMLParser
 from http.cookies import CookieError, Morsel, SimpleCookie
@@ -239,6 +239,39 @@ class _ParsedReconDocument:
     body_text: str
     query_parameter_names: list[str]
     interesting_markers: list[str]
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PassiveReconParameter:
+    """One transient parameter name and location extracted without its value."""
+
+    name: str
+    location: str
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PassiveReconOperation:
+    """One transient request declaration from an already-fetched document.
+
+    ``url`` can contain concrete identifiers and query values. Callers must keep
+    this object in memory and project it through the canonical surface graph
+    before writing, displaying, or logging it.
+    """
+
+    method: str
+    url: str
+    parameters: tuple[PassiveReconParameter, ...] = ()
+    header_names: tuple[str, ...] = ()
+    hints: tuple[str, ...] = ()
+    source_kind: str = "native_recon"
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PassiveReconDocument:
+    """Transient bounded navigation data without body, cookie, or field values."""
+
+    links: tuple[str, ...]
+    operations: tuple[PassiveReconOperation, ...]
 
 
 class _ReconHeaders:
@@ -861,6 +894,110 @@ def _parse_recon_document(
     )
 
 
+def parse_passive_recon_document(
+    final_url: str,
+    headers: Mapping[str, str],
+    body: bytes | str,
+) -> PassiveReconDocument:
+    """Extract transient navigation declarations without retaining field values.
+
+    This parser performs no I/O.  It deliberately omits response text, titles,
+    cookies, header values, form defaults, and JavaScript payload values. Exact
+    URLs remain transient and must never be serialized or logged directly.
+    """
+    document = _parse_recon_document(
+        final_url,
+        _ReconHeaders({str(name): str(value) for name, value in headers.items()}),
+        body,
+    )
+    operations: list[PassiveReconOperation] = []
+    page_url = _canonical_url(final_url)
+    links = tuple(item for item in sorted(set(document.links))[:128] if item != page_url)
+    for link in links:
+        operations.append(
+            PassiveReconOperation(
+                method="GET",
+                url=link,
+                parameters=tuple(
+                    PassiveReconParameter(name=name, location="query")
+                    for name in _query_names(link)[:32]
+                ),
+                hints=("link",),
+            )
+        )
+    for script in (item for item in sorted(set(document.scripts))[:64] if item != page_url):
+        operations.append(
+            PassiveReconOperation(
+                method="GET",
+                url=script,
+                parameters=tuple(
+                    PassiveReconParameter(name=name, location="query")
+                    for name in _query_names(script)[:32]
+                ),
+                hints=("script",),
+            )
+        )
+    for form in document.forms[:64]:
+        fields = tuple(
+            sorted({field.name for field in form.inputs[:64] if field.name and not field.disabled})
+        )
+        query_parameters = tuple(
+            PassiveReconParameter(name=name, location="query")
+            for name in _query_names(form.action)[:32]
+        )
+        form_parameters = tuple(
+            PassiveReconParameter(
+                name=name,
+                location="query" if form.method == "GET" else "form",
+            )
+            for name in fields[:64]
+        )
+        operations.append(
+            PassiveReconOperation(
+                method=form.method,
+                url=form.action,
+                parameters=tuple((*query_parameters, *form_parameters))[:64],
+                hints=("form",),
+            )
+        )
+    for template in document.request_templates[:64]:
+        template_fields = template.get("fields")
+        template_headers = template.get("headers")
+        template_url = urljoin(final_url, str(template.get("url") or ""))
+        query_parameters = tuple(
+            PassiveReconParameter(name=name, location="query")
+            for name in _query_names(template_url)[:32]
+        )
+        body_parameters = (
+            tuple(
+                PassiveReconParameter(name=name, location="body")
+                for name in sorted(
+                    str(raw_name) for raw_name in template_fields if str(raw_name).strip()
+                )
+            )
+            if isinstance(template_fields, Mapping)
+            else ()
+        )
+        operations.append(
+            PassiveReconOperation(
+                method=str(template.get("method") or "GET").strip().upper(),
+                url=template_url,
+                parameters=tuple((*query_parameters, *body_parameters))[:64],
+                header_names=(
+                    tuple(sorted(str(name) for name in template_headers if str(name).strip()))[:64]
+                    if isinstance(template_headers, Mapping)
+                    else ()
+                ),
+                hints=("javascript",),
+                source_kind="javascript_inline",
+            )
+        )
+    return PassiveReconDocument(
+        links=links,
+        operations=tuple(operations[:256]),
+    )
+
+
 def _looks_like_html(body_text: str, content_type: str) -> bool:
     content_type = content_type.lower()
     if "html" in content_type:
@@ -1469,9 +1606,13 @@ def _contains_any(text: str, words: Iterable[str]) -> bool:
 
 
 __all__ = [
+    "PassiveReconDocument",
+    "PassiveReconOperation",
+    "PassiveReconParameter",
     "ReconForm",
     "ReconInput",
     "ReconPage",
     "ReconResult",
+    "parse_passive_recon_document",
     "run_recon",
 ]

--- a/packages/ravage/tests/test_authorization_matrix_runtime.py
+++ b/packages/ravage/tests/test_authorization_matrix_runtime.py
@@ -35,7 +35,7 @@ from ravage.traffic.policy import (
     TrafficPolicyController,
     TrafficPolicyMode,
 )
-from ravage.web_core.http_probe import ProbeResponse
+from ravage.web_core.http_probe import ProbeNetworkContext, ProbeResponse
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -48,12 +48,16 @@ _OWNER_SECRET = "owner-secret-must-not-escape"  # noqa: S105 - redaction sentine
 _ANONYMOUS_SECRET = "anonymous-secret-must-not-escape"  # noqa: S105 - redaction sentinel.
 _BUILT_OWNER_COUNT = 2
 _END_TO_END_REQUEST_COUNT = 9
+_ALICE_GENERATION = 3
+_BOB_GENERATION = 7
 
 
 @dataclass
 class _StubOwner:
     identity: str
     traffic_policy: TrafficPolicyController
+    network_context: ProbeNetworkContext | None = None
+    identity_generation: int = 1
     secret: str = _OWNER_SECRET
     close_error: Exception | None = None
     requests: list[tuple[str, str]] = field(default_factory=list)
@@ -77,6 +81,7 @@ class _StubOwner:
 @dataclass
 class _StubSession:
     traffic_policy: TrafficPolicyController
+    network_context: ProbeNetworkContext | None = None
     secret: str = _ANONYMOUS_SECRET
     requests: list[tuple[str, str]] = field(default_factory=list)
     default_headers: dict[str, str] = field(
@@ -91,8 +96,9 @@ class _StubSession:
 
 def test_constructor_requires_two_identities_and_matching_role_keys(tmp_path: Path) -> None:
     policy = _traffic_policy(tmp_path)
-    anonymous = _StubSession(policy)
-    alice = _StubOwner("alice", policy)
+    network_context = ProbeNetworkContext()
+    anonymous = _StubSession(policy, network_context=network_context)
+    alice = _StubOwner("alice", policy, network_context=network_context)
 
     with pytest.raises(AuthorizationMatrixRuntimeError, match="at least two"):
         ManagedAuthorizationMatrix(
@@ -101,9 +107,10 @@ def test_constructor_requires_two_identities_and_matching_role_keys(tmp_path: Pa
             anonymous_session=anonymous,  # type: ignore[arg-type]
             traffic_policy=policy,
             initial_traffic_snapshot=policy.snapshot(),
+            network_context=network_context,
         )
 
-    bob = _StubOwner("bob", policy)
+    bob = _StubOwner("bob", policy, network_context=network_context)
     with pytest.raises(AuthorizationMatrixRuntimeError, match="roles do not match"):
         ManagedAuthorizationMatrix(
             owners={"alice": alice, "bob": bob},
@@ -111,6 +118,7 @@ def test_constructor_requires_two_identities_and_matching_role_keys(tmp_path: Pa
             anonymous_session=anonymous,  # type: ignore[arg-type]
             traffic_policy=policy,
             initial_traffic_snapshot=policy.snapshot(),
+            network_context=network_context,
         )
 
 
@@ -120,17 +128,26 @@ def test_constructor_rejects_reserved_identity_aliases(
     reserved_alias: str,
 ) -> None:
     policy = _traffic_policy(tmp_path)
+    network_context = ProbeNetworkContext()
 
     with pytest.raises(AuthorizationMatrixRuntimeError, match="reserved anonymous alias"):
         ManagedAuthorizationMatrix(
             owners={
-                "alice": _StubOwner("alice", policy),
-                reserved_alias: _StubOwner(reserved_alias, policy),
+                "alice": _StubOwner("alice", policy, network_context=network_context),
+                reserved_alias: _StubOwner(
+                    reserved_alias,
+                    policy,
+                    network_context=network_context,
+                ),
             },
             roles={"alice": ("member",), reserved_alias: ("guest",)},
-            anonymous_session=_StubSession(policy),  # type: ignore[arg-type]
+            anonymous_session=_StubSession(  # type: ignore[arg-type]
+                policy,
+                network_context=network_context,
+            ),
             traffic_policy=policy,
             initial_traffic_snapshot=policy.snapshot(),
+            network_context=network_context,
         )
 
 
@@ -162,6 +179,31 @@ def test_constructor_rejects_owner_and_anonymous_policy_mismatches(tmp_path: Pat
 
     with pytest.raises(AuthorizationMatrixRuntimeError, match="anonymous matrix traffic"):
         _matrix(policy, anonymous_session=_StubSession(other_policy))
+
+
+def test_constructor_rejects_owner_and_anonymous_network_context_mismatches(
+    tmp_path: Path,
+) -> None:
+    policy = _traffic_policy(tmp_path)
+    shared = ProbeNetworkContext()
+    other = ProbeNetworkContext()
+
+    with pytest.raises(AuthorizationMatrixRuntimeError, match="identities do not share"):
+        _matrix(
+            policy,
+            owners={
+                "alice": _StubOwner("alice", policy, network_context=shared),
+                "bob": _StubOwner("bob", policy, network_context=other),
+            },
+            network_context=shared,
+        )
+
+    with pytest.raises(AuthorizationMatrixRuntimeError, match="anonymous matrix traffic"):
+        _matrix(
+            policy,
+            anonymous_session=_StubSession(policy, network_context=other),
+            network_context=shared,
+        )
 
 
 def test_requests_route_to_configured_and_anonymous_lanes(tmp_path: Path) -> None:
@@ -219,6 +261,32 @@ def test_roles_are_normalized_and_fail_closed_for_unknown_aliases(tmp_path: Path
     assert runtime.roles("anonymous") == ()
     with pytest.raises(AuthorizationMatrixRuntimeError, match="unknown authorization"):
         runtime.roles("mallory")
+
+
+def test_identity_generations_are_exposed_without_credentials(tmp_path: Path) -> None:
+    policy = _traffic_policy(tmp_path)
+    runtime = _matrix(
+        policy,
+        owners={
+            "alice": _StubOwner(
+                "alice",
+                policy,
+                identity_generation=_ALICE_GENERATION,
+            ),
+            "bob": _StubOwner(
+                "bob",
+                policy,
+                identity_generation=_BOB_GENERATION,
+            ),
+        },
+    )
+
+    assert runtime.identity_generation("alice") == _ALICE_GENERATION
+    assert runtime.identity_generation("bob") == _BOB_GENERATION
+    assert runtime.identity_generation(None) == 0
+    assert runtime.identity_generation("anonymous") == 0
+    with pytest.raises(AuthorizationMatrixRuntimeError, match="unknown authorization"):
+        runtime.identity_generation("mallory")
 
 
 def test_initial_snapshot_is_stable_and_current_snapshot_is_live(tmp_path: Path) -> None:
@@ -334,23 +402,36 @@ def test_builder_selects_roles_shares_controller_and_snapshots_before_owners(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     policy = _traffic_policy(tmp_path)
+    network_context = ProbeNetworkContext()
     owner_calls: list[tuple[str, TrafficPolicyController]] = []
     anonymous_calls: list[TrafficPolicyController] = []
-    anonymous = _StubSession(policy)
+    owner_network_contexts: list[ProbeNetworkContext] = []
+    anonymous_network_contexts: list[ProbeNetworkContext] = []
+    anonymous = _StubSession(policy, network_context=network_context)
 
     def fake_build(**kwargs: object) -> _StubOwner:
         identity = kwargs["identity"]
         candidate = kwargs["traffic_policy"]
+        candidate_network_context = kwargs["network_context"]
         assert isinstance(identity, str)
         assert isinstance(candidate, TrafficPolicyController)
+        assert isinstance(candidate_network_context, ProbeNetworkContext)
         owner_calls.append((identity, candidate))
+        owner_network_contexts.append(candidate_network_context)
         candidate.record_unmetered_action()
-        return _StubOwner(identity, candidate)
+        return _StubOwner(
+            identity,
+            candidate,
+            network_context=candidate_network_context,
+        )
 
     def fake_probe_session(_target_url: str, **kwargs: object) -> _StubSession:
         candidate = kwargs["traffic_policy"]
+        candidate_network_context = kwargs["network_context"]
         assert isinstance(candidate, TrafficPolicyController)
+        assert isinstance(candidate_network_context, ProbeNetworkContext)
         anonymous_calls.append(candidate)
+        anonymous_network_contexts.append(candidate_network_context)
         return anonymous
 
     monkeypatch.setattr(matrix_runtime, "build_authenticated_attack_runtime", fake_build)
@@ -360,6 +441,7 @@ def test_builder_selects_roles_shares_controller_and_snapshots_before_owners(
         config=_authentication_config(),
         identities=(" bob ", "alice", "bob"),
         policy=policy,
+        network_context=network_context,
     )
 
     assert runtime.identities == ("alice", "bob")
@@ -368,6 +450,8 @@ def test_builder_selects_roles_shares_controller_and_snapshots_before_owners(
     assert [alias for alias, _candidate in owner_calls] == ["alice", "bob"]
     assert all(candidate is policy for _alias, candidate in owner_calls)
     assert anonymous_calls == [policy]
+    assert owner_network_contexts == [network_context, network_context]
+    assert anonymous_network_contexts == [network_context]
     assert runtime.initial_traffic_snapshot.unmetered_action_count == 0
     assert runtime.traffic_snapshot().unmetered_action_count == _BUILT_OWNER_COUNT
     runtime.close()
@@ -384,12 +468,15 @@ def test_builder_closes_partial_owners_when_later_construction_fails(
     def fake_build(**kwargs: object) -> _StubOwner:
         identity = kwargs["identity"]
         candidate = kwargs["traffic_policy"]
+        network_context = kwargs["network_context"]
         assert isinstance(identity, str)
         assert candidate is policy
+        assert isinstance(network_context, ProbeNetworkContext)
         calls.append(identity)
         if identity == "bob":
             message = "owner build exploded"
             raise RuntimeError(message)
+        alice.network_context = network_context
         return alice
 
     def unexpected_probe_session(*_args: object, **_kwargs: object) -> None:
@@ -528,13 +615,14 @@ def test_real_managed_runtime_keeps_bearer_identities_isolated_end_to_end(
     ]
 
 
-def _matrix(
+def _matrix(  # noqa: PLR0913 - explicit fault injection for constructor invariants.
     policy: TrafficPolicyController,
     *,
     owners: Mapping[str, _StubOwner] | None = None,
     roles: Mapping[str, tuple[str, ...]] | None = None,
     anonymous_session: _StubSession | None = None,
     initial_snapshot: object | None = None,
+    network_context: ProbeNetworkContext | None = None,
 ) -> ManagedAuthorizationMatrix:
     selected_owners = dict(
         owners
@@ -543,14 +631,33 @@ def _matrix(
             "bob": _StubOwner("bob", policy),
         }
     )
+    shared_network_context = network_context or next(
+        (
+            owner.network_context
+            for owner in selected_owners.values()
+            if owner.network_context is not None
+        ),
+        None,
+    )
+    if shared_network_context is None and anonymous_session is not None:
+        shared_network_context = anonymous_session.network_context
+    if shared_network_context is None:
+        shared_network_context = ProbeNetworkContext()
+    for owner in selected_owners.values():
+        if owner.network_context is None:
+            owner.network_context = shared_network_context
+    selected_anonymous = anonymous_session or _StubSession(policy)
+    if selected_anonymous.network_context is None:
+        selected_anonymous.network_context = shared_network_context
     selected_roles = roles or dict.fromkeys(selected_owners, ("member",))
     snapshot = policy.snapshot() if initial_snapshot is None else initial_snapshot
     return ManagedAuthorizationMatrix(
         owners=selected_owners,  # type: ignore[arg-type]
         roles=selected_roles,
-        anonymous_session=anonymous_session or _StubSession(policy),  # type: ignore[arg-type]
+        anonymous_session=selected_anonymous,  # type: ignore[arg-type]
         traffic_policy=policy,
         initial_traffic_snapshot=snapshot,  # type: ignore[arg-type]
+        network_context=shared_network_context,
     )
 
 
@@ -559,6 +666,7 @@ def _build(
     config: AuthenticationConfig,
     identities: Sequence[str],
     policy: TrafficPolicyController,
+    network_context: ProbeNetworkContext | None = None,
 ) -> ManagedAuthorizationMatrix:
     return build_managed_authorization_matrix(
         config=config,
@@ -571,6 +679,7 @@ def _build(
         max_rps=5,
         secret_resolver=MappingSecretResolver({}, provider="test"),
         traffic_policy=policy,
+        network_context=network_context,
     )
 
 

--- a/packages/ravage/tests/test_authorization_surface_map.py
+++ b/packages/ravage/tests/test_authorization_surface_map.py
@@ -1,0 +1,707 @@
+# ruff: noqa: PLR2004, S105
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+import pytest
+from ravage.auth.authorization_matrix import ANONYMOUS_ACTOR
+from ravage.auth.authorization_surface_map import run_authorization_surface_map
+from ravage.traffic.policy import TrafficPolicySnapshot
+from ravage.web_core.scope_policy import same_origin
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+_TARGET = "https://app.example.test/"
+_ALICE = "alice"
+_BOB = "bob"
+
+
+@dataclass(frozen=True, slots=True)
+class _Response:
+    status: int | None
+    final_url: str
+    headers: Mapping[str, str]
+    body: str
+    body_bytes: bytes
+    error: str = ""
+    truncated: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _Plan:
+    response: _Response
+    generation_after: int | None = None
+
+
+class _Runtime:
+    def __init__(
+        self,
+        *,
+        identities: Sequence[str] = (_ALICE, _BOB),
+        responses: Mapping[tuple[str | None, str], Sequence[_Plan]] | None = None,
+        roles: Mapping[str, Sequence[str]] | None = None,
+        final_snapshot_changes: Mapping[str, int | str] | None = None,
+    ) -> None:
+        self._identities = tuple(identities)
+        self._responses = {key: tuple(plans) for key, plans in (responses or {}).items()}
+        self._roles = {
+            alias: tuple(values)
+            for alias, values in (
+                roles
+                or {
+                    _ALICE: ("admin",),
+                    _BOB: ("member",),
+                }
+            ).items()
+        }
+        self._generations: dict[str | None, int] = dict.fromkeys(self._identities, 1)
+        self._generations[None] = 0
+        self._call_counts: dict[tuple[str | None, str], int] = {}
+        self._final_snapshot_changes = dict(final_snapshot_changes or {})
+        self.requests: list[tuple[str | None, str, str]] = []
+        self._physical_requests = 0
+        self._completed_requests = 0
+        self._initial = _snapshot()
+
+    @property
+    def identities(self) -> Sequence[str]:
+        return self._identities
+
+    @property
+    def initial_traffic_snapshot(self) -> TrafficPolicySnapshot:
+        return self._initial
+
+    def roles(self, identity_alias: str) -> Sequence[str]:
+        return self._roles[identity_alias]
+
+    def identity_generation(self, identity_alias: str | None) -> int:
+        return self._generations[identity_alias]
+
+    def in_scope(self, url: str) -> bool:
+        return same_origin(_TARGET, url)
+
+    def request(self, identity_alias: str | None, method: str, url: str) -> _Response:
+        self.requests.append((identity_alias, method, url))
+        self._physical_requests += 1
+        key = (identity_alias, url)
+        index = self._call_counts.get(key, 0)
+        self._call_counts[key] = index + 1
+        plans = self._responses.get(key)
+        plan = plans[min(index, len(plans) - 1)] if plans else _Plan(_response(url))
+        if plan.generation_after is not None:
+            self._generations[identity_alias] = plan.generation_after
+        self._completed_requests += 1
+        return plan.response
+
+    def traffic_snapshot(self) -> TrafficPolicySnapshot:
+        snapshot = _snapshot(
+            physical=self._physical_requests,
+            completed=self._completed_requests,
+        )
+        if self._physical_requests and self._final_snapshot_changes:
+            return replace(snapshot, **self._final_snapshot_changes)
+        return snapshot
+
+
+def test_stable_shared_surface_has_no_candidates() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET)),
+            (_BOB, _TARGET): _stable(_response(_TARGET)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert result.coverage_limited is False
+    assert result.reason_codes == ()
+    assert result.candidates == ()
+    assert runtime.requests == [
+        (_ALICE, "GET", _TARGET),
+        (_BOB, "GET", _TARGET),
+    ]
+
+
+def test_empty_missing_and_fragment_links_do_not_force_repeats() -> None:
+    inert_links = '<a>Missing</a><a href="">Empty</a><a href="#local">Fragment</a>'
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, inert_links)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert result.candidates == ()
+    assert len(runtime.requests) == 2
+
+
+def test_identity_only_visibility_creates_review_candidate() -> None:
+    admin_url = f"{_TARGET}admin"
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, '<a href="/admin">Admin</a>')),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+            (_ALICE, admin_url): _stable(_response(admin_url)),
+            (_BOB, admin_url): _stable(_response(admin_url)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert len(result.candidates) == 1
+    candidate = result.candidates[0]
+    assert candidate.route_shape == "/admin"
+    assert candidate.reason_codes == ("identity_visibility_difference",)
+    assert candidate.discovered_by == (_ALICE,)
+    assert candidate.not_discovered_by == (_BOB,)
+    evidence = {item.actor: item for item in candidate.actor_evidence}
+    assert evidence[_ALICE].declaration_observed is True
+    assert evidence[_BOB].declaration_observed is False
+    assert all(item.stable for item in candidate.actor_evidence)
+    assert candidate.review_ready is True
+
+
+def test_link_candidate_is_not_suppressed_when_route_is_also_a_script_source() -> None:
+    admin_url = f"{_TARGET}admin"
+    body = '<a href="/admin">Admin</a><script src="/admin"></script>'
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, body)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+            (_ALICE, admin_url): _stable(_response(admin_url)),
+            (_BOB, admin_url): _stable(_response(admin_url)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    candidates = {candidate.route_shape: candidate for candidate in result.candidates}
+    assert candidates["/admin"].reason_codes == ("identity_visibility_difference",)
+    assert candidates["/admin"].review_ready is True
+
+
+def test_stable_success_vs_denied_creates_review_candidate() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=200)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=403)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert len(result.candidates) == 1
+    candidate = result.candidates[0]
+    assert candidate.route_shape == "/"
+    assert candidate.reason_codes == ("response_access_class_difference",)
+    assert candidate.review_ready is True
+    evidence = {item.actor: item for item in candidate.actor_evidence}
+    assert evidence[_ALICE].access_classes == ("success",)
+    assert evidence[_ALICE].statuses == (200,)
+    assert evidence[_BOB].access_classes == ("denied",)
+    assert evidence[_BOB].statuses == (403,)
+    assert all(item.stable for item in candidate.actor_evidence)
+
+
+def test_success_status_variants_do_not_create_status_noise() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=200)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=204)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert result.candidates == ()
+    assert len(runtime.requests) == 2
+
+
+def test_rotating_query_values_do_not_make_a_stable_shape_incomplete() -> None:
+    first = _html(_TARGET, '<a href="/download?signature=first-secret">Download</a>')
+    second = _html(_TARGET, '<a href="/download?signature=second-secret">Download</a>')
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _sequence(first, second),
+            (_BOB, _TARGET): _sequence(first, second),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+    rendered = json.dumps(result.to_json(), sort_keys=True)
+
+    assert result.complete is True
+    assert "unstable_surface_observation" not in result.reason_codes
+    assert result.candidates == ()
+    assert "first-secret" not in rendered
+    assert "second-secret" not in rendered
+
+
+def test_query_action_form_script_and_javascript_operations_are_never_dispatched() -> None:
+    body = """
+    <a href="/search?q=private-value">Search</a>
+    <a href="/logout">Log out</a>
+    <a href="/account/%256c%256f%2567%256f%2575%2574">Encoded log out</a>
+    <a href="/account/deleteAccount">Delete account</a>
+    <form method="GET" action="/reports">
+      <input name="account" value="private-value">
+    </form>
+    <form method="POST" action="/orders/update">
+      <input name="csrf" value="private-value">
+    </form>
+    <script src="/assets/app.js"></script>
+    <script>fetch('/api/diagnostics')</script>
+    """
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, body)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, body)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert {url for _actor, _method, url in runtime.requests} == {_TARGET}
+    assert len(runtime.requests) == 4
+    assert {
+        "action_route_not_dispatched",
+        "declared_operation_not_dispatched",
+        "non_get_operation_not_dispatched",
+        "query_route_not_dispatched",
+        "static_asset_not_dispatched",
+    } <= set(result.coverage_reason_codes)
+
+
+def test_deeply_encoded_paths_and_common_action_routes_are_never_dispatched() -> None:
+    encoded_logout = "".join(f"%{ord(character):02x}" for character in "logout")
+    for _round in range(5):
+        encoded_logout = encoded_logout.replace("%", "%25")
+    body = f"""
+    <a href="/safe/%25252e%25252e/admin">Traversal</a>
+    <a href="/account/{encoded_logout}">Deep logout</a>
+    <a href="/billing/cancelSubscription">Cancel</a>
+    <a href="/admin/impersonate">Impersonate</a>
+    <a href="/jobs/restart">Restart</a>
+    <a href="/payments/transfer">Transfer</a>
+    <a href="/newsletter/unsubscribe">Unsubscribe</a>
+    <a href="/tasks/execute">Execute</a>
+    <a href="/billing/purchase">Purchase</a>
+    <a href="/admin/deploy">Deploy</a>
+    <a href="/system/shutdown">Shutdown</a>
+    <a href="/jobs/run">Run</a>
+    <a href="/orders/refund">Refund</a>
+    <a href="/account/changePassword">Change password</a>
+    <a href="/account/enable2FA">Enable 2FA</a>
+    <a href="/account/disable2fa">Disable 2FA</a>
+    <a href="/account/reset2FA">Reset 2FA</a>
+    <a href="/keys/rotate2fa">Rotate 2FA</a>
+    <a href="/admin/delete2FA">Delete 2FA</a>
+    """
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, body)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, body)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is True
+    assert {url for _actor, _method, url in runtime.requests} == {_TARGET}
+    assert len(runtime.requests) == 4
+    assert "action_route_not_dispatched" in result.coverage_reason_codes
+    assert "unsafe_surface_declaration_skipped" in result.coverage_reason_codes
+
+
+def test_short_action_prefixes_do_not_hide_safe_navigation_routes() -> None:
+    safe_paths = (
+        "address",
+        "banner",
+        "buyer-guide",
+        "runtime",
+        "changelog",
+        "movement",
+        "payments",
+    )
+    body = "".join(f'<a href="/{path}">{path}</a>' for path in safe_paths)
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, body)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, body)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    requested_urls = {url for _actor, _method, url in runtime.requests}
+    assert result.complete is True
+    assert requested_urls == {_TARGET} | {f"{_TARGET}{path}" for path in safe_paths}
+
+
+def test_redirect_query_names_are_preserved_without_dispatching_values() -> None:
+    location = "/callback?code=private-code&state=private-state"
+    redirect = _response(_TARGET, status=302, headers={"Location": location})
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(redirect),
+            (_BOB, _TARGET): _stable(redirect),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+    callback = next(
+        operation
+        for operation in (result.surface_graph.operations or {}).values()
+        if operation.route_shape == "/callback"
+    )
+    rendered = json.dumps(result.to_json(), sort_keys=True)
+
+    assert {(parameter.name, parameter.location) for parameter in callback.parameters} == {
+        ("code", "query"),
+        ("state", "query"),
+    }
+    assert {url for _actor, _method, url in runtime.requests} == {_TARGET}
+    assert "private-code" not in rendered
+    assert "private-state" not in rendered
+
+
+def test_unstable_surface_is_incomplete_and_never_review_ready() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _sequence(
+                _html(_TARGET, '<a href="/first">First</a>'),
+                _html(_TARGET, '<a href="/second">Second</a>'),
+            ),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is False
+    assert "unstable_surface_observation" in result.reason_codes
+    assert not any(candidate.review_ready for candidate in result.candidates)
+    assert len(runtime.requests) == 4
+
+
+@pytest.mark.parametrize("status", [429, 500, 503])
+def test_rate_limit_and_server_errors_are_incomplete(status: int) -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=status)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=200)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is False
+    assert "inconclusive_response_status" in result.reason_codes
+    assert not any(candidate.review_ready for candidate in result.candidates)
+    assert result.actors[0].inconclusive_count == 1
+
+
+def test_identity_generation_change_is_incomplete_and_never_review_ready() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): (_Plan(_response(_TARGET), generation_after=2),),
+            (_BOB, _TARGET): _stable(_response(_TARGET)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is False
+    assert "identity_generation_changed" in result.reason_codes
+    assert not any(candidate.review_ready for candidate in result.candidates)
+    alice_probe_observations = tuple(
+        observation
+        for observation in (result.surface_graph.observations or {}).values()
+        if observation.identity_alias == _ALICE and observation.source_kind == "probe"
+    )
+    assert alice_probe_observations
+    assert all(observation.response_status is None for observation in alice_probe_observations)
+
+
+def test_output_is_deterministic_across_identity_input_order() -> None:
+    alice_body = '<a href="/zeta">Zeta</a><a href="/alpha">Alpha</a>'
+    bob_body = '<a href="/alpha">Alpha</a>'
+    responses = {
+        (_ALICE, _TARGET): _stable(_html(_TARGET, alice_body)),
+        (_BOB, _TARGET): _stable(_html(_TARGET, bob_body)),
+    }
+    first = _Runtime(identities=(_BOB, _ALICE), responses=responses)
+    second = _Runtime(identities=(_ALICE, _BOB), responses=responses)
+
+    first_result = run_authorization_surface_map(_TARGET, runtime=first)
+    second_result = run_authorization_surface_map(_TARGET, runtime=second)
+
+    assert first_result.to_json() == second_result.to_json()
+    assert first.requests == second.requests
+
+
+def test_receipt_never_persists_response_or_concrete_secret_values() -> None:
+    resource_id = "f84a91b4-45d1-4e70-8b34-2f3215a9e773"
+    query_secret = "query-secret-must-not-persist"
+    cookie_secret = "cookie-secret-must-not-persist"
+    body_secret = "body-secret-must-not-persist"
+    form_secret = "form-secret-must-not-persist"
+    javascript_secret = "javascript-secret-must-not-persist"
+    body = f"""
+    <p>{body_secret}</p>
+    <a href="/users/{resource_id}?access={query_secret}">Account</a>
+    <form method="POST" action="/orders/{resource_id}/update">
+      <input name="csrf" value="{form_secret}">
+    </form>
+    <script>
+      fetch('/orders/{resource_id}/details?auth={query_secret}', {{
+        headers: {{Authorization: 'Bearer {javascript_secret}'}},
+        body: JSON.stringify({{password: '{javascript_secret}'}})
+      }})
+    </script>
+    """
+    alice_response = _html(
+        _TARGET,
+        body,
+        headers={"Set-Cookie": f"session={cookie_secret}; HttpOnly"},
+    )
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(alice_response),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+    rendered = json.dumps(result.to_json(), sort_keys=True)
+
+    assert result.complete is True
+    assert result.candidates
+    for secret in (
+        resource_id,
+        query_secret,
+        cookie_secret,
+        body_secret,
+        form_secret,
+        javascript_secret,
+    ):
+        assert secret not in rendered
+    assert "/users/{id}" in rendered
+    assert "/orders/{id}/update" in rendered
+
+
+def test_receipt_conservatively_shapes_short_ids_slugs_and_target_path_secrets() -> None:
+    secret_segments = (
+        "customer-acme",
+        "a1b2",
+        "abc123",
+        "ABCDEFGHIJKLMNOP",
+        "tokenonlysecret",
+    )
+    body = (
+        '<a href="/widgets/customer-acme">Customer</a>'
+        '<a href="/widgets/a1b2">Short ID</a>'
+        '<a href="/objects/abc123">Object</a>'
+        '<a href="/foo/ABCDEFGHIJKLMNOP">Opaque label</a>'
+        '<a href="/download/tokenonlysecret">Download</a>'
+    )
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, body)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, "")),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+    rendered = json.dumps(result.to_json(), sort_keys=True)
+
+    assert all(secret not in rendered for secret in secret_segments)
+    assert "/widgets/{segment}" in rendered
+    assert "/objects/{id}" in rendered
+    assert "/download/{id}" in rendered
+
+    target_with_secret = f"{_TARGET}download/tokenonlysecret"
+    target_result = run_authorization_surface_map(target_with_secret, runtime=_Runtime())
+    target_rendered = json.dumps(target_result.to_json(), sort_keys=True)
+    assert "tokenonlysecret" not in target_rendered
+    assert "/download/{id}" in target_rendered
+
+
+def test_frontier_limit_bounds_dispatch_without_marking_run_incomplete() -> None:
+    links = "".join(f'<a href="/page/{index}">Page {index}</a>' for index in range(1, 7))
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_html(_TARGET, links)),
+            (_BOB, _TARGET): _stable(_html(_TARGET, links)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime, max_urls=3)
+
+    assert result.complete is True
+    assert result.coverage_limited is True
+    assert "frontier_limit_reached" in result.coverage_reason_codes
+    assert {url for _actor, _method, url in runtime.requests} == {
+        _TARGET,
+        f"{_TARGET}page/1",
+        f"{_TARGET}page/2",
+    }
+    assert len(runtime.requests) == 8
+    assert all(actor.mapped_url_count == 3 for actor in result.actors)
+
+
+def test_optional_anonymous_actor_is_last_then_repeated_first() -> None:
+    runtime = _Runtime(
+        identities=(_BOB, _ALICE),
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=200)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=403)),
+            (None, _TARGET): _stable(_response(_TARGET, status=403)),
+        },
+    )
+
+    result = run_authorization_surface_map(
+        _TARGET,
+        runtime=runtime,
+        include_anonymous=True,
+    )
+
+    assert tuple(actor.actor for actor in result.actors) == (
+        _ALICE,
+        _BOB,
+        ANONYMOUS_ACTOR,
+    )
+    assert runtime.requests == [
+        (_ALICE, "GET", _TARGET),
+        (_BOB, "GET", _TARGET),
+        (None, "GET", _TARGET),
+        (None, "GET", _TARGET),
+        (_BOB, "GET", _TARGET),
+        (_ALICE, "GET", _TARGET),
+    ]
+
+
+def test_result_reports_exact_whole_run_traffic_accounting() -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=200)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=403)),
+        }
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    delta = result.traffic_delta
+    assert delta.physical_request_count == len(runtime.requests) == 4
+    assert delta.completed_request_count == 4
+    assert delta.incomplete_request_count == 0
+    assert delta.pending_dispatch_count == 0
+    assert delta.reservation_count == 0
+    assert delta.cache_hit_count == 0
+    assert delta.deduplicated_count == 0
+    assert delta.retry_count == 0
+    assert delta.blocked_count == 0
+    assert delta.circuit_open_count == 0
+    assert delta.unmetered_action_count == 0
+    assert delta.initial_accounting_status == "exact"
+    assert delta.current_accounting_status == "exact"
+    assert sum(actor.observation_count for actor in result.actors) == 4
+
+
+@pytest.mark.parametrize(
+    ("snapshot_changes", "reason"),
+    [
+        ({"cache_hit_count": 1}, "reused_traffic_response"),
+        ({"retry_count": 1}, "traffic_policy_retry"),
+        ({"unmetered_action_count": 1}, "unmetered_traffic"),
+        ({"accounting_status": "inexact"}, "traffic_accounting_not_exact"),
+    ],
+)
+def test_policy_anomalies_make_every_candidate_not_review_ready(
+    snapshot_changes: Mapping[str, int | str],
+    reason: str,
+) -> None:
+    runtime = _Runtime(
+        responses={
+            (_ALICE, _TARGET): _stable(_response(_TARGET, status=200)),
+            (_BOB, _TARGET): _stable(_response(_TARGET, status=403)),
+        },
+        final_snapshot_changes=snapshot_changes,
+    )
+
+    result = run_authorization_surface_map(_TARGET, runtime=runtime)
+
+    assert result.complete is False
+    assert reason in result.reason_codes
+    assert result.candidates
+    assert not any(candidate.review_ready for candidate in result.candidates)
+
+
+def _stable(response: _Response) -> tuple[_Plan, ...]:
+    return (_Plan(response),)
+
+
+def _sequence(*responses: _Response) -> tuple[_Plan, ...]:
+    return tuple(_Plan(response) for response in responses)
+
+
+def _html(
+    url: str,
+    body: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> _Response:
+    return _response(
+        url,
+        body=f"<html><body>{body}</body></html>",
+        headers={"Content-Type": "text/html; charset=utf-8", **dict(headers or {})},
+    )
+
+
+def _response(
+    url: str,
+    *,
+    status: int | None = 200,
+    body: str = "",
+    headers: Mapping[str, str] | None = None,
+) -> _Response:
+    return _Response(
+        status=status,
+        final_url=url,
+        headers=dict(headers or {}),
+        body=body,
+        body_bytes=body.encode("utf-8"),
+    )
+
+
+def _snapshot(
+    *,
+    physical: int = 0,
+    completed: int = 0,
+) -> TrafficPolicySnapshot:
+    return TrafficPolicySnapshot(
+        physical_request_count=physical,
+        completed_request_count=completed,
+        incomplete_request_count=0,
+        pending_dispatch_count=0,
+        reservation_count=0,
+        cache_hit_count=0,
+        deduplicated_count=0,
+        retry_count=0,
+        blocked_count=0,
+        circuit_open_count=0,
+        unmetered_action_count=0,
+        accounting_status="exact",
+    )

--- a/packages/ravage/tests/test_authorization_surface_map_cli.py
+++ b/packages/ravage/tests/test_authorization_surface_map_cli.py
@@ -1,0 +1,378 @@
+# ruff: noqa: PLR2004
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+import pytest
+import yaml
+from ravage import __main__ as cli
+from ravage.agent_core.surface_graph import SurfaceGraphState, SurfaceParameter
+from ravage.auth.authorization_matrix import TrafficSnapshotDelta
+from ravage.auth.authorization_surface_map import (
+    AuthorizationSurfaceActorResult,
+    AuthorizationSurfaceCandidate,
+    AuthorizationSurfaceMapResult,
+)
+from ravage.traffic.policy import TrafficPolicyConfig, TrafficPolicyController, TrafficPolicyMode
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+_TARGET = "http://127.0.0.1:18759/"
+_ARGPARSE_ERROR = 2
+_DIRECTORY_MODE = 0o700
+_FILE_MODE = 0o600
+
+
+@dataclass
+class _FakeManagedRuntime:
+    close_calls: int = 0
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close_calls += 1
+
+
+def test_auth_surface_map_help_explains_bounds_and_candidate_semantics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["auth", "map", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: ravage auth map" in output
+    assert "--identity" in output
+    assert "--include-anonymous" in output
+    assert "--max-urls" in output
+    assert "--max-physical-requests" in output
+    assert "--traffic-max-rps" in output
+    assert "--authorized-remote-target" in output
+    assert "not confirmed vulnerabilities" in output
+
+
+def test_remote_surface_map_fails_before_runtime_without_authorization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    _write_brief(brief, target="https://surface.example.test/")
+
+    def unexpected_build(**_kwargs: object) -> None:
+        pytest.fail("remote refusal must happen before runtime construction")
+
+    monkeypatch.setattr(cli, "build_managed_authorization_matrix", unexpected_build)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["auth", "map", str(brief)])
+
+    assert exc_info.value.code == _ARGPARSE_ERROR
+    assert "remote targets require --authorized-remote-target" in capsys.readouterr().err
+    assert not (tmp_path / "runs").exists()
+
+
+def test_unknown_or_single_identity_fails_before_creating_artifacts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "surface-run"
+    _write_brief(brief)
+
+    with pytest.raises(SystemExit) as single:
+        cli.main(
+            [
+                "auth",
+                "map",
+                str(brief),
+                "--identity",
+                "alice",
+                "--run-dir",
+                str(run_dir),
+            ]
+        )
+    assert single.value.code == _ARGPARSE_ERROR
+    assert "requires at least two" in capsys.readouterr().err
+    assert not run_dir.exists()
+
+    with pytest.raises(SystemExit) as unknown:
+        cli.main(
+            [
+                "auth",
+                "map",
+                str(brief),
+                "--identity",
+                "alice",
+                "--identity",
+                "mallory",
+                "--run-dir",
+                str(run_dir),
+            ]
+        )
+    assert unknown.value.code == _ARGPARSE_ERROR
+    assert "unknown configured identity" in capsys.readouterr().err
+    assert not run_dir.exists()
+
+
+def test_complete_surface_map_writes_private_sanitized_candidate_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "surface-run"
+    _write_brief(brief)
+    result = _result(complete=True)
+    capture = _install_fakes(monkeypatch, result)
+
+    cli.main(
+        [
+            "auth",
+            "map",
+            str(brief),
+            "--identity",
+            "bob",
+            "--identity",
+            "alice",
+            "--include-anonymous",
+            "--run-dir",
+            str(run_dir),
+            "--max-urls",
+            "5",
+            "--max-physical-requests",
+            "37",
+            "--traffic-max-rps",
+            "0.25",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    receipt_path = run_dir / "authorization-surface-map.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    kwargs = capture["builder_kwargs"]
+    policy = capture["policy"]
+    runtime = capture["runtime"]
+    run_kwargs = capture["run_kwargs"]
+    assert isinstance(kwargs, dict)
+    assert isinstance(policy, TrafficPolicyController)
+    assert isinstance(runtime, _FakeManagedRuntime)
+    assert isinstance(run_kwargs, dict)
+    assert kwargs["identities"] == ("alice", "bob")
+    assert kwargs["traffic_policy"] is policy
+    assert run_kwargs["include_anonymous"] is True
+    assert run_kwargs["max_urls"] == 5
+    assert policy.config.mode is TrafficPolicyMode.ENFORCE
+    assert policy.config.max_physical_requests == 37
+    assert policy.config.max_rps == 0.25
+    assert runtime.close_calls == 1
+    assert receipt == result.to_json()
+    assert receipt["complete"] is True
+    assert receipt["candidates"][0]["review_ready"] is True
+    assert stat.S_IMODE(run_dir.stat().st_mode) == _DIRECTORY_MODE
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == _FILE_MODE
+    assert "AUTH SURFACE MAP" in output
+    assert "Candidates are not vulnerabilities" in output
+    assert "ravage auth matrix" in output
+    assert "483920" not in json.dumps(receipt)
+    assert "query-secret-value" not in json.dumps(receipt)
+
+
+def test_incomplete_json_receipt_is_written_then_exits_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    brief = tmp_path / "brief.yaml"
+    run_dir = tmp_path / "surface-run"
+    _write_brief(brief)
+    result = _result(complete=False)
+    _install_fakes(monkeypatch, result)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "auth",
+                "map",
+                str(brief),
+                "--run-dir",
+                str(run_dir),
+                "--json",
+            ]
+        )
+
+    assert exc_info.value.code == 1
+    stdout = json.loads(capsys.readouterr().out)
+    receipt = json.loads((run_dir / "authorization-surface-map.json").read_text(encoding="utf-8"))
+    assert stdout == receipt == result.to_json()
+    assert receipt["complete"] is False
+    assert receipt["candidates"][0]["review_ready"] is False
+
+
+def _install_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    result: AuthorizationSurfaceMapResult,
+) -> dict[str, object]:
+    capture: dict[str, object] = {}
+
+    class PolicyFactory:
+        @staticmethod
+        def open(
+            state_path: str | Path,
+            *,
+            target_url: str,
+            config: TrafficPolicyConfig,
+            **_kwargs: object,
+        ) -> TrafficPolicyController:
+            policy = TrafficPolicyController.open(
+                state_path,
+                target_url=target_url,
+                config=config,
+            )
+            capture["policy"] = policy
+            return policy
+
+    def fake_build(**kwargs: object) -> _FakeManagedRuntime:
+        runtime = _FakeManagedRuntime()
+        capture["builder_kwargs"] = dict(kwargs)
+        capture["runtime"] = runtime
+        return runtime
+
+    def fake_run(
+        target_url: str,
+        *,
+        runtime: object,
+        **kwargs: object,
+    ) -> AuthorizationSurfaceMapResult:
+        capture["run_target"] = target_url
+        capture["run_runtime"] = runtime
+        capture["run_kwargs"] = dict(kwargs)
+        return result
+
+    monkeypatch.setattr(cli, "TrafficPolicyController", PolicyFactory)
+    monkeypatch.setattr(cli, "build_managed_authorization_matrix", fake_build)
+    monkeypatch.setattr(cli, "run_authorization_surface_map", fake_run)
+    return capture
+
+
+def _result(*, complete: bool) -> AuthorizationSurfaceMapResult:
+    graph = SurfaceGraphState.for_target(_TARGET)
+    operation = graph.add(
+        url=f"{_TARGET}accounts/483920?token=query-secret-value",
+        method="GET",
+        parameters=(SurfaceParameter.create(name="token", location="query"),),
+        source_kind="native_recon",
+        identity_alias="alice",
+        access_level="declared",
+        scope_decision="allowed",
+        replayability="not_replayable",
+    )
+    candidate = AuthorizationSurfaceCandidate(
+        candidate_id="asm_0123456789abcdef01234567",
+        operation_id=operation.operation_id,
+        method="GET",
+        route_shape=operation.route_shape,
+        parameters=operation.parameters,
+        discovered_by=("alice",),
+        not_discovered_by=("bob",),
+        actor_evidence=(),
+        reason_codes=("identity_visibility_difference",),
+        review_ready=complete,
+    )
+    zero = TrafficSnapshotDelta(
+        physical_request_count=0,
+        completed_request_count=0,
+        incomplete_request_count=0,
+        pending_dispatch_count=0,
+        reservation_count=0,
+        cache_hit_count=0,
+        deduplicated_count=0,
+        retry_count=0,
+        blocked_count=0,
+        circuit_open_count=0,
+        unmetered_action_count=0,
+        initial_accounting_status="exact",
+        current_accounting_status="exact",
+    )
+    return AuthorizationSurfaceMapResult(
+        complete=complete,
+        coverage_limited=False,
+        reason_codes=() if complete else ("traffic_policy_blocked",),
+        coverage_reason_codes=(),
+        actors=(
+            AuthorizationSurfaceActorResult(
+                actor="alice",
+                roles=("owner",),
+                mapped_url_count=1,
+                observation_count=2,
+                success_count=2,
+                denied_count=0,
+                redirect_count=0,
+                inconclusive_count=0,
+                complete=complete,
+            ),
+            AuthorizationSurfaceActorResult(
+                actor="bob",
+                roles=("customer",),
+                mapped_url_count=1,
+                observation_count=2,
+                success_count=0,
+                denied_count=2,
+                redirect_count=0,
+                inconclusive_count=0,
+                complete=complete,
+            ),
+        ),
+        candidates=(candidate,),
+        surface_graph=graph,
+        traffic_delta=zero,
+    )
+
+
+def _write_brief(
+    path: Path,
+    *,
+    target: str = _TARGET,
+    identities: Sequence[str] = ("alice", "bob"),
+) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "engagement_id": "44444444-4444-4444-8444-444444444444",
+                "scope": {"in_scope": [target], "out_of_scope": []},
+                "roe": {"max_rps": 5},
+                "objectives": ["api_security_assessment"],
+                "budget": {"max_cost_usd": 1.0, "max_runtime_min": 5},
+                "context": {"description": "Authorized role-aware surface test."},
+                "authentication": {
+                    "identities": [
+                        {
+                            "alias": alias,
+                            "roles": ["owner"] if alias == "alice" else ["customer"],
+                            "flow": {
+                                "kind": "bearer",
+                                "secret_refs": {"token": {"key": f"TOKEN_{alias.upper()}"}},
+                            },
+                            "health_check": {
+                                "endpoint": {
+                                    "url": f"{target.rstrip('/')}/health",
+                                    "scope": "target",
+                                },
+                                "authenticated_marker": "signed-in",
+                            },
+                        }
+                        for alias in identities
+                    ]
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )

--- a/packages/ravage/tests/test_http_probe.py
+++ b/packages/ravage/tests/test_http_probe.py
@@ -7,13 +7,14 @@ from email.message import Message
 from http.client import HTTPException, IncompleteRead
 from http.cookiejar import Cookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from threading import Thread
+from threading import Barrier, Lock, Thread
 from typing import cast
 from urllib.error import HTTPError
 from urllib.request import ProxyHandler, Request
 
 import pytest
 from ravage.web_core.http_probe import (
+    ProbeNetworkContext,
     ProbeResponse,
     ProbeSession,
     _connect_pinned_socket,
@@ -193,6 +194,113 @@ def test_remote_probe_enforces_path_scope_and_dns_pin(monkeypatch) -> None:
     assert allowed.status == 302
     assert "outside target origin" in denied.error
     assert "changed after pinning" in changed.error
+
+
+def test_network_context_shares_dns_pin_across_isolated_sessions_without_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("ravage.web_core.http_probe.build_opener", lambda *_handlers: _FakeOpener())
+    answers = iter((("203.0.113.25",), ("203.0.113.26",)))
+    resolver_calls: list[tuple[str, int]] = []
+
+    def resolver(host: str, port: int) -> tuple[str, ...]:
+        resolver_calls.append((host, port))
+        return next(answers)
+
+    network_context = ProbeNetworkContext(resolver)
+    first = ProbeSession(
+        "https://staging.example.test/",
+        allow_remote_target=True,
+        network_context=network_context,
+    )
+    second = ProbeSession(
+        "https://staging.example.test/",
+        allow_remote_target=True,
+        network_context=network_context,
+    )
+
+    first_response = first.get("/first")
+    second_response = second.get("/second")
+
+    assert first.network_context is network_context
+    assert second.network_context is network_context
+    assert first_response.status == _FakeResponse.status
+    assert second_response.status is None
+    assert "changed after pinning" in second_response.error
+    assert resolver_calls == [
+        ("staging.example.test", 443),
+        ("staging.example.test", 443),
+    ]
+
+
+def test_network_context_accepts_dns_reordering_but_never_races_pin_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("ravage.web_core.http_probe.build_opener", lambda *_handlers: _FakeOpener())
+    reordered = iter(
+        (
+            ("203.0.113.25", "203.0.113.26"),
+            ("203.0.113.26", "203.0.113.25"),
+        )
+    )
+    shared = ProbeNetworkContext(lambda _host, _port: next(reordered))
+    first = ProbeSession(
+        "https://staging.example.test/",
+        allow_remote_target=True,
+        network_context=shared,
+    )
+    second = ProbeSession(
+        "https://staging.example.test/",
+        allow_remote_target=True,
+        network_context=shared,
+    )
+
+    assert first.get("/first").status == _FakeResponse.status
+    assert second.get("/second").status == _FakeResponse.status
+
+    barrier = Barrier(2)
+    answer_lock = Lock()
+    answers = iter((("203.0.113.30",), ("203.0.113.31",)))
+
+    def racing_resolver(_host: str, _port: int) -> tuple[str, ...]:
+        with answer_lock:
+            answer = next(answers)
+        barrier.wait(timeout=2)
+        return answer
+
+    racing = ProbeNetworkContext(racing_resolver)
+    results: list[str] = []
+
+    def pin() -> None:
+        results.append(racing.pin("race.example.test", 443))
+
+    threads = (Thread(target=pin), Thread(target=pin))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert sorted(results) == ["", "remote target DNS resolution changed after pinning"]
+    assert racing.pinned_addresses("race.example.test", 443) in {
+        ("203.0.113.30",),
+        ("203.0.113.31",),
+    }
+
+
+def test_probe_forks_retain_network_context_and_mixed_dns_configuration_is_rejected() -> None:
+    network_context = ProbeNetworkContext(lambda _host, _port: ("127.0.0.1",))
+    session = ProbeSession(
+        "http://127.0.0.1:8000/",
+        network_context=network_context,
+    )
+
+    assert session.fork().network_context is network_context
+    with pytest.raises(ValueError, match="cannot be combined"):
+        ProbeSession(
+            "http://127.0.0.1:8000/",
+            resolver=lambda _host, _port: ("127.0.0.1",),
+            network_context=network_context,
+        )
 
 
 @pytest.mark.parametrize("address", ["0.0.0.0", "::", "::ffff:0.0.0.0"])

--- a/packages/ravage/tests/test_passive_recon_document.py
+++ b/packages/ravage/tests/test_passive_recon_document.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from ravage.web_core.recon import parse_passive_recon_document
+
+
+def test_passive_document_is_transient_and_hides_exact_urls_from_repr() -> None:
+    secret = "query-secret-sentinel"  # noqa: S105 - leak sentinel.
+    document = parse_passive_recon_document(
+        "https://app.example.test/account/123",
+        {
+            "Content-Type": "text/html",
+            "Set-Cookie": "session=cookie-secret-sentinel; Secure",
+        },
+        (
+            f"<a href='/orders/987?token={secret}'>order</a>"
+            "<form method='POST' action='/save?flow=private'>"
+            "<input name='title' value='form-secret-sentinel'>"
+            "</form>"
+        ),
+    )
+
+    assert secret in document.links[0]
+    assert secret not in repr(document)
+    assert all(secret not in repr(operation) for operation in document.operations)
+    assert "cookie-secret-sentinel" not in repr(document)
+    assert "form-secret-sentinel" not in repr(document)
+
+
+def test_passive_document_filters_inert_self_links_and_empty_script_sources() -> None:
+    page = "https://app.example.test/dashboard"
+    document = parse_passive_recon_document(
+        page,
+        {"Content-Type": "text/html"},
+        (
+            "<html><a>missing</a><a href=''>empty</a><a href='#fragment'>fragment</a>"
+            "<script>window.ready = true;</script></html>"
+        ),
+    )
+
+    assert document.links == ()
+    assert all(not (item.url == page and "script" in item.hints) for item in document.operations)
+
+
+def test_passive_document_preserves_mixed_parameter_locations_without_values() -> None:
+    document = parse_passive_recon_document(
+        "https://app.example.test/",
+        {"Content-Type": "text/html"},
+        """
+        <form method="POST" action="/save?flow=private-value">
+          <input name="title" value="form-value-secret">
+        </form>
+        <script>
+          fetch('/api/jobs?view=private-value', {
+            method: 'POST',
+            headers: {'X-Trace': 'header-value-secret'},
+            body: JSON.stringify({job_id: 'body-value-secret'})
+          });
+        </script>
+        """,
+    )
+
+    form = next(item for item in document.operations if item.hints == ("form",))
+    javascript = next(item for item in document.operations if item.hints == ("javascript",))
+
+    assert {(item.name, item.location) for item in form.parameters} == {
+        ("flow", "query"),
+        ("title", "form"),
+    }
+    assert {(item.name, item.location) for item in javascript.parameters} == {
+        ("job_id", "body"),
+        ("view", "query"),
+    }
+    serialized_metadata = repr(
+        (
+            tuple((item.name, item.location) for item in form.parameters),
+            tuple((item.name, item.location) for item in javascript.parameters),
+            javascript.header_names,
+        )
+    )
+    assert "private-value" not in serialized_metadata
+    assert "form-value-secret" not in serialized_metadata
+    assert "body-value-secret" not in serialized_metadata
+    assert "header-value-secret" not in serialized_metadata


### PR DESCRIPTION
## Summary

  - Added role aware route discovery.
  - Added anon user comparisons.
  - Added shared DNS and traffic controls.
  - Added strict request limits and low noise pacing.
  - Added private JSON results without exact URLs, secrets, or response bodies.