### PR TITLE
feat(demo): add scope-locked TestFire showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ retention controls. Do not use a hosted route for sensitive customer or
 production data unless the engagement permits that disclosure. Use a local
 model route when target evidence must remain local.
 
-## Live XBEN demo
+## Live demos
+
+### Local XBEN
 
 For a short live demo, set <code>XBEN_ROOT</code> to the <code>benchmarks</code>
 directory in an XBEN checkout, start Docker, and export
@@ -124,6 +126,26 @@ Ravage builds a fresh local XBEN-009 target, attacks it with the pinned
 GPT-5.4 high profile, scores the result, saves the evidence under
 <code>runs/demo</code>, and removes the target and its local image. The preset
 limits the run to ten model requests, ten turns, ten minutes, and $1.50.
+
+### Authorized TestFire website
+
+For a live domain-name demo, Ravage can assess HCL AppScan's deliberately
+vulnerable TestFire banking site. HCL publishes
+<a href="https://help.hcl-software.com/appscan/ASoC/appseccloud_results_samplescans_2.html">demo.testfire.net as a dynamic scanning sample</a>.
+Review that authorization, export <code>OPENAI_API_KEY</code>, and explicitly
+acknowledge the remote target:
+
+~~~bash
+ravage demo testfire --authorized-remote-target
+~~~
+
+This command cannot accept another hostname. It permits only the curated login
+routes, GET/HEAD plus the login POST, and a code-owned set of harmless login
+values; stacked, destructive, and time-delay payloads are rejected before
+dispatch. It also disables process, scanner, recovery, and autonomous lanes,
+caps the whole run at 24 physical requests and 0.5 RPS, and stops after one
+non-destructive, evidence-backed finding. The target is a shared public demo and
+may occasionally be unavailable or reset by its operator.
 
 ## Authenticated testing
 
@@ -257,7 +279,8 @@ model assertion as a confirmed finding.
 | Traffic inspection and replay | <code>ravage traffic</code> | Scoped artifacts |
 | Knowledge skills | <code>ravage skills</code>, <code>ravage code-bug</code> | Advisory |
 | Passive SATCOM inspection | <code>ravage satcom inspect</code> | No transmit |
-| XBEN evaluation | <code>ravage xben</code>, <code>ravage demo xben</code> | Docker-based research harness and live demo |
+| Curated live demos | <code>ravage demo xben</code>, <code>ravage demo testfire</code> | Local XBEN or scope-locked HCL TestFire target |
+| XBEN evaluation | <code>ravage xben</code> | Docker-based research harness |
 | Improvement Lab | <code>scripts/improvement_lab.py</code> | Isolated archive |
 
 Knowledge skills can guide prioritization, but cannot add tools, expand scope,

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -239,6 +239,10 @@ _MAX_SCAN_PROOF_NODES = 20_000
 _MAX_SCAN_OBSERVATION_CHARS = 10_000
 _MAX_SCAN_TRANSCRIPT_CHARS = 80_000
 _MAX_SCAN_COVERAGE_REASON_CODES = 8
+_TESTFIRE_MAX_PHYSICAL_REQUESTS = 24
+_TESTFIRE_MAX_REQUEST_BODY_BYTES = 1_024
+_TESTFIRE_MAX_RPS = 0.5
+_TESTFIRE_REQUEST_PROFILE = "testfire-login-demo"
 
 _TOP_LEVEL_COMMANDS = (
     "attack",
@@ -360,7 +364,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
         _competitors(args_list[1:])
         return
     if args_list[:1] == ["demo"]:
-        handle_demo_command(args_list[1:])
+        handle_demo_command(args_list[1:], attack_runner=_attack)
         return
     if args_list[:1] in (["xben"], ["benchmark"]):
         _xben(args_list[1:])
@@ -423,6 +427,11 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
         "--traffic-max-rps",
         type=float,
         help="strictly sub-1 whole-run HTTP dispatch rate in low-noise mode (default: 0.5)",
+    )
+    parser.add_argument(
+        "--traffic-request-profile",
+        choices=[_TESTFIRE_REQUEST_PROFILE],
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--recovery-profile",
@@ -669,6 +678,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0911, PLR0912
             traffic_policy_mode=args.traffic_policy,
             traffic_policy_max_physical_requests=args.max_physical_requests,
             traffic_policy_max_rps=args.traffic_max_rps,
+            traffic_policy_config=traffic_policy.config,
             traffic_policy_reference=traffic_policy.to_reference(),
         )
         if args.autonomous_route:
@@ -814,6 +824,7 @@ def _top_level_help() -> None:
                 "  ravage auth add BRIEF.yaml --type form --health /account --marker Logout",
                 "  ravage traffic capture http://127.0.0.1:3000",
                 "  ravage demo xben",
+                "  ravage demo testfire --authorized-remote-target",
                 "  ravage lab list",
                 "  ravage authbench",
                 "",
@@ -841,7 +852,7 @@ def _top_level_help() -> None:
                 "  ravage skills {list,validate} [PATH|builtin]",
                 "  ravage satcom inspect ARTIFACT --format {tle,ccsds-space-packets}",
                 "  ravage competitors {preflight,run,report,adapt-ravage}",
-                "  ravage demo xben",
+                "  ravage demo {xben,testfire}",
                 "  ravage lab {list,show,up,down}",
                 "  ravage observe RUN_DIR",
                 "  ravage report RUN_DIR --brief BRIEF.yaml",
@@ -1801,7 +1812,7 @@ def _pin_parsed_knowledge_pack(
     parsed.knowledge_pack_sha256 = None if metadata is None else metadata.sha256
 
 
-def _resolve_traffic_policy_args(
+def _resolve_traffic_policy_args(  # noqa: C901, PLR0912 - fail-closed profile checks.
     parser: argparse.ArgumentParser,
     parsed: argparse.Namespace,
     *,
@@ -1811,6 +1822,22 @@ def _resolve_traffic_policy_args(
     mode = str(getattr(parsed, "traffic_policy", None) or default_mode)
     request_limit = getattr(parsed, "max_physical_requests", None)
     requested_rps = getattr(parsed, "traffic_max_rps", None)
+    request_profile = getattr(parsed, "traffic_request_profile", None)
+    if request_profile == _TESTFIRE_REQUEST_PROFILE:
+        if getattr(parsed, "autonomous_route", False):
+            parser.error("the TestFire request profile disables autonomous routing")
+        if getattr(parsed, "recovery_profile", "off") != "off":
+            parser.error("the TestFire request profile disables recovery roles")
+        if mode != "low-noise":
+            parser.error("the TestFire request profile requires --traffic-policy low-noise")
+        if request_limit is None:
+            request_limit = _TESTFIRE_MAX_PHYSICAL_REQUESTS
+        elif request_limit > _TESTFIRE_MAX_PHYSICAL_REQUESTS:
+            parser.error("the TestFire request profile permits at most 24 physical requests")
+        if requested_rps is None:
+            requested_rps = _TESTFIRE_MAX_RPS
+        elif requested_rps > _TESTFIRE_MAX_RPS:
+            parser.error("the TestFire request profile permits at most 0.5 RPS")
     if request_limit is not None and request_limit <= 0:
         parser.error("--max-physical-requests must be a positive integer")
     if requested_rps is not None and (
@@ -1838,10 +1865,33 @@ def _resolve_traffic_policy_args(
 
 def _traffic_policy_config(parsed: argparse.Namespace) -> TrafficPolicyConfig:
     if parsed.traffic_policy == "low-noise":
-        return TrafficPolicyConfig.low_noise(
+        config = TrafficPolicyConfig.low_noise(
             max_physical_requests=int(parsed.max_physical_requests),
             max_rps=float(parsed.traffic_max_rps),
         )
+        if getattr(parsed, "traffic_request_profile", None) == _TESTFIRE_REQUEST_PROFILE:
+            return replace(
+                config,
+                allowed_request_routes=(
+                    "GET /bank/main.jsp",
+                    "GET /login.jsp",
+                    "HEAD /bank/main.jsp",
+                    "HEAD /login.jsp",
+                    "POST /doLogin",
+                ),
+                allowed_query_fields=("mode",),
+                allowed_explicit_headers=(
+                    "accept",
+                    "accept-encoding",
+                    "content-type",
+                    "user-agent",
+                ),
+                allowed_form_fields=("btnSubmit", "passw", "uid"),
+                max_request_body_bytes=_TESTFIRE_MAX_REQUEST_BODY_BYTES,
+                request_value_profile=_TESTFIRE_REQUEST_PROFILE,
+                require_public_addresses=True,
+            )
+        return config
     return TrafficPolicyConfig()
 
 
@@ -1991,6 +2041,11 @@ def _attack(  # noqa: C901, PLR0912, PLR0915 - CLI options are intentionally exp
         "--traffic-max-rps",
         type=float,
         help="strictly sub-1 whole-run HTTP dispatch rate in low-noise mode (default: 0.5)",
+    )
+    parser.add_argument(
+        "--traffic-request-profile",
+        choices=[_TESTFIRE_REQUEST_PROFILE],
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--recovery-profile",
@@ -2687,6 +2742,8 @@ def _local_attack_command(  # noqa: C901, PLR0912, PLR0913
                 str(parsed.traffic_max_rps),
             ]
         )
+    if parsed.traffic_request_profile:
+        command.extend(["--traffic-request-profile", parsed.traffic_request_profile])
     if parsed.model_config is not None:
         command.extend(["--model-config", str(parsed.model_config)])
     if parsed.identity:

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -317,6 +317,7 @@ class AIWebAgentSettings:
     traffic_policy_mode: Literal["observe", "low-noise"] = "observe"
     traffic_policy_max_physical_requests: int | None = None
     traffic_policy_max_rps: float | None = None
+    traffic_policy_config: TrafficPolicyConfig | None = None
     traffic_policy_reference: dict[str, object] | None = None
 
 
@@ -366,6 +367,7 @@ def run_ai_web_agent(
 ) -> None:
     brief = load_engagement_brief(brief_path)
     flag_objective = _brief_has_flag_objective(brief)
+    stop_after_first_finding = _brief_stops_after_first_finding(brief)
     assert_authorized_target(
         target_url,
         scope=brief.scope,
@@ -397,6 +399,7 @@ def run_ai_web_agent(
     audit = AuditStore(settings.db_path or workspace.root / "audit.db", scope=brief.scope)
     runtime = _make_tool_runtime(settings, brief, target_url=target_url)
     state.surface["flag_objective"] = flag_objective
+    state.surface["stop_after_first_finding"] = stop_after_first_finding
     recovery_state_path = workspace.root / "recovery-state.json"
     recovery = _initial_recovery_campaign(
         settings=settings,
@@ -423,6 +426,7 @@ def run_ai_web_agent(
         "reference_architecture": "planner-executor with working memory",
         "knowledge_pack": knowledge_pack_metadata,
         "flag_objective": flag_objective,
+        "stop_after_first_finding": stop_after_first_finding,
         "traffic_policy": traffic_policy.config.to_json(),
         "traffic_policy_snapshot": traffic_policy.snapshot().to_json(),
     }
@@ -450,6 +454,7 @@ def run_ai_web_agent(
         "tool_runtime": settings.tool_runtime_mode,
         "autonomous_route": settings.autonomous_route,
         "flag_objective": flag_objective,
+        "stop_after_first_finding": stop_after_first_finding,
     }
     if session_mode:
         workspace_started_payload["session_mode"] = session_mode
@@ -505,6 +510,7 @@ def run_ai_web_agent(
         state.surface["scope_max_rps"] = brief.roe.max_rps
         state.surface["allow_remote_target"] = settings.allow_remote_target
         state.surface["continue_after_proof"] = _brief_requests_multiple_proofs(brief)
+        state.surface["stop_after_first_finding"] = stop_after_first_finding
         expected_proof_count = _brief_expected_proof_count(brief)
         if expected_proof_count is None:
             state.surface.pop("expected_proof_count", None)
@@ -837,6 +843,7 @@ def run_ai_web_agent(
             if settings.authentication is not None and not outcome.session_mode:
                 outcome = replace(outcome, session_mode=session_mode)
             outcome = _continue_after_proof_outcome(state, outcome)
+            outcome = _stop_after_finding_outcome(state, outcome)
             outcome_json = outcome.to_json()
             _update_state_from_action(state, action=action, outcome=outcome_json)
             post_action_state_trace = state_trace_snapshot(state)
@@ -2514,6 +2521,8 @@ def _premature_final_action(action: Mapping[str, object]) -> dict[str, object]:
 
 def _brief_requests_multiple_proofs(brief: EngagementBrief) -> bool:
     context = dict(brief.context or {})
+    if context.get("stop_after_first_finding") is True:
+        return False
     if context.get("continue_after_proof") is True:
         return True
     if context.get("stop_after_first_proof") is False:
@@ -2540,6 +2549,10 @@ def _brief_expected_proof_count(brief: EngagementBrief) -> int | None:
     if isinstance(expected_count, bool) or not isinstance(expected_count, int):
         return None
     return expected_count if expected_count > 0 else None
+
+
+def _brief_stops_after_first_finding(brief: EngagementBrief) -> bool:
+    return dict(brief.context or {}).get("stop_after_first_finding") is True
 
 
 def _brief_has_flag_objective(brief: EngagementBrief) -> bool:
@@ -2579,6 +2592,15 @@ def _continue_after_proof_outcome(state: AgentState, outcome: ActionResult) -> A
     if not outcome.stop or outcome.outcome != "flag_candidate":
         return outcome
     return replace(outcome, stop=False)
+
+
+def _stop_after_finding_outcome(state: AgentState, outcome: ActionResult) -> ActionResult:
+    if (
+        state.surface.get("stop_after_first_finding") is True
+        and outcome.outcome == "finding_confirmed"
+    ):
+        return replace(outcome, stop=True)
+    return outcome
 
 
 def _make_tool_runtime(
@@ -2648,6 +2670,23 @@ def _open_run_traffic_policy(
         )
     else:
         raise ValueError(f"unsupported traffic policy mode: {settings.traffic_policy_mode}")
+    if settings.traffic_policy_config is not None:
+        configured = settings.traffic_policy_config
+        baseline = replace(
+            configured,
+            allowed_request_routes=(),
+            allowed_query_fields=None,
+            allowed_explicit_headers=None,
+            allowed_form_fields=None,
+            max_request_body_bytes=None,
+            request_value_profile=None,
+            require_public_addresses=False,
+        )
+        if baseline != config:
+            raise TrafficPolicyError(
+                "traffic policy configuration does not match agent settings"
+            )
+        config = configured
     if settings.traffic_policy_reference is not None:
         referenced = TrafficPolicyController.from_reference(
             settings.traffic_policy_reference,

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/scoped_http.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/scoped_http.py
@@ -481,6 +481,17 @@ def _validated_transport_address(
     return parsed
 
 
+def _validated_public_transport_address(
+    address: str,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    parsed = _validated_transport_address(address)
+    effective = parsed.ipv4_mapped if isinstance(parsed, ipaddress.IPv6Address) else None
+    candidate = effective or parsed
+    if not candidate.is_global or candidate.is_multicast:
+        raise OSError("remote HTTP resolver returned a non-public address")
+    return parsed
+
+
 class UrllibScopedHttpTransport:
     """One stable cookie session with redirects disabled for external validation."""
 
@@ -710,6 +721,10 @@ class ScopedGraphHttpExecutor:
         ):
             raise ScopedHttpError("traffic policy belongs to a different target origin")
         self.authentication = authentication
+        policy_config = getattr(bound_traffic_policy, "config", None)
+        self._require_public_addresses = bool(
+            getattr(policy_config, "require_public_addresses", False)
+        )
         # Managed ProbeSession owns the same controller and accounts each auth,
         # health, refresh, redirect, and action dispatch. Do not double-wrap it.
         self.traffic_policy = None if authentication is not None else bound_traffic_policy
@@ -1224,6 +1239,15 @@ class ScopedGraphHttpExecutor:
             raise ScopedHttpError(f"remote HTTP DNS resolution failed: {exc}") from exc
         if not addresses:
             raise ScopedHttpError("remote HTTP DNS resolution returned no addresses")
+        if self._require_public_addresses:
+            try:
+                addresses = tuple(
+                    str(_validated_public_transport_address(address)) for address in addresses
+                )
+            except OSError as exc:
+                raise ScopedHttpError(
+                    f"remote HTTP DNS resolution rejected an address: {exc}"
+                ) from exc
         key = (host.lower(), port)
         with self._pin_lock:
             pinned = self._pins.setdefault(key, addresses)

--- a/packages/ravage/src/ravage/probe_suite_parts/sqli/sqli.py
+++ b/packages/ravage/src/ravage/probe_suite_parts/sqli/sqli.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
 from ravage.agent_core.agent_state import AgentState
-from ravage.web_core.http_probe import (
-    ProbeResponse,
-    ProbeSession,
-    ResponseDelta,
-    compare_responses,
-    response_secrets,
-)
 from ravage.probe_suite_parts.general import input_payload_probe
 from ravage.probe_suite_parts.result import ProbeRunResult
 from ravage.probe_suite_parts.sqli.sqli_detection import (
@@ -56,9 +49,15 @@ from ravage.probe_suite_parts.support import (
     _url_looks_static_oauth_redirect,
 )
 from ravage.probes.sqli_extractor import run_sqli_exploit
-from ravage.web_core.proof_recognizer import recognize_proofs
 from ravage.runtime.common import clip
-
+from ravage.web_core.http_probe import (
+    ProbeResponse,
+    ProbeSession,
+    ResponseDelta,
+    compare_responses,
+    response_secrets,
+)
+from ravage.web_core.proof_recognizer import recognize_proofs
 
 _SQLI_REQUEST_BUDGET = 90
 _SQLI_AUTH_BYPASS_PAYLOADS = (
@@ -694,16 +693,27 @@ def _target_looks_auth_bypass_candidate(target: dict[str, object]) -> bool:
     if kind not in {"form", "replay"}:
         return False
     input_name = str(target.get("input") or "").lower()
-    if input_name not in {"username", "user", "login", "log", "email"} and not _contains_word(
+    if input_name not in {
+        "username",
+        "user",
+        "userid",
+        "user_id",
+        "uid",
+        "login",
+        "log",
+        "email",
+    } and not _contains_word(
         input_name,
         ("user", "login", "email"),
     ):
         return False
 
     form = _dict_value(target.get("form"))
+    raw_hints = target.get("hints")
+    hints = raw_hints if isinstance(raw_hints, (list, tuple)) else ()
     text = (
         f"{kind} {target.get('url') or ''} {input_name} "
-        f"{' '.join(str(item) for item in target.get('hints') or [])} {form!r}"
+        f"{' '.join(str(item) for item in hints)} {form!r}"
     ).lower()
     if _contains_word(text, ("password", "passwd", "pwd", "login", "signin", "admin", "auth")):
         return True

--- a/packages/ravage/src/ravage/traffic/policy.py
+++ b/packages/ravage/src/ravage/traffic/policy.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import math
 import os
+import posixpath
 import secrets
 import stat
 import tempfile
@@ -25,7 +26,7 @@ from email.utils import parsedate_to_datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote, urlsplit, urlunsplit
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -36,6 +37,25 @@ TRAFFIC_POLICY_VERSION = 1
 _MAX_LEDGER_BYTES = 8_000_000
 _CACHE_FILE_SUFFIX = ".json"
 _OVERLOAD_STATUSES = frozenset({429, 502, 503, 504})
+_REQUEST_VALUE_PROFILES = frozenset({"testfire-login-demo"})
+_TESTFIRE_SAFE_QUERY_VALUES = {"mode": frozenset({"demo"})}
+_TESTFIRE_SAFE_FORM_VALUES = {
+    "btnsubmit": frozenset({"Login", "Submit", "btnSubmit"}),
+    "passw": frozenset({"", "RavagePass123!"}),
+    "uid": frozenset(
+        {
+            "",
+            "ravage",
+            "admin' -- ",
+            "admin' -- -",
+            "admin'#",
+            "' OR '1'='1' -- ",
+            "1' OR '1'='1' -- ",
+            "admin' OR '1'='1' -- ",
+            "admin') OR ('1'='1' -- ",
+        }
+    ),
+}
 _SENSITIVE_REQUEST_HEADERS = frozenset(
     {
         "authorization",
@@ -82,6 +102,10 @@ class TrafficPolicyConfig:
     ``observe`` records physical dispatches without changing request behavior.
     ``enforce`` activates the cap, pacing, cache/deduplication, retries, backoff,
     and circuit breaker.
+
+    ``allowed_explicit_headers`` constrains caller-supplied headers. Trusted
+    transport headers such as Host, Cookie, and Content-Length are generated
+    after admission and are not model-controlled.
     """
 
     mode: TrafficPolicyMode = TrafficPolicyMode.OBSERVE
@@ -100,6 +124,13 @@ class TrafficPolicyConfig:
     lease_timeout_seconds: float = 120.0
     dedupe_wait_timeout_seconds: float = 30.0
     cacheable_lanes: tuple[str, ...] = ("agent_http", "baseline", "recon")
+    allowed_request_routes: tuple[str, ...] = ()
+    allowed_query_fields: tuple[str, ...] | None = None
+    allowed_explicit_headers: tuple[str, ...] | None = None
+    allowed_form_fields: tuple[str, ...] | None = None
+    max_request_body_bytes: int | None = None
+    request_value_profile: str | None = None
+    require_public_addresses: bool = False
 
     def __post_init__(self) -> None:
         try:
@@ -135,6 +166,37 @@ class TrafficPolicyConfig:
         if not lanes:
             raise ValueError("cacheable_lanes cannot be empty")
         object.__setattr__(self, "cacheable_lanes", lanes)
+        routes = tuple(
+            sorted({_normalized_request_route(item) for item in self.allowed_request_routes})
+        )
+        object.__setattr__(self, "allowed_request_routes", routes)
+        object.__setattr__(
+            self,
+            "allowed_query_fields",
+            _normalized_field_names(self.allowed_query_fields, "allowed_query_fields"),
+        )
+        object.__setattr__(
+            self,
+            "allowed_explicit_headers",
+            _normalized_field_names(
+                self.allowed_explicit_headers,
+                "allowed_explicit_headers",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allowed_form_fields",
+            _normalized_field_names(self.allowed_form_fields, "allowed_form_fields"),
+        )
+        if self.max_request_body_bytes is not None:
+            _positive_int(self.max_request_body_bytes, "max_request_body_bytes")
+        if (
+            self.request_value_profile is not None
+            and self.request_value_profile not in _REQUEST_VALUE_PROFILES
+        ):
+            raise ValueError("request_value_profile is unsupported")
+        if not isinstance(self.require_public_addresses, bool):
+            raise ValueError("require_public_addresses must be a boolean")
 
     @classmethod
     def low_noise(
@@ -154,7 +216,7 @@ class TrafficPolicyConfig:
         )
 
     def to_json(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "mode": self.mode.value,
             "max_rps": self.max_rps,
             "max_physical_requests": self.max_physical_requests,
@@ -172,6 +234,21 @@ class TrafficPolicyConfig:
             "dedupe_wait_timeout_seconds": self.dedupe_wait_timeout_seconds,
             "cacheable_lanes": list(self.cacheable_lanes),
         }
+        if self.allowed_request_routes:
+            payload["allowed_request_routes"] = list(self.allowed_request_routes)
+        if self.allowed_query_fields is not None:
+            payload["allowed_query_fields"] = list(self.allowed_query_fields)
+        if self.allowed_explicit_headers is not None:
+            payload["allowed_explicit_headers"] = list(self.allowed_explicit_headers)
+        if self.allowed_form_fields is not None:
+            payload["allowed_form_fields"] = list(self.allowed_form_fields)
+        if self.max_request_body_bytes is not None:
+            payload["max_request_body_bytes"] = self.max_request_body_bytes
+        if self.request_value_profile is not None:
+            payload["request_value_profile"] = self.request_value_profile
+        if self.require_public_addresses:
+            payload["require_public_addresses"] = True
+        return payload
 
     @classmethod
     def from_json(cls, value: Mapping[str, object]) -> Self:
@@ -192,6 +269,13 @@ class TrafficPolicyConfig:
             "lease_timeout_seconds",
             "dedupe_wait_timeout_seconds",
             "cacheable_lanes",
+            "allowed_request_routes",
+            "allowed_query_fields",
+            "allowed_explicit_headers",
+            "allowed_form_fields",
+            "max_request_body_bytes",
+            "request_value_profile",
+            "require_public_addresses",
         }
         unknown = set(value).difference(allowed)
         if unknown:
@@ -235,6 +319,19 @@ class TrafficPolicyConfig:
             cacheable_lanes=tuple(
                 str(item)
                 for item in _list(value.get("cacheable_lanes", list(defaults.cacheable_lanes)))
+            ),
+            allowed_request_routes=tuple(
+                str(item) for item in _list(value.get("allowed_request_routes", []))
+            ),
+            allowed_query_fields=_optional_string_tuple(value.get("allowed_query_fields")),
+            allowed_explicit_headers=_optional_string_tuple(
+                value.get("allowed_explicit_headers")
+            ),
+            allowed_form_fields=_optional_string_tuple(value.get("allowed_form_fields")),
+            max_request_body_bytes=_optional_int(value.get("max_request_body_bytes")),
+            request_value_profile=_optional_string(value.get("request_value_profile")),
+            require_public_addresses=_bool(
+                value.get("require_public_addresses", defaults.require_public_addresses)
             ),
         )
 
@@ -483,6 +580,10 @@ class TrafficPolicyController:
     def acquire(self, intent: RequestIntent, *, retry: bool = False) -> TrafficDecision:
         """Return a cache hit, a scheduled dispatch lease, or a preflight block."""
         self._validate_intent_origin(intent)
+        blocked_reason = self._request_restriction_reason(intent)
+        if blocked_reason:
+            self._record_blocked()
+            return TrafficDecision(TrafficDecisionKind.BLOCKED, reason=blocked_reason)
         wait_started = self._now()
         dedupe_observed = False
         while True:
@@ -907,6 +1008,84 @@ class TrafficPolicyController:
         if _target_origin(intent.url) != self.target_origin:
             raise TrafficPolicyBlocked("traffic intent belongs to a different target origin")
 
+    def _request_restriction_reason(  # noqa: PLR0911 - fail-closed checks stay explicit.
+        self,
+        intent: RequestIntent,
+    ) -> str:
+        config = self.config
+        if config.allowed_request_routes:
+            request_path = urlsplit(intent.url).path or "/"
+            normalized_path = _normalized_request_path(intent.url)
+            if request_path != normalized_path:
+                return "traffic request path is not canonical"
+            route = f"{intent.method} {normalized_path}"
+            if route not in config.allowed_request_routes:
+                return "traffic request method and path are outside the permitted route set"
+
+        parsed = urlsplit(intent.url)
+        query_fields: list[tuple[str, str]] = []
+        if config.allowed_query_fields is not None or config.request_value_profile is not None:
+            try:
+                query_fields = parse_qsl(
+                    parsed.query,
+                    keep_blank_values=True,
+                    max_num_fields=32,
+                )
+            except ValueError:
+                return "traffic request query is malformed or too large"
+        if config.allowed_query_fields is not None:
+            query_names = {str(name).casefold() for name, _value in query_fields}
+            if not query_names.issubset(set(config.allowed_query_fields)):
+                return "traffic request query contains a field outside the permitted set"
+        query_value_reason = _request_query_value_restriction_reason(
+            config.request_value_profile,
+            query_fields,
+        )
+        if query_value_reason:
+            return query_value_reason
+
+        if config.allowed_explicit_headers is not None:
+            header_names = {str(name).strip().casefold() for name in intent.headers}
+            if not header_names.issubset(set(config.allowed_explicit_headers)):
+                return "traffic request contains an explicit header outside the permitted set"
+
+        body = intent.body or b""
+        if config.max_request_body_bytes is not None and len(body) > config.max_request_body_bytes:
+            return "traffic request body exceeds the permitted size"
+        if not body:
+            return ""
+        if intent.method != "POST":
+            return "traffic request bodies are permitted only for POST"
+        if config.allowed_form_fields is None:
+            return ""
+        content_type = next(
+            (
+                str(value).split(";", 1)[0].strip().casefold()
+                for name, value in intent.headers.items()
+                if str(name).casefold() == "content-type"
+            ),
+            "",
+        )
+        if content_type != "application/x-www-form-urlencoded":
+            return "traffic request body is not an approved form encoding"
+        try:
+            decoded = body.decode("utf-8", errors="strict")
+            fields = parse_qsl(decoded, keep_blank_values=True, max_num_fields=16)
+        except (UnicodeDecodeError, ValueError):
+            return "traffic request form body is malformed or too large"
+        if not fields:
+            return "traffic request form body is empty"
+        field_names = {str(name).casefold() for name, _value in fields}
+        if not field_names.issubset(set(config.allowed_form_fields)):
+            return "traffic request form contains a field outside the permitted set"
+        form_value_reason = _request_form_value_restriction_reason(
+            config.request_value_profile,
+            fields,
+        )
+        if form_value_reason:
+            return form_value_reason
+        return ""
+
     @staticmethod
     def _validate_lease(raw: Mapping[str, object], lease: DispatchLease) -> str:
         if _counter(raw, "sequence") != lease.sequence:
@@ -1165,6 +1344,83 @@ def _target_origin(url: str) -> str:
     return urlunsplit((parsed.scheme.lower(), netloc, "", "", ""))
 
 
+def _normalized_request_route(value: object) -> str:
+    raw = str(value).strip()
+    method, separator, raw_path = raw.partition(" ")
+    method = method.strip().upper()
+    raw_path = raw_path.strip()
+    if (
+        not separator
+        or not method
+        or not method.isascii()
+        or not method.isalpha()
+        or not raw_path.startswith("/")
+        or "?" in raw_path
+        or "#" in raw_path
+    ):
+        raise ValueError("allowed_request_routes entries must use 'METHOD /absolute-path'")
+    path = _normalized_url_path(raw_path)
+    return f"{method} {path}"
+
+
+def _normalized_request_path(url: str) -> str:
+    return _normalized_url_path(urlsplit(url).path or "/")
+
+
+def _normalized_url_path(path: str) -> str:
+    normalized = posixpath.normpath(unquote(path or "/"))
+    if normalized == ".":
+        return "/"
+    return normalized if normalized.startswith("/") else f"/{normalized}"
+
+
+def _normalized_field_names(
+    values: tuple[str, ...] | None,
+    name: str,
+) -> tuple[str, ...] | None:
+    if values is None:
+        return None
+    normalized: set[str] = set()
+    for value in values:
+        field = str(value).strip().casefold()
+        if (
+            not field
+            or len(field) > 128
+            or any(character.isspace() or ord(character) < 33 for character in field)
+        ):
+            raise ValueError(f"{name} contains an invalid field name")
+        normalized.add(field)
+    return tuple(sorted(normalized))
+
+
+def _request_query_value_restriction_reason(
+    profile: str | None,
+    fields: list[tuple[str, str]],
+) -> str:
+    if profile is None:
+        return ""
+    if profile == "testfire-login-demo":
+        for raw_name, value in fields:
+            allowed = _TESTFIRE_SAFE_QUERY_VALUES.get(str(raw_name).casefold())
+            if allowed is None or value not in allowed:
+                return "traffic request query contains a value outside the safe profile"
+    return ""
+
+
+def _request_form_value_restriction_reason(
+    profile: str | None,
+    fields: list[tuple[str, str]],
+) -> str:
+    if profile is None:
+        return ""
+    if profile == "testfire-login-demo":
+        for raw_name, value in fields:
+            allowed = _TESTFIRE_SAFE_FORM_VALUES.get(str(raw_name).casefold())
+            if allowed is None or value not in allowed:
+                return "traffic request form contains a value outside the safe profile"
+    return ""
+
+
 def _retry_after_seconds(headers: Mapping[str, str], *, now: float) -> float:
     value = next(
         (str(item) for name, item in headers.items() if str(name).casefold() == "retry-after"),
@@ -1320,6 +1576,20 @@ def _optional_int(value: object) -> int | None:
 
 def _optional_float(value: object) -> float | None:
     return None if value is None else _float(value)
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TrafficPolicyError("traffic policy configuration string is invalid")
+    return value
+
+
+def _optional_string_tuple(value: object) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    return tuple(str(item) for item in _list(value))
 
 
 def _positive_number(value: object, name: str) -> None:

--- a/packages/ravage/src/ravage/web_core/http_probe.py
+++ b/packages/ravage/src/ravage/web_core/http_probe.py
@@ -280,6 +280,18 @@ def _validated_connection_address(
     return parsed
 
 
+def _validated_public_connection_address(
+    address: str,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    parsed = _validated_connection_address(address)
+    effective = parsed.ipv4_mapped if isinstance(parsed, ipaddress.IPv6Address) else None
+    candidate = effective or parsed
+    if not candidate.is_global or candidate.is_multicast:
+        message = "probe resolver returned a non-public address"
+        raise ValueError(message)
+    return parsed
+
+
 class _RequestPacer:
     def __init__(self, max_rps: float | None) -> None:
         normalized_rate: float | None = None
@@ -510,7 +522,7 @@ class ResponseDelta:
 class ProbeNetworkContext:
     """Share one resolver and immutable DNS pin set across isolated sessions."""
 
-    __slots__ = ("_lock", "_pins", "_resolver")
+    __slots__ = ("_lock", "_pins", "_require_public_addresses", "_resolver")
 
     def __init__(
         self,
@@ -522,13 +534,29 @@ class ProbeNetworkContext:
         self._resolver = resolver or _resolve_addresses
         self._pins = _pins if _pins is not None else {}
         self._lock = _lock or threading.Lock()
+        self._require_public_addresses = False
+
+    def require_public_addresses(self) -> None:
+        """Reject private, loopback, link-local, reserved, and mixed DNS answers."""
+        with self._lock:
+            for addresses in self._pins.values():
+                for address in addresses:
+                    _validated_public_connection_address(address)
+            self._require_public_addresses = True
 
     def pin(self, host: str, port: int) -> str:
         """Resolve and freeze one address set, returning a stable error if unsafe."""
+        with self._lock:
+            require_public_addresses = self._require_public_addresses
         try:
             resolved = self._resolver(host, port)
             parsed_addresses = tuple(
-                _validated_connection_address(str(address).strip()) for address in resolved
+                (
+                    _validated_public_connection_address(str(address).strip())
+                    if require_public_addresses
+                    else _validated_connection_address(str(address).strip())
+                )
+                for address in resolved
             )
         except OSError as exc:
             return f"remote target DNS resolution failed: {exc}"
@@ -539,6 +567,12 @@ class ProbeNetworkContext:
             return "remote target DNS resolution returned no addresses"
         key = (host.lower(), port)
         with self._lock:
+            if self._require_public_addresses and not require_public_addresses:
+                try:
+                    for address in addresses:
+                        _validated_public_connection_address(address)
+                except ValueError as exc:
+                    return f"remote target DNS resolution rejected an address: {exc}"
             pinned = self._pins.setdefault(key, addresses)
             if pinned != addresses:
                 return "remote target DNS resolution changed after pinning"
@@ -623,6 +657,11 @@ class ProbeSession:
                 traffic_policy_reference,
                 require_existing=True,
             )
+        if (
+            self._traffic_policy is not None
+            and self._traffic_policy.config.require_public_addresses
+        ):
+            self._network_context.require_public_addresses()
         self._traffic_lane = str(traffic_lane).strip() or "probe"
         self._traffic_cacheable = bool(traffic_cacheable)
         self._traffic_retryable = bool(traffic_retryable)

--- a/packages/ravage/src/ravage/xben_parts/demo.py
+++ b/packages/ravage/src/ravage/xben_parts/demo.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import uuid4
+
+import yaml  # type: ignore[import-untyped]
 
 from ravage.xben_parts.models import DEFAULT_BENCHMARKS_ROOT, XbenSettings
 from ravage.xben_parts.runner import run_xben
@@ -17,15 +20,35 @@ DEFAULT_DEMO_TIMEOUT_SECONDS = 600
 DEFAULT_DEMO_INPUT_TOKEN_CEILING = 20_000
 DEFAULT_DEMO_MIN_FREE_GIB = 10
 
+TESTFIRE_TARGET_URL = "https://demo.testfire.net/login.jsp?mode=demo"
+TESTFIRE_SCOPE_URLS = (
+    "https://demo.testfire.net/login.jsp",
+    "https://demo.testfire.net/doLogin",
+    "https://demo.testfire.net/bank/main.jsp",
+)
+TESTFIRE_AUTHORIZATION_URL = (
+    "https://help.hcl-software.com/appscan/ASoC/"
+    "appseccloud_results_samplescans_2.html"
+)
+TESTFIRE_MAX_TURNS = 6
+TESTFIRE_MAX_COST_USD = 1.5
+TESTFIRE_MAX_RUNTIME_MIN = 8
+TESTFIRE_MAX_PHYSICAL_REQUESTS = 24
+TESTFIRE_MAX_RPS = 0.5
+TESTFIRE_ROE_MAX_RPS = 1
+
+AttackRunner = Callable[[list[str]], object]
+
 
 def handle_demo_command(
     args: list[str],
     *,
     env: Mapping[str, str] | None = None,
-) -> dict[str, object]:
+    attack_runner: AttackRunner | None = None,
+) -> dict[str, object] | object:
     parser = argparse.ArgumentParser(
         prog="ravage demo",
-        description="Run a short, live Ravage demonstration on an authorized local target.",
+        description="Run a short, live Ravage demonstration on an authorized target.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     xben_parser = subparsers.add_parser(
@@ -44,7 +67,41 @@ def handle_demo_command(
         action="store_true",
         help="validate Docker, the model route, budgets, and the selected case without attacking",
     )
+    testfire_parser = subparsers.add_parser(
+        "testfire",
+        help="run a bounded assessment of HCL's deliberately vulnerable banking demo",
+        description=(
+            "Assess HCL's deliberately vulnerable TestFire website using its published "
+            "DAST demo URL. The hostname is fixed and cannot be overridden."
+        ),
+    )
+    testfire_parser.add_argument(
+        "--authorized-remote-target",
+        action="store_true",
+        help=(
+            "acknowledge the published HCL authorization and send bounded traffic to "
+            "demo.testfire.net"
+        ),
+    )
+    testfire_parser.add_argument("--output-dir", type=Path)
     parsed = parser.parse_args(args)
+
+    if parsed.command == "testfire":
+        if not parsed.authorized_remote_target:
+            testfire_parser.error(
+                "this public demo requires --authorized-remote-target; review HCL's "
+                f"published DAST sample target first: {TESTFIRE_AUTHORIZATION_URL}"
+            )
+        if attack_runner is None:
+            message = "the TestFire demo requires the Ravage attack runner"
+            raise RuntimeError(message)
+        try:
+            return _run_testfire_demo(
+                output_dir=parsed.output_dir,
+                attack_runner=attack_runner,
+            )
+        except ValueError as exc:
+            testfire_parser.error(str(exc))
 
     active_env = os.environ if env is None else env
     benchmarks_root = _benchmarks_root(parsed.benchmarks_root, env=active_env)
@@ -92,6 +149,94 @@ def handle_demo_command(
     if not parsed.preflight and not _single_case_solved(report):
         raise SystemExit(1)
     return report
+
+
+def _run_testfire_demo(
+    *,
+    output_dir: Path | None,
+    attack_runner: AttackRunner,
+) -> object:
+    run_dir = output_dir or _fresh_output_dir("testfire")
+    brief_path = _write_testfire_brief(run_dir)
+    return attack_runner(
+        [
+            str(brief_path),
+            "--target-url",
+            TESTFIRE_TARGET_URL,
+            "--run-dir",
+            str(run_dir),
+            "--agent-mode",
+            "ctf-free-roam",
+            "--model-profile",
+            DEFAULT_DEMO_MODEL_PROFILE,
+            "--model-tier",
+            "high",
+            "--max-turns",
+            str(TESTFIRE_MAX_TURNS),
+            "--traffic-policy",
+            "low-noise",
+            "--max-physical-requests",
+            str(TESTFIRE_MAX_PHYSICAL_REQUESTS),
+            "--traffic-max-rps",
+            str(TESTFIRE_MAX_RPS),
+            "--traffic-request-profile",
+            "testfire-login-demo",
+            "--authorized-remote-target",
+            "--tool-runtime",
+            "docker",
+            "--no-tool-recon",
+            "--show-agent-actions",
+            "--allow-paid-models",
+            "--report",
+        ]
+    )
+
+
+def _write_testfire_brief(run_dir: Path) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    brief_path = run_dir / "brief.yaml"
+    if brief_path.exists() or brief_path.is_symlink():
+        message = f"refusing to overwrite existing demo brief: {brief_path}"
+        raise ValueError(message)
+    payload = {
+        "engagement_id": str(uuid4()),
+        "scope": {
+            "in_scope": list(TESTFIRE_SCOPE_URLS),
+            "out_of_scope": [],
+        },
+        "roe": {
+            "max_rps": TESTFIRE_ROE_MAX_RPS,
+            "no_destructive_actions": True,
+            "data_handling": "placeholders_only",
+        },
+        "objectives": ["web_application_assessment"],
+        "budget": {
+            "max_cost_usd": TESTFIRE_MAX_COST_USD,
+            "max_runtime_min": TESTFIRE_MAX_RUNTIME_MIN,
+        },
+        "context": {
+            "description": (
+                "HCL AppScan's deliberately vulnerable TestFire banking website, "
+                "published as a dynamic application security testing demo target."
+            ),
+            "win_condition": (
+                "Confirm one non-destructive, evidence-backed web vulnerability and stop."
+            ),
+            "stop_after_first_finding": True,
+            "rules": [
+                "Stay on the exact https://demo.testfire.net origin and the curated "
+                "login routes exposed by the traffic policy.",
+                "Do not follow or test links, redirects, hosts, or ports outside that origin.",
+                "Use only read-only or harmless proof requests; do not create accounts, "
+                "transfer funds, upload files, change data, or test denial of service.",
+                "Stop after one executor-validated vulnerability is confirmed.",
+            ],
+            "authorization_reference": TESTFIRE_AUTHORIZATION_URL,
+        },
+    }
+    with brief_path.open("x", encoding="utf-8") as stream:
+        yaml.safe_dump(payload, stream, sort_keys=False)
+    return brief_path
 
 
 def _benchmarks_root(explicit: Path | None, *, env: Mapping[str, str]) -> Path:

--- a/packages/ravage/tests/test_agent_traffic_policy.py
+++ b/packages/ravage/tests/test_agent_traffic_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import replace
 from pathlib import Path
 from uuid import uuid4
 
@@ -254,6 +255,41 @@ def test_policy_reference_cannot_weaken_settings(tmp_path: Path) -> None:
             target_url="http://127.0.0.1/",
             roe_max_rps=5,
         )
+
+
+def test_policy_reference_preserves_code_owned_request_restrictions(tmp_path: Path) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    config = replace(
+        TrafficPolicyConfig.low_noise(max_physical_requests=24, max_rps=0.5),
+        allowed_request_routes=("GET /login.jsp", "POST /doLogin"),
+        allowed_query_fields=("mode",),
+        allowed_explicit_headers=("content-type", "user-agent"),
+        allowed_form_fields=("passw", "uid"),
+        max_request_body_bytes=1_024,
+        request_value_profile="testfire-login-demo",
+        require_public_addresses=True,
+    )
+    expected = TrafficPolicyController.open(
+        workspace.root / "traffic-policy.json",
+        target_url="https://demo.testfire.net/login.jsp?mode=demo",
+        config=config,
+    )
+    settings = AIWebAgentSettings(
+        traffic_policy_mode="low-noise",
+        traffic_policy_max_physical_requests=24,
+        traffic_policy_max_rps=0.5,
+        traffic_policy_config=config,
+        traffic_policy_reference=expected.to_reference(),
+    )
+
+    opened = _open_run_traffic_policy(
+        settings=settings,
+        workspace=workspace,
+        target_url="https://demo.testfire.net/login.jsp?mode=demo",
+        roe_max_rps=0.5,
+    )
+
+    assert opened.config == config
 
 
 def test_resume_rejects_missing_workspace_policy_ledger(tmp_path: Path) -> None:

--- a/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
+++ b/packages/ravage/tests/test_ai_agent_same_turn_resolution.py
@@ -67,6 +67,20 @@ def test_injected_model_final_uses_open_surface_route_in_the_same_turn() -> None
     assert selected["task_id"] == "surface-map"
 
 
+def test_demo_stop_after_first_finding_turns_confirmation_terminal() -> None:
+    state = AgentState(surface={"stop_after_first_finding": True})
+    outcome = ActionResult(
+        ok=True,
+        observation="executor persisted a confirmed SQL injection finding",
+        outcome="finding_confirmed",
+    )
+
+    terminal = ai_agent._stop_after_finding_outcome(state, outcome)  # noqa: SLF001
+
+    assert terminal.stop is True
+    assert terminal.outcome == "finding_confirmed"
+
+
 def test_locked_primitive_precedes_a_higher_priority_open_recon_task() -> None:
     state = AgentState(turn=4)
     state.surface["flag_objective"] = False

--- a/packages/ravage/tests/test_autonomous_graph_scoped_http.py
+++ b/packages/ravage/tests/test_autonomous_graph_scoped_http.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable, Sequence
+from dataclasses import replace
 from email.message import Message
 from typing import TYPE_CHECKING
 
@@ -763,6 +764,48 @@ def test_each_redirect_is_scope_checked_before_following() -> None:
         )
 
     assert len(transport.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [
+        ("127.0.0.1",),
+        ("10.0.0.8",),
+        ("169.254.169.254",),
+        ("224.0.0.1",),
+        ("ff0e::1",),
+        ("8.8.8.8", "127.0.0.1"),
+    ],
+)
+def test_shared_public_only_policy_rejects_non_public_graph_dns(
+    tmp_path: Path,
+    addresses: tuple[str, ...],
+) -> None:
+    config = replace(
+        TrafficPolicyConfig.low_noise(max_physical_requests=4, max_rps=0.5),
+        require_public_addresses=True,
+    )
+    policy = TrafficPolicyController.open(
+        tmp_path / "traffic-policy.json",
+        target_url=TARGET_URL,
+        config=config,
+    )
+    transport = QueuedTransport([_response(status=200)])
+    executor = _executor(
+        transport,
+        resolver=lambda _host, _port: addresses,
+        traffic_policy=policy,
+    )
+
+    with pytest.raises(ScopedHttpError, match="non-public address"):
+        executor(
+            node_id="node-public-only",
+            arguments={"path": "/app"},
+            action_id="action-public-only",
+        )
+
+    assert transport.calls == []
+    assert policy.snapshot().physical_request_count == 0
 
 
 def test_managed_out_of_scope_redirect_redacts_sensitive_location_from_failure() -> None:

--- a/packages/ravage/tests/test_http_probe.py
+++ b/packages/ravage/tests/test_http_probe.py
@@ -7,12 +7,14 @@ from email.message import Message
 from http.client import HTTPException, IncompleteRead
 from http.cookiejar import Cookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from threading import Barrier, Lock, Thread
 from typing import cast
 from urllib.error import HTTPError
 from urllib.request import ProxyHandler, Request
 
 import pytest
+from ravage.traffic.policy import TrafficPolicyConfig, TrafficPolicyController
 from ravage.web_core.http_probe import (
     ProbeNetworkContext,
     ProbeResponse,
@@ -322,6 +324,83 @@ def test_remote_probe_rejects_unspecified_dns_addresses(
 
     assert response.status is None
     assert "unspecified address" in response.error
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [
+        ("127.0.0.1",),
+        ("10.0.0.8",),
+        ("169.254.169.254",),
+        ("224.0.0.1",),
+        ("ff0e::1",),
+        ("::1",),
+        ("8.8.8.8", "127.0.0.1"),
+    ],
+    ids=[
+        "loopback",
+        "private",
+        "metadata",
+        "ipv4-multicast",
+        "ipv6-multicast",
+        "ipv6-loopback",
+        "mixed",
+    ],
+)
+def test_public_only_policy_rejects_non_public_dns_before_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    addresses: tuple[str, ...],
+) -> None:
+    monkeypatch.setattr(
+        "ravage.web_core.http_probe.build_opener",
+        lambda *_handlers: _FakeOpener(),
+    )
+    target = "https://demo.testfire.net/login.jsp"
+    policy = TrafficPolicyController.open(
+        tmp_path / "traffic.json",
+        target_url=target,
+        config=TrafficPolicyConfig(require_public_addresses=True),
+    )
+    session = ProbeSession(
+        target,
+        allow_remote_target=True,
+        resolver=lambda _host, _port: addresses,
+        traffic_policy=policy,
+    )
+
+    response = session.get(target)
+
+    assert response.status is None
+    assert "non-public address" in response.error
+    assert policy.snapshot().physical_request_count == 0
+
+
+def test_public_only_policy_accepts_public_dns_answer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ravage.web_core.http_probe.build_opener",
+        lambda *_handlers: _FakeOpener(),
+    )
+    target = "https://demo.testfire.net/login.jsp"
+    policy = TrafficPolicyController.open(
+        tmp_path / "traffic.json",
+        target_url=target,
+        config=TrafficPolicyConfig(require_public_addresses=True),
+    )
+    session = ProbeSession(
+        target,
+        allow_remote_target=True,
+        resolver=lambda _host, _port: ("8.8.8.8",),
+        traffic_policy=policy,
+    )
+
+    response = session.get(target)
+
+    assert response.status == _FakeResponse.status
+    assert policy.snapshot().physical_request_count == 1
 
 
 def test_form_defaults_preserve_named_submit_controls() -> None:

--- a/packages/ravage/tests/test_sqli_targets.py
+++ b/packages/ravage/tests/test_sqli_targets.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urljoin, urlsplit, urlunsplit
 
 from ravage.agent_core.agent_state import AgentState
 from ravage.probe_suite_parts.sqli.sqli import (
+    _target_looks_auth_bypass_candidate,
     probe_filtered_query_bypass,
     probe_sqli_differential,
     probe_sqli_exploit_runner,
@@ -17,6 +18,23 @@ from ravage.web_core.http_probe import ProbeResponse
 
 _MIN_LONG_EXTRACTION_OFFSET = 73
 _MAX_PARENTHESES_UNION_REQUESTS = 100
+
+
+def test_testfire_uid_form_is_an_auth_bypass_candidate() -> None:
+    target = {
+        "kind": "form",
+        "url": "https://demo.testfire.net/doLogin",
+        "input": "uid",
+        "form": {
+            "inputs": [
+                {"name": "uid", "type": "text"},
+                {"name": "passw", "type": "password"},
+                {"name": "btnSubmit", "type": "submit"},
+            ]
+        },
+    }
+
+    assert _target_looks_auth_bypass_candidate(target)
 
 
 def test_sqli_targets_skip_off_origin_parameters_and_prioritize_contact_forms() -> None:

--- a/packages/ravage/tests/test_traffic_policy.py
+++ b/packages/ravage/tests/test_traffic_policy.py
@@ -7,8 +7,10 @@ import time
 from dataclasses import replace
 from pathlib import Path
 from threading import Event, Thread
+from urllib.parse import urlencode
 
 import pytest
+from ravage.probe_suite_parts.sqli.sqli import _SQLI_AUTH_BYPASS_PAYLOADS
 from ravage.traffic import policy as traffic_policy_module
 from ravage.traffic.policy import (
     RequestIntent,
@@ -66,6 +68,170 @@ def test_config_rejects_non_finite_numbers(value: float) -> None:
 def test_config_rejects_rate_with_infinite_interval() -> None:
     with pytest.raises(ValueError, match="finite pacing interval"):
         TrafficPolicyConfig(max_rps=5e-324)
+
+
+def _testfire_request_config() -> TrafficPolicyConfig:
+    return TrafficPolicyConfig(
+        mode=TrafficPolicyMode.ENFORCE,
+        max_physical_requests=24,
+        allowed_request_routes=("GET /", "GET /login.jsp", "POST /doLogin"),
+        allowed_query_fields=("mode",),
+        allowed_explicit_headers=(
+            "accept",
+            "accept-encoding",
+            "content-type",
+            "user-agent",
+        ),
+        allowed_form_fields=("uid", "passw", "btnSubmit"),
+        max_request_body_bytes=1_024,
+        request_value_profile="testfire-login-demo",
+        require_public_addresses=True,
+    )
+
+
+def test_request_restrictions_round_trip_through_durable_reference(tmp_path: Path) -> None:
+    config = _testfire_request_config()
+    controller = _controller(tmp_path, config)
+
+    restored = TrafficPolicyController.from_reference(controller.to_reference())
+
+    assert restored.config == config
+
+
+def test_request_restrictions_allow_only_curated_login_traffic(tmp_path: Path) -> None:
+    controller = _controller(tmp_path, _testfire_request_config())
+    get_login = RequestIntent(
+        "GET",
+        "http://127.0.0.1/login.jsp?mode=demo",
+        headers={"Accept": "text/html", "User-Agent": "ravage"},
+    )
+    post_login = RequestIntent(
+        "POST",
+        "http://127.0.0.1/doLogin",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body=b"uid=ravage&passw=RavagePass123%21&btnSubmit=Login",
+    )
+    safe_auth_bypass = RequestIntent(
+        "POST",
+        "http://127.0.0.1/doLogin",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body=b"uid=admin%27+--+&passw=RavagePass123%21&btnSubmit=Login",
+    )
+
+    for intent in (get_login, post_login, safe_auth_bypass):
+        decision = controller.acquire(intent)
+        assert decision.kind is TrafficDecisionKind.DISPATCH
+        assert decision.lease is not None
+        controller.cancel(decision.lease)
+
+
+@pytest.mark.parametrize("uid", _SQLI_AUTH_BYPASS_PAYLOADS)
+def test_testfire_profile_admits_every_code_owned_auth_bypass_value(
+    tmp_path: Path,
+    uid: str,
+) -> None:
+    controller = _controller(tmp_path, _testfire_request_config())
+    body = urlencode(
+        {
+            "uid": uid,
+            "passw": "RavagePass123!",
+            "btnSubmit": "Login",
+        }
+    ).encode()
+
+    decision = controller.acquire(
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=body,
+        )
+    )
+
+    assert decision.kind is TrafficDecisionKind.DISPATCH
+    assert decision.lease is not None
+    controller.cancel(decision.lease)
+
+
+@pytest.mark.parametrize(
+    "intent",
+    [
+        RequestIntent("GET", "http://127.0.0.1/admin/admin.jsp"),
+        RequestIntent("GET", "http://127.0.0.1/ignored/../login.jsp"),
+        RequestIntent("GET", "http://127.0.0.1/login%2Ejsp"),
+        RequestIntent("DELETE", "http://127.0.0.1/login.jsp"),
+        RequestIntent("GET", "http://127.0.0.1/login.jsp?next=/admin"),
+        RequestIntent("GET", "http://127.0.0.1/login.jsp?mode=staging"),
+        RequestIntent(
+            "GET",
+            "http://127.0.0.1/login.jsp",
+            headers={"Host": "normal.example"},
+        ),
+        RequestIntent(
+            "GET",
+            "http://127.0.0.1/login.jsp",
+            headers={"Cookie": "session=attacker-controlled"},
+        ),
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=b"uid=guest&passw=demo&role=admin",
+        ),
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=b"uid=admin%27%3B+DROP+TABLE+users%3B--&passw=RavagePass123%21",
+        ),
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=b"uid=1%27+OR+SLEEP%2810%29--+&passw=RavagePass123%21",
+        ),
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/json"},
+            body=b'{"uid":"guest","passw":"demo"}',
+        ),
+        RequestIntent(
+            "POST",
+            "http://127.0.0.1/doLogin",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=b"uid=" + (b"x" * 1_024),
+        ),
+    ],
+    ids=[
+        "off-route",
+        "dot-segment-path",
+        "encoded-path",
+        "method",
+        "query-field",
+        "query-value",
+        "host-header",
+        "explicit-cookie",
+        "form-field",
+        "destructive-form-value",
+        "timing-form-value",
+        "body-encoding",
+        "body-size",
+    ],
+)
+def test_request_restrictions_block_before_dispatch(
+    tmp_path: Path,
+    intent: RequestIntent,
+) -> None:
+    controller = _controller(tmp_path, _testfire_request_config())
+
+    decision = controller.acquire(intent)
+
+    assert decision.kind is TrafficDecisionKind.BLOCKED
+    snapshot = controller.snapshot()
+    assert snapshot.physical_request_count == 0
+    assert snapshot.reservation_count == 0
+    assert snapshot.blocked_count == 1
 
 
 def _intent(path: str = "/", *, cacheable: bool = False) -> RequestIntent:

--- a/packages/ravage/tests/test_xben_demo_cli.py
+++ b/packages/ravage/tests/test_xben_demo_cli.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+import yaml
 from ravage import __main__ as cli
+from ravage.run_data.brief import load_engagement_brief
 from ravage.xben_parts import demo
 
 if TYPE_CHECKING:
@@ -19,6 +22,11 @@ DEMO_TIMEOUT_SECONDS = 600
 DEMO_MAX_COST_USD = 1.50
 DEMO_INPUT_TOKEN_CEILING = 20_000
 DEMO_MIN_FREE_GIB = 10
+TESTFIRE_TARGET_URL = "https://demo.testfire.net/login.jsp?mode=demo"
+TESTFIRE_MAX_TURNS = 6
+TESTFIRE_MAX_REQUESTS = 24
+TESTFIRE_MAX_BODY_BYTES = 1_024
+TESTFIRE_MAX_RPS = 0.5
 TWO_RUNS = 2
 ARGPARSE_ERROR_EXIT = 2
 
@@ -84,22 +92,211 @@ def test_top_level_cli_dispatches_demo_xben(
     assert captured[0].ids == (DEMO_CASE_ID,)
 
 
-def test_demo_help_exposes_the_single_live_command(
+def test_demo_help_exposes_both_live_commands(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     with pytest.raises(SystemExit) as top_level:
         cli.main(["--help"])
 
     assert top_level.value.code == 0
-    assert "ravage demo xben" in capsys.readouterr().out
+    top_level_output = capsys.readouterr().out
+    assert "ravage demo xben" in top_level_output
+    assert "ravage demo testfire --authorized-remote-target" in top_level_output
 
     with pytest.raises(SystemExit) as captured:
         cli.main(["demo", "--help"])
 
     assert captured.value.code == 0
     output = capsys.readouterr().out
-    assert "{xben}" in output
+    assert "{xben,testfire}" in output
     assert "build, attack, score, and remove one local XBEN target" in output
+    assert "deliberately vulnerable" in output
+    assert "banking demo" in output
+
+
+def test_demo_testfire_requires_explicit_remote_authorization(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    called = False
+
+    def attack(_args: list[str]) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(SystemExit) as captured:
+        demo.handle_demo_command(
+            ["testfire", "--output-dir", str(tmp_path / "run")],
+            attack_runner=attack,
+        )
+
+    assert captured.value.code == ARGPARSE_ERROR_EXIT
+    assert called is False
+    error = capsys.readouterr().err
+    assert "--authorized-remote-target" in error
+    assert demo.TESTFIRE_AUTHORIZATION_URL in error
+
+
+def test_demo_testfire_uses_immutable_scope_and_enforced_request_profile(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+    run_dir = tmp_path / "testfire-run"
+
+    def attack(args: list[str]) -> None:
+        commands.append(args)
+
+    demo.handle_demo_command(
+        [
+            "testfire",
+            "--authorized-remote-target",
+            "--output-dir",
+            str(run_dir),
+        ],
+        attack_runner=attack,
+    )
+
+    [command] = commands
+    brief_path = Path(command[0])
+    brief = yaml.safe_load(brief_path.read_text(encoding="utf-8"))
+    loaded_brief = load_engagement_brief(brief_path)
+    assert command[command.index("--target-url") + 1] == TESTFIRE_TARGET_URL
+    assert command[command.index("--run-dir") + 1] == str(run_dir)
+    assert command[command.index("--model-profile") + 1] == DEMO_MODEL_PROFILE
+    assert command[command.index("--model-tier") + 1] == "high"
+    assert command[command.index("--max-turns") + 1] == str(TESTFIRE_MAX_TURNS)
+    assert command[command.index("--traffic-policy") + 1] == "low-noise"
+    assert command[command.index("--max-physical-requests") + 1] == str(
+        TESTFIRE_MAX_REQUESTS
+    )
+    assert command[command.index("--traffic-max-rps") + 1] == str(TESTFIRE_MAX_RPS)
+    assert command[command.index("--traffic-request-profile") + 1] == (
+        "testfire-login-demo"
+    )
+    assert "--authorized-remote-target" in command
+    assert "--tool-runtime" in command
+    assert command[command.index("--tool-runtime") + 1] == "docker"
+    assert "--no-tool-recon" in command
+    assert "--show-agent-actions" in command
+    assert "--allow-paid-models" in command
+    assert "--report" in command
+    assert brief["scope"] == {
+        "in_scope": list(demo.TESTFIRE_SCOPE_URLS),
+        "out_of_scope": [],
+    }
+    assert brief["roe"]["max_rps"] == demo.TESTFIRE_ROE_MAX_RPS
+    assert loaded_brief.roe.max_rps == demo.TESTFIRE_ROE_MAX_RPS
+    assert brief["roe"]["no_destructive_actions"] is True
+    assert brief["context"]["authorization_reference"] == (
+        demo.TESTFIRE_AUTHORIZATION_URL
+    )
+    assert brief["context"]["stop_after_first_finding"] is True
+
+
+def test_top_level_cli_dispatches_demo_testfire_without_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def run(argv: list[str], _stdout_path: Path) -> int:
+        commands.append(argv)
+        return 0
+
+    monkeypatch.setattr(cli, "_run_subprocess_tee_stdout", run)
+
+    cli.main(
+        [
+            "demo",
+            "testfire",
+            "--authorized-remote-target",
+            "--output-dir",
+            str(tmp_path / "run"),
+        ]
+    )
+
+    assert len(commands) == 1
+    assert commands[0][commands[0].index("--target-url") + 1] == TESTFIRE_TARGET_URL
+    assert commands[0][commands[0].index("--traffic-request-profile") + 1] == (
+        "testfire-login-demo"
+    )
+
+
+def test_demo_testfire_rejects_target_override_without_running(
+    tmp_path: Path,
+) -> None:
+    called = False
+
+    def attack(_args: list[str]) -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(SystemExit) as captured:
+        demo.handle_demo_command(
+            [
+                "testfire",
+                "--authorized-remote-target",
+                "--target-url",
+                "https://example.com",
+                "--output-dir",
+                str(tmp_path / "run"),
+            ],
+            attack_runner=attack,
+        )
+
+    assert captured.value.code == ARGPARSE_ERROR_EXIT
+    assert called is False
+
+
+def test_testfire_request_profile_is_code_owned_and_route_locked() -> None:
+    config = cli._traffic_policy_config(  # noqa: SLF001 - verify the CLI safety boundary.
+        argparse.Namespace(
+            traffic_policy="low-noise",
+            max_physical_requests=TESTFIRE_MAX_REQUESTS,
+            traffic_max_rps=TESTFIRE_MAX_RPS,
+            traffic_request_profile="testfire-login-demo",
+        )
+    )
+
+    assert config.allowed_request_routes == (
+        "GET /bank/main.jsp",
+        "GET /login.jsp",
+        "HEAD /bank/main.jsp",
+        "HEAD /login.jsp",
+        "POST /doLogin",
+    )
+    assert config.allowed_query_fields == ("mode",)
+    assert config.allowed_form_fields == ("btnsubmit", "passw", "uid")
+    assert config.max_request_body_bytes == TESTFIRE_MAX_BODY_BYTES
+    assert config.request_value_profile == "testfire-login-demo"
+    assert config.require_public_addresses is True
+
+
+@pytest.mark.parametrize(
+    ("autonomous_route", "recovery_profile"),
+    [(True, "off"), (False, "recovery-v1")],
+)
+def test_testfire_request_profile_rejects_expansive_agent_routes(
+    autonomous_route: bool,  # noqa: FBT001 - parametrized safety-boundary input.
+    recovery_profile: str,
+) -> None:
+    parser = argparse.ArgumentParser()
+    parsed = argparse.Namespace(
+        traffic_policy="low-noise",
+        max_physical_requests=TESTFIRE_MAX_REQUESTS,
+        traffic_max_rps=TESTFIRE_MAX_RPS,
+        traffic_request_profile="testfire-login-demo",
+        autonomous_route=autonomous_route,
+        recovery_profile=recovery_profile,
+    )
+
+    with pytest.raises(SystemExit):
+        cli._resolve_traffic_policy_args(  # noqa: SLF001 - verify the CLI safety boundary.
+            parser,
+            parsed,
+            default_mode="low-noise",
+            roe_max_rps=demo.TESTFIRE_ROE_MAX_RPS,
+        )
 
 
 def test_demo_xben_captures_the_exact_safe_preset(


### PR DESCRIPTION
## Summary

  - add `ravage demo testfire --authorized-remote-target`
  - target HCL’s deliberately vulnerable `demo.testfire.net`
  - show narrated agent actions during the run
  - stop after the first confirmed finding