### PR TITLE
fix(agent): validate dynamic model replies

### DIFF
--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -1984,7 +1984,10 @@ def _observed_structured_forms(state: AgentState) -> list[dict[str, object]]:
     forms = _list_of_dicts(state.surface.get("forms"))
     for raw_form in state.signals.get("forms", []):
         if isinstance(raw_form, dict):
-            forms.append(dict(raw_form))
+            normalized_form: dict[str, object] = {
+                str(key): value for key, value in raw_form.items()
+            }
+            forms.append(normalized_form)
         elif isinstance(raw_form, str):
             parsed = _json_object(raw_form)
             if parsed:
@@ -4115,13 +4118,20 @@ def _complete_model(
             )
             for message in messages
         ]
-        return complete(messages=chat_messages, route=route)
+        return _require_model_reply(complete(messages=chat_messages, route=route))
 
     chat = getattr(client, "chat", None)
     if callable(chat):
-        return chat(messages)
+        return _require_model_reply(chat(messages))
 
     raise TypeError("model client must define complete(...) or chat(...)")
+
+
+def _require_model_reply(value: object) -> ModelReply:
+    if isinstance(value, ModelReply):
+        return value
+    message = "model client complete(...) or chat(...) must return ModelReply"
+    raise TypeError(message)
 
 
 def _require_accountable_paid_reply(

--- a/packages/ravage/tests/test_chat_client.py
+++ b/packages/ravage/tests/test_chat_client.py
@@ -5,11 +5,47 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import pytest
-from ravage.agent_core.ai_agent import ChatClient
+from ravage.agent_core.ai_agent import ChatClient, ChatMessage, ModelReply, _complete_model
 from ravage.model_core.providers import ProviderKind, ResolvedModelRoute
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+
+def test_complete_model_requires_typed_reply_from_dynamic_client() -> None:
+    class InvalidClient:
+        def chat(self, _messages: list[dict[str, str]]) -> object:
+            return object()
+
+    with pytest.raises(TypeError, match="must return ModelReply"):
+        _complete_model(
+            InvalidClient(),
+            messages=[{"role": "user", "content": "return json"}],
+            route=_route(),
+        )
+
+
+def test_complete_model_preserves_valid_typed_complete_reply() -> None:
+    expected = ModelReply(content='{"action":"final"}')
+
+    class ValidClient:
+        def complete(
+            self,
+            *,
+            messages: list[ChatMessage],
+            route: ResolvedModelRoute,
+        ) -> object:
+            assert messages == [ChatMessage(role="user", content="return json")]
+            assert route == _route()
+            return expected
+
+    reply = _complete_model(
+        ValidClient(),
+        messages=[{"role": "user", "content": "return json"}],
+        route=_route(),
+    )
+
+    assert reply is expected
 
 
 def test_openai_compatible_chat_client_requests_json_object_response() -> None:


### PR DESCRIPTION
## Summary

  - Fixes the Pylance error where dynamic `complete()` and `chat()` results were inferred as `object` instead of `ModelReply`
  - Validates model-client replies at runtime
  - Normalized observed form dictionaries
