### PR TITLE
feat(models): add abliteration.ai provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
+ABLIT_KEY=
 AZURE_OPENAI_API_KEY=
 
 # Optional local OpenAI-compatible endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ before an entry is described as released.
 
 ### Changed
 
+- Added an opt-in, cost-accounted `hosted-abliteration` model profile using
+  abliteration.ai's OpenAI-compatible API.
 - Replaced the CLI's remote HTTP-only lane with the full `ai-web` base for
   explicitly authorized remote targets, forcing command-like tools through a
   DNS-pinned, target-scoped Docker network and extending URL scope to probes and

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -222,6 +222,37 @@ and [pricing table](https://platform.claude.com/docs/en/about-claude/pricing).
 An unknown `RAVAGE_ANTHROPIC_*_MODEL` override is not ready until its prices are
 provided explicitly in a custom model config.
 
+## Hosted abliteration.ai Routes
+
+Ravage can call abliteration.ai through its OpenAI-compatible Chat Completions
+API. Create a provider key, then set it beside the engagement brief:
+
+```dotenv
+# .env.ravage
+ABLIT_KEY=your_key_here
+RAVAGE_ABLITERATION_MID_MODEL=abliterated-model-large
+```
+
+Use:
+
+```text
+--model-profile hosted-abliteration --model-tier mid
+```
+
+The built-in tiers select `abliterated-model-large-v2` for high,
+`abliterated-model-large` for mid, and `abliterated-model` for low. Ravage calls
+`https://api.abliteration.ai/v1/chat/completions`, requests structured JSON,
+and keeps its normal scope, authorization, traffic, evidence, and cost gates in
+control of execution.
+
+These are hosted paid-risk routes. Their standard list prices were verified on
+2026-09-02 against the provider's [pricing
+table](https://abliteration.ai/pricing). Discounts and separately billed web
+search are not included in Ravage's token estimate. An unknown
+`RAVAGE_ABLITERATION_*_MODEL` override remains unpriced and is rejected before
+a paid request. Review the provider's [data-handling
+terms](https://abliteration.ai/data-handling) before sending target evidence.
+
 ## Attack Example
 
 Run the local Acme lab first:

--- a/examples/model_profiles.yaml
+++ b/examples/model_profiles.yaml
@@ -113,6 +113,25 @@ profiles:
           api_key_env: ANTHROPIC_API_KEY
           max_output_tokens: 4096
 
+  hosted-abliteration:
+    default_tier: mid
+    routes:
+      high:
+        - provider: abliteration
+          model: ${RAVAGE_ABLITERATION_HIGH_MODEL:abliterated-model-large-v2}
+          api_key_env: ABLIT_KEY
+          max_output_tokens: 4096
+      mid:
+        - provider: abliteration
+          model: ${RAVAGE_ABLITERATION_MID_MODEL:abliterated-model-large}
+          api_key_env: ABLIT_KEY
+          max_output_tokens: 4096
+      low:
+        - provider: abliteration
+          model: ${RAVAGE_ABLITERATION_LOW_MODEL:abliterated-model}
+          api_key_env: ABLIT_KEY
+          max_output_tokens: 4096
+
   mixed-fallback:
     default_tier: mid
     routes:

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -4332,10 +4332,13 @@ def _create_init_files(
             "# Ravage model provider settings\n"
             "OPENAI_API_KEY=\n"
             "ANTHROPIC_API_KEY=\n"
+            "ABLIT_KEY=\n"
             "RAVAGE_OPENAI_LOW_MODEL=gpt-5.4-mini-2026-03-17\n"
             "RAVAGE_OPENAI_MID_MODEL=gpt-5.4-2026-03-05\n"
             "RAVAGE_ANTHROPIC_LOW_MODEL=claude-haiku-4-5-20251001\n"
             "RAVAGE_ANTHROPIC_MID_MODEL=claude-sonnet-4-6\n"
+            "RAVAGE_ABLITERATION_LOW_MODEL=abliterated-model\n"
+            "RAVAGE_ABLITERATION_MID_MODEL=abliterated-model-large\n"
         )
     )
     auth_result = None
@@ -5618,6 +5621,8 @@ def _preferred_model_profile() -> str:
         return "hosted-openai"
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
         return "hosted-anthropic"
+    if os.environ.get("ABLIT_KEY", "").strip():
+        return "hosted-abliteration"
     return "local-ollama"
 
 

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -80,6 +80,7 @@ from ravage.dry_run import RouteParam, RouteProbe
 from ravage.model_core.providers import (
     ModelTier,
     ResolvedModelRoute,
+    abliteration_standard_token_prices,
     anthropic_standard_token_prices,
     load_model_registry,
     model_route_transport_error,
@@ -4885,6 +4886,16 @@ def _response_cost_is_known(
         elif response_prices != requested_prices:
             return False
         if _usage_token_count(usage, "cache_creation_input_tokens") != 0:
+            return False
+    if route.provider == "abliteration":
+        if not response_model:
+            return False
+        requested_prices = abliteration_standard_token_prices(route.model)
+        response_prices = abliteration_standard_token_prices(response_model)
+        if requested_prices is None:
+            if response_model != route.model:
+                return False
+        elif response_prices != requested_prices:
             return False
     cached_input_tokens = _cached_input_tokens(route, usage)
     return cached_input_tokens == 0 or route.cached_input_cost_per_1m_tokens is not None

--- a/packages/ravage/src/ravage/model_core/providers.py
+++ b/packages/ravage/src/ravage/model_core/providers.py
@@ -18,6 +18,7 @@ type ModelTier = Literal["high", "mid", "low"]
 type ProviderKind = Literal[
     "openai",
     "anthropic",
+    "abliteration",
     "gemini",
     "openrouter",
     "litellm",
@@ -43,6 +44,7 @@ LOCAL_PROVIDERS: frozenset[ProviderKind] = frozenset({"ollama", "lmstudio", "lla
 DEFAULT_API_KEY_ENV: dict[ProviderKind, str] = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
+    "abliteration": "ABLIT_KEY",
     "gemini": "GOOGLE_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
     "azure": "AZURE_OPENAI_API_KEY",
@@ -54,6 +56,7 @@ DEFAULT_API_KEY_ENV: dict[ProviderKind, str] = {
 }
 DEFAULT_BASE_URL: dict[ProviderKind, str] = {
     "anthropic": "https://api.anthropic.com",
+    "abliteration": "https://api.abliteration.ai/v1",
     "ollama": "http://localhost:11434/v1",
     "lmstudio": "http://localhost:1234/v1",
     "llamacpp": "http://localhost:8080/v1",
@@ -62,10 +65,12 @@ DEFAULT_BASE_URL: dict[ProviderKind, str] = {
 }
 OPENAI_NATIVE_BASE_URL = "https://api.openai.com/v1"
 ANTHROPIC_NATIVE_BASE_URL = "https://api.anthropic.com"
+ABLITERATION_NATIVE_BASE_URL = "https://api.abliteration.ai/v1"
 DIRECT_CHAT_PROVIDERS: frozenset[ProviderKind] = frozenset(
     {
         "openai",
         "anthropic",
+        "abliteration",
         "litellm",
         "custom_openai",
         *LOCAL_PROVIDERS,
@@ -124,6 +129,19 @@ ANTHROPIC_STANDARD_TOKEN_PRICES: dict[str, TokenPrices] = {
 
 def anthropic_standard_token_prices(model: str) -> TokenPrices | None:
     return ANTHROPIC_STANDARD_TOKEN_PRICES.get(model)
+
+
+# abliteration.ai list pricing per 1M tokens, verified 2026-09-02.
+# https://abliteration.ai/pricing
+ABLITERATION_STANDARD_TOKEN_PRICES: dict[str, TokenPrices] = {
+    "abliterated-model": TokenPrices(3.0, 0.3, 3.0),
+    "abliterated-model-large": TokenPrices(5.0, 0.5, 5.0),
+    "abliterated-model-large-v2": TokenPrices(5.0, 0.5, 5.0),
+}
+
+
+def abliteration_standard_token_prices(model: str) -> TokenPrices | None:
+    return ABLITERATION_STANDARD_TOKEN_PRICES.get(model)
 
 
 DEFAULT_MODEL_CONFIG: dict[str, object] = {
@@ -318,6 +336,44 @@ DEFAULT_MODEL_CONFIG: dict[str, object] = {
                             "claude-haiku-4-5-20251001}"
                         ),
                         "api_key_env": "ANTHROPIC_API_KEY",
+                        "max_output_tokens": 4096,
+                    }
+                ],
+            },
+        },
+        "hosted-abliteration": {
+            "default_tier": "mid",
+            "routes": {
+                "high": [
+                    {
+                        "provider": "abliteration",
+                        "model": (
+                            "${RAVAGE_ABLITERATION_HIGH_MODEL:"
+                            "abliterated-model-large-v2}"
+                        ),
+                        "api_key_env": "ABLIT_KEY",
+                        "max_output_tokens": 4096,
+                    }
+                ],
+                "mid": [
+                    {
+                        "provider": "abliteration",
+                        "model": (
+                            "${RAVAGE_ABLITERATION_MID_MODEL:"
+                            "abliterated-model-large}"
+                        ),
+                        "api_key_env": "ABLIT_KEY",
+                        "max_output_tokens": 4096,
+                    }
+                ],
+                "low": [
+                    {
+                        "provider": "abliteration",
+                        "model": (
+                            "${RAVAGE_ABLITERATION_LOW_MODEL:"
+                            "abliterated-model}"
+                        ),
+                        "api_key_env": "ABLIT_KEY",
                         "max_output_tokens": 4096,
                     }
                 ],
@@ -646,6 +702,8 @@ def _effective_token_prices(
         known = openai_standard_token_prices(route.model)
     elif route.provider == "anthropic":
         known = anthropic_standard_token_prices(route.model)
+    elif route.provider == "abliteration":
+        known = abliteration_standard_token_prices(route.model)
     else:
         known = None
     if known is None:
@@ -682,6 +740,8 @@ def model_route_transport_issue(route: ResolvedModelRoute) -> str | None:
         return "openai_native_base_url_required"
     if route.provider == "anthropic" and base_url != ANTHROPIC_NATIVE_BASE_URL:
         return "anthropic_native_base_url_required"
+    if route.provider == "abliteration" and base_url != ABLITERATION_NATIVE_BASE_URL:
+        return "abliteration_native_base_url_required"
     return None
 
 
@@ -703,6 +763,11 @@ def model_route_transport_error(route: ResolvedModelRoute) -> str | None:
         return (
             f"provider=anthropic only supports {ANTHROPIC_NATIVE_BASE_URL}; "
             "use provider=litellm for a gateway"
+        )
+    if issue == "abliteration_native_base_url_required":
+        return (
+            f"provider=abliteration only supports {ABLITERATION_NATIVE_BASE_URL}; "
+            "use provider=custom_openai for a gateway"
         )
     return None
 

--- a/packages/ravage/tests/test_ai_providers.py
+++ b/packages/ravage/tests/test_ai_providers.py
@@ -23,6 +23,11 @@ ANTHROPIC_STANDARD_ROUTES = (
     ("mid", "claude-sonnet-4-6", (3.0, 0.3, 15.0)),
     ("low", "claude-haiku-4-5-20251001", (1.0, 0.1, 5.0)),
 )
+ABLITERATION_STANDARD_ROUTES = (
+    ("high", "abliterated-model-large-v2", (5.0, 0.5, 5.0)),
+    ("mid", "abliterated-model-large", (5.0, 0.5, 5.0)),
+    ("low", "abliterated-model", (3.0, 0.3, 3.0)),
+)
 UNSUPPORTED_DIRECT_PROVIDERS: tuple[ProviderKind, ...] = (
     "gemini",
     "openrouter",
@@ -281,6 +286,53 @@ def test_hosted_anthropic_unknown_override_is_not_ready_for_paid_call() -> None:
     assert route.missing_pricing
 
 
+@pytest.mark.parametrize(("tier", "model", "prices"), ABLITERATION_STANDARD_ROUTES)
+def test_hosted_abliteration_profile_has_accountable_pricing(
+    tier: ModelTier,
+    model: str,
+    prices: tuple[float, float, float],
+) -> None:
+    env = {"ABLIT_KEY": "ak-test"}
+    registry = load_model_registry(env=env)
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="hosted-abliteration",
+        tier=tier,
+        env=env,
+    )[0]
+
+    assert route.ready
+    assert route.provider == "abliteration"
+    assert route.model == model
+    assert route.base_url == "https://api.abliteration.ai/v1"
+    assert route.api_key_env == "ABLIT_KEY"
+    assert (
+        route.input_cost_per_1m_tokens,
+        route.cached_input_cost_per_1m_tokens,
+        route.output_cost_per_1m_tokens,
+    ) == prices
+
+
+def test_hosted_abliteration_unknown_override_is_not_ready_for_paid_call() -> None:
+    env = {
+        "ABLIT_KEY": "ak-test",
+        "RAVAGE_ABLITERATION_LOW_MODEL": "future-abliterated-model",
+    }
+    registry = load_model_registry(env=env)
+
+    route = resolve_model_routes(
+        registry,
+        profile_name="hosted-abliteration",
+        tier="low",
+        env=env,
+    )[0]
+
+    assert not route.ready
+    assert route.missing_env == ()
+    assert route.missing_pricing
+
+
 def test_universal_litellm_requires_explicit_pricing_before_it_is_ready() -> None:
     registry = load_model_registry(env={})
 
@@ -429,6 +481,11 @@ profiles:
             "anthropic",
             "https://gateway.example",
             "anthropic_native_base_url_required",
+        ),
+        (
+            "abliteration",
+            "https://gateway.example/v1",
+            "abliteration_native_base_url_required",
         ),
     ],
 )

--- a/packages/ravage/tests/test_chat_client.py
+++ b/packages/ravage/tests/test_chat_client.py
@@ -11,6 +11,8 @@ from ravage.model_core.providers import ProviderKind, ResolvedModelRoute
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+ABLITERATION_EXPECTED_COST_USD = 0.00222
+
 
 def test_complete_model_requires_typed_reply_from_dynamic_client() -> None:
     class InvalidClient:
@@ -250,6 +252,50 @@ def test_native_anthropic_client_rejects_unpriced_cache_creation() -> None:
     assert reply.cost_usd == 0.0
 
 
+def test_abliteration_chat_client_uses_published_prices() -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=3.0,
+            cached_input_cost_per_1m_tokens=0.3,
+            output_cost_per_1m_tokens=3.0,
+        ),
+        provider="abliteration",
+        model="abliterated-model",
+        base_url="https://api.abliteration.ai/v1",
+        api_key_env="ABLIT_KEY",
+    )
+    client = _CapturingChatClient(route)
+    client.response_model = "abliterated-model"
+
+    reply = client.chat([{"role": "user", "content": "return json"}])
+
+    assert client.request_body["max_tokens"] == route.max_output_tokens
+    assert "service_tier" not in client.request_body
+    assert reply.cost_known is True
+    assert reply.cost_usd == pytest.approx(ABLITERATION_EXPECTED_COST_USD)
+
+
+def test_abliteration_chat_client_rejects_different_price_band() -> None:
+    route = replace(
+        _route(
+            input_cost_per_1m_tokens=3.0,
+            cached_input_cost_per_1m_tokens=0.3,
+            output_cost_per_1m_tokens=3.0,
+        ),
+        provider="abliteration",
+        model="abliterated-model",
+        base_url="https://api.abliteration.ai/v1",
+        api_key_env="ABLIT_KEY",
+    )
+    client = _CapturingChatClient(route)
+    client.response_model = "abliterated-model-large"
+
+    reply = client.chat([{"role": "user", "content": "return json"}])
+
+    assert reply.cost_known is False
+    assert reply.cost_usd == 0.0
+
+
 @pytest.mark.parametrize(
     ("provider", "base_url"),
     [
@@ -257,6 +303,7 @@ def test_native_anthropic_client_rejects_unpriced_cache_creation() -> None:
         ("custom_openai", None),
         ("openai", "https://gateway.example/v1"),
         ("anthropic", "https://gateway.example"),
+        ("abliteration", "https://gateway.example/v1"),
     ],
 )
 def test_chat_client_rejects_unsupported_transport_before_dispatch(

--- a/packages/ravage/tests/test_cli_plumbing.py
+++ b/packages/ravage/tests/test_cli_plumbing.py
@@ -646,8 +646,10 @@ def test_cli_init_writes_env_and_brief(
     payload = cli.yaml.safe_load(brief_path.read_text(encoding="utf-8"))
     output = capsys.readouterr().out
     assert "OPENAI_API_KEY=" in env_text
+    assert "ABLIT_KEY=" in env_text
     assert "RAVAGE_OPENAI_LOW_MODEL=gpt-5.4-mini-2026-03-17" in env_text
     assert "RAVAGE_ANTHROPIC_LOW_MODEL=claude-haiku-4-5-20251001" in env_text
+    assert "RAVAGE_ABLITERATION_LOW_MODEL=abliterated-model" in env_text
     assert payload["scope"]["in_scope"] == ["http://127.0.0.1:8080"]
     assert payload["objectives"] == ["web_application_assessment"]
     assert payload["context"]["description"].startswith("TODO:")
@@ -661,6 +663,16 @@ def test_cli_init_writes_env_and_brief(
     assert f"--env-file {env_path}" in output
     assert "--tool-runtime host" not in output
     assert "--model-profile hosted-openai" not in output
+
+
+def test_preferred_model_profile_selects_abliteration_when_it_is_only_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("ABLIT_KEY", "ak-test")
+
+    assert cli._preferred_model_profile() == "hosted-abliteration"  # noqa: SLF001
 
 
 def test_cli_init_remote_url_prints_authorized_attack_command(

--- a/packages/ravage/tests/test_host_runtime_local_tools.py
+++ b/packages/ravage/tests/test_host_runtime_local_tools.py
@@ -51,21 +51,23 @@ def test_host_runtime_scrubs_parent_secrets_from_shell_and_python(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-secret")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-anthropic-secret")
+    monkeypatch.setenv("ABLIT_KEY", "fake-abliteration-secret")
     monkeypatch.setenv("RAVAGE_ARBITRARY_PARENT_SECRET", "fake-parent-secret")
     runtime = ExternalToolRuntime()
     try:
         shell = runtime.run_command(
             command=(
-                "printf '%s|%s|%s|%s' "
+                "printf '%s|%s|%s|%s|%s' "
                 '"${OPENAI_API_KEY-unset}" "${ANTHROPIC_API_KEY-unset}" '
-                '"${RAVAGE_ARBITRARY_PARENT_SECRET-unset}" "$RAVAGE_TARGET_URL"'
+                '"${ABLIT_KEY-unset}" "${RAVAGE_ARBITRARY_PARENT_SECRET-unset}" '
+                '"$RAVAGE_TARGET_URL"'
             ),
             target_url="http://127.0.0.1:8765",
         )
         python = runtime.run_python(
             code=(
                 "import os\n"
-                "keys = ('OPENAI_API_KEY', 'ANTHROPIC_API_KEY', "
+                "keys = ('OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'ABLIT_KEY', "
                 "'RAVAGE_ARBITRARY_PARENT_SECRET')\n"
                 "print('|'.join(os.environ.get(key, 'unset') for key in keys))\n"
                 "print(os.environ['RAVAGE_TARGET_URL'])\n"
@@ -77,10 +79,10 @@ def test_host_runtime_scrubs_parent_secrets_from_shell_and_python(
         runtime.close()
 
     assert shell.ok is True
-    assert shell.stdout == "unset|unset|unset|http://127.0.0.1:8765"
+    assert shell.stdout == "unset|unset|unset|unset|http://127.0.0.1:8765"
     assert python.ok is True
     assert python.stdout.splitlines() == [
-        "unset|unset|unset",
+        "unset|unset|unset|unset",
         "http://127.0.0.1:8765",
         str(runtime.workdir),
     ]


### PR DESCRIPTION
## Summary

Adds opt-in abliteration.ai (https://abliteration.ai/) model support through its OpenAI-compatible Chat Completions API.

  - Adds the hosted-abliteration profile with three tiers:
      - high: abliterated-model-large-v2
      - mid: abliterated-model-large
      - low: abliterated-model

  - Loads credentials from ABLIT_KEY.
  - Auto selects the profile when it is the only configured hosted-provider key.
  - Accounts for the provider’s pricing.
  - Rejects unknown model overrides before making paid requests.
