### PR TITLE
feat(agent): add stateful request replay

### DIFF
--- a/.github/workflows/publish-kali-image.yml
+++ b/.github/workflows/publish-kali-image.yml
@@ -56,10 +56,60 @@ jobs:
           cache-from: type=gha,scope=ravage-kali-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=ravage-kali-${{ matrix.arch }},ignore-error=true
 
+  preflight:
+    name: Verify the immutable publication source
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'release' && github.event.release.prerelease == false) }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require current main or its exact peeled release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            "refs/heads/main:refs/remotes/origin/main"
+          event_commit="$(git rev-parse --verify "${GITHUB_SHA}^{commit}")"
+          main_commit="$(git rev-parse --verify "refs/remotes/origin/main^{commit}")"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+              echo "Manual image publication must run from main." >&2
+              exit 1
+            fi
+            publication_commit="${event_commit}"
+          else
+            git fetch --force --no-tags origin \
+              "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            publication_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+            if [ "${event_commit}" != "${publication_commit}" ]; then
+              echo "Release event commit is not the peeled release-tag commit." >&2
+              exit 1
+            fi
+          fi
+
+          if [ "${publication_commit}" != "${main_commit}" ]; then
+            echo "Image publication commit is not current main." >&2
+            exit 1
+          fi
+
+      - name: Check release metadata
+        run: python scripts/check_release.py
+
   publish-platform:
     name: Publish ${{ matrix.platform }} digest
-    if: github.event_name != 'pull_request'
+    if: >-
+      ${{ github.event_name != 'pull_request' &&
+          (github.event_name != 'release' || github.event.release.prerelease == false) }}
     runs-on: ${{ matrix.runner }}
+    needs: preflight
     permissions:
       contents: read
       packages: write # Push the architecture-specific image digest to GHCR.
@@ -130,7 +180,9 @@ jobs:
 
   publish-manifest:
     name: Publish, sign, and attest multi-architecture image
-    if: github.event_name != 'pull_request'
+    if: >-
+      ${{ github.event_name != 'pull_request' &&
+          (github.event_name != 'release' || github.event.release.prerelease == false) }}
     needs:
       - publish-platform
     runs-on: ubuntu-24.04
@@ -166,7 +218,7 @@ jobs:
           tags: |
             type=sha,prefix=sha-,format=long
             type=raw,value=latest,enable=${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && !github.event.release.prerelease) }}
-            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
             type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
 
       - name: Create multi-architecture manifest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,24 +9,62 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: publish-pypi-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Test release build
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'release' && github.event.release.prerelease == false) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require the peeled release tag to equal current main
+        if: github.event_name == 'release' && github.event.release.prerelease == false
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            "refs/heads/main:refs/remotes/origin/main" \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          event_commit="$(git rev-parse --verify "${GITHUB_SHA}^{commit}")"
+          release_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          main_commit="$(git rev-parse --verify "refs/remotes/origin/main^{commit}")"
+          if [ "${event_commit}" != "${release_commit}" ]; then
+            echo "Release event commit ${event_commit} is not peeled tag commit ${release_commit}." >&2
+            exit 1
+          fi
+          if [ "${release_commit}" != "${main_commit}" ]; then
+            echo "Release tag commit ${release_commit} is not current main ${main_commit}." >&2
+            exit 1
+          fi
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
+      - name: Check release metadata
+        run: python scripts/check_release.py
+
+      - name: Refuse occupied PyPI versions
+        if: github.event_name == 'release' && github.event.release.prerelease == false
+        run: python scripts/check_pypi_version.py
+
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Install test dependencies
         run: |
@@ -39,9 +77,6 @@ jobs:
             pyyaml==6.0.3 \
             ruff==0.15.14
           python -m pip install -e packages/schemas -e packages/ravage
-
-      - name: Check release metadata
-        run: python scripts/check_release.py
 
       - name: Check maintained documentation
         run: python scripts/check_docs.py
@@ -117,20 +152,24 @@ jobs:
     needs: test
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Build distribution
         run: |
-          python -m pip install --upgrade pip build
-          python -m build packages/schemas --outdir dist/schemas
+          python -m pip install build==1.6.0 hatchling==1.32.0 twine==7.0.0
+          python -m build --no-isolation packages/schemas --outdir dist/schemas
+          python -m twine check dist/schemas/*
+          python -m pip hash dist/schemas/*
 
       - name: Upload ravage-schemas artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ravage-schemas-dist
           path: dist/schemas/*
@@ -142,17 +181,20 @@ jobs:
     needs: test
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Build distribution
         run: |
-          python -m pip install --upgrade pip build
-          python -m build packages/ravage --outdir dist/ravage
+          python -m pip install build==1.6.0 hatchling==1.32.0 twine==7.0.0
+          python -m build --no-isolation packages/ravage --outdir dist/ravage
+          python -m twine check dist/ravage/*
 
       - name: Verify wheel contract surface
         run: |
@@ -176,10 +218,10 @@ jobs:
               importlib.import_module(f"ravage.control_plane.{module}")
           assert (Path(ravage.__file__).parent / "py.typed").is_file()
           PY
-          sha256sum dist/ravage/*
+          python -m pip hash dist/ravage/*
 
       - name: Upload ravage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ravage-dist
           path: dist/ravage/*
@@ -191,19 +233,19 @@ jobs:
     needs:
       - build-schemas
       - build-ravage
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && github.event.release.prerelease == false
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write # Mint the short-lived production PyPI credential.
     steps:
       - name: Download ravage-schemas artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ravage-schemas-dist
           path: dist/schemas
 
       - name: Publish ravage-schemas
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist/schemas
 
@@ -213,18 +255,18 @@ jobs:
     needs:
       - build-ravage
       - publish-schemas
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && github.event.release.prerelease == false
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write # Mint the short-lived production PyPI credential.
     steps:
       - name: Download ravage artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ravage-dist
           path: dist/ravage
 
       - name: Publish ravage
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist/ravage

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,201 @@
+name: Rehearse TestPyPI Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact unused package version to rehearse
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-testpypi-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build TestPyPI rehearsal artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install the pinned build toolchain
+        run: python -m pip install build==1.6.0 hatchling==1.32.0 twine==7.0.0
+
+      - name: Validate the requested release version
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          python scripts/check_release.py
+          actual_version="$(
+            python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          pyproject = Path("packages/ravage/pyproject.toml")
+          print(tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"])
+          PY
+          )"
+          if [ "${actual_version}" != "${EXPECTED_VERSION}" ]; then
+            echo "Requested ${EXPECTED_VERSION}, but the checkout contains ${actual_version}." >&2
+            exit 1
+          fi
+          python scripts/check_pypi_version.py --index-base https://test.pypi.org/pypi
+
+      - name: Build and validate both distributions
+        run: |
+          set -euo pipefail
+          python -m build --no-isolation packages/schemas --outdir dist/schemas
+          python -m build --no-isolation packages/ravage --outdir dist/ravage
+          python -m twine check dist/schemas/* dist/ravage/*
+          python -m pip hash dist/schemas/* dist/ravage/*
+
+      - name: Upload ravage-schemas rehearsal artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: testpypi-ravage-schemas-dist
+          path: dist/schemas/*
+          if-no-files-found: error
+
+      - name: Upload ravage rehearsal artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: testpypi-ravage-dist
+          path: dist/ravage/*
+          if-no-files-found: error
+
+  publish-schemas:
+    name: Publish ravage-schemas to TestPyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: testpypi
+    permissions:
+      id-token: write # Mint the short-lived TestPyPI publishing credential.
+    steps:
+      - name: Download ravage-schemas rehearsal artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: testpypi-ravage-schemas-dist
+          path: dist/schemas
+
+      - name: Publish ravage-schemas to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/schemas
+
+  publish-ravage:
+    name: Publish ravage to TestPyPI
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish-schemas
+    environment: testpypi
+    permissions:
+      id-token: write # Mint the short-lived TestPyPI publishing credential.
+    steps:
+      - name: Download ravage rehearsal artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: testpypi-ravage-dist
+          path: dist/ravage
+
+      - name: Publish ravage to TestPyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/ravage
+
+  verify:
+    name: Verify the published TestPyPI wheels
+    runs-on: ubuntu-latest
+    needs: publish-ravage
+    timeout-minutes: 15
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Download and install only the published wheels
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          download_dir="$(mktemp -d)"
+          smoke_root="$(mktemp -d)"
+          echo "DOWNLOAD_DIR=${download_dir}" >>"${GITHUB_ENV}"
+          echo "SMOKE_ROOT=${smoke_root}" >>"${GITHUB_ENV}"
+
+          downloaded=false
+          for attempt in $(seq 1 12); do
+            rm -f "${download_dir}"/*.whl
+            if python -m pip download \
+              --index-url https://test.pypi.org/simple/ \
+              --only-binary=:all: \
+              --no-deps \
+              --dest "${download_dir}" \
+              "ravage-schemas==${EXPECTED_VERSION}" \
+              "ravage==${EXPECTED_VERSION}"; then
+              downloaded=true
+              break
+            fi
+            if [ "${attempt}" -lt 12 ]; then
+              sleep 10
+            fi
+          done
+          if [ "${downloaded}" != true ]; then
+            echo "The TestPyPI wheels did not become available in time." >&2
+            exit 1
+          fi
+
+          python -m venv "${smoke_root}/venv"
+          "${smoke_root}/venv/bin/python" -m pip install \
+            --index-url https://pypi.org/simple/ \
+            "cryptography>=42.0" \
+            "pydantic>=2.8" \
+            "PyYAML>=6.0" \
+            "rich>=14.1"
+          "${smoke_root}/venv/bin/python" -m pip install \
+            --no-index --no-deps "${download_dir}"/*.whl
+          "${smoke_root}/venv/bin/python" -m pip check
+
+      - name: Run a bounded model-free installed-wheel smoke test
+        env:
+          RAVAGE_COLOR: never
+        run: |
+          set -euo pipefail
+          ravage_bin="${SMOKE_ROOT}/venv/bin/ravage"
+          cleanup() {
+            "${ravage_bin}" lab down ravage-acme-box >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          cd "${SMOKE_ROOT}"
+          "${ravage_bin}" --help >/dev/null
+          "${ravage_bin}" doctor --json >doctor.json
+          "${ravage_bin}" lab list
+          "${ravage_bin}" lab up ravage-acme-box
+          "${ravage_bin}" init http://127.0.0.1:8088 \
+            --brief brief.yaml \
+            --env-file .env.ravage \
+            --description "Bundled local release smoke target"
+          "${ravage_bin}" scan brief.yaml \
+            --run-dir scan \
+            --probe surface_map \
+            --timeout-seconds 10 \
+            --report
+          "${ravage_bin}" audit verify scan
+          "${ravage_bin}" observe scan --json >observer.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,20 +6,69 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    env:
-      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write # Create releases and update the generated release branch.
+      issues: write # Maintain Release Please issue labels and references.
+      pull-requests: write # Create and update the version pull request.
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
+      - name: Require the release automation token
+        env:
+          TOKEN_CONFIGURED: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          if [ "${TOKEN_CONFIGURED}" != "true" ]; then
+            echo "RELEASE_PLEASE_TOKEN is required; GITHUB_TOKEN cannot trigger downstream release workflows." >&2
+            exit 1
+          fi
+
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: tools/release/release-please-config.json
           manifest-file: tools/release/.release-please-manifest.json
+
+      - name: Check out the generated release PR
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: true # Required for the reviewed lockfile-only push below.
+
+      - name: Set up Python
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Synchronize and validate the release lockfile
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          python -m pip install uv==0.12.5
+          uv lock
+          python scripts/check_release.py
+
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock is already synchronized."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: synchronize release lockfile"
+          git push origin "HEAD:${RELEASE_PR_BRANCH}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ before an entry is described as released.
 
 ## Unreleased
 
+### Added
+
+- Added a request-aware, gray-box HTTP action path for model-driven runs. It
+  reuses session cookies, records redacted request contracts, replays observed
+  request shapes, and links each agent request to durable evidence identifiers.
+- Added evidence-lead locking for validation replays, including authentication
+  pause/reactivation and crash-safe HTTP, traffic, and evidence state.
+- Added lane-aware traffic inspection for runs that contain both base-agent and
+  autonomous-graph histories. Combined output uses qualified identifiers such
+  as `base:rq_0001` and `autonomous_graph:rq_0001`.
+- Added a separate, environment-scoped TestPyPI rehearsal workflow with
+  installed-wheel verification. Repository environment and trusted-publisher
+  configuration remain required before it can be used.
+
+### Security
+
+- Bound evidence-lead replays to their recorded origin, including relative
+  requests, so an auxiliary-service lead cannot drift back to the primary
+  target.
+- Prevented automatic proof capture from accepting request-authored header
+  names or values, including repeatedly percent-encoded variants, as target
+  evidence.
+- Bound report traffic and policy-ledger inputs to the report target and exact
+  engagement scope, with post-load boundary revalidation to close artifact
+  replacement races.
+- Hardened production publication to require an unused version and an exact
+  peeled release-tag commit matching current `main` before either package is
+  built or published.
+- Made Release Please main-only with an explicit automation token, and stopped
+  GitHub prereleases from publishing PyPI packages or Kali image manifests.
+
+### Fixed
+
+- Fixed report generation rejecting the valid two-lane traffic layout produced
+  by a normal base-then-graph run.
+- Made reports fail closed when durable base-agent HTTP state exists without
+  its required traffic history, matching the graph lane's provenance rule.
+
 ### Changed
 
 - Added an opt-in, cost-accounted `hosted-abliteration` model profile using
@@ -19,13 +57,14 @@ before an entry is described as released.
 - Simplified public onboarding and separated current docs from archived plans.
 - Added security reporting, contribution guidance, and repository templates.
 
-## 0.5.0 Source Baseline - 2026-07-11
+## 0.5.0 PyPI Preview - 2026-07-14
 
-`0.5.0` is the current source version and Release Please manifest baseline. It
-was not published as a GitHub tag or PyPI release, so it is not presented as a
-released artifact.
+`ravage==0.5.0` and `ravage-schemas==0.5.0` were published to PyPI without a
+matching GitHub tag or release. The repository later diverged while still
+identifying itself as `0.5.0`, so those immutable artifacts do not represent
+the current source tree and must not be overwritten.
 
-Notable source capabilities at this baseline include:
+Notable capabilities in the source line around that preview included:
 
 - the model-driven agent and deterministic scan paths;
 - local deliberately vulnerable labs;

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ abstract: >-
 repository-code: https://github.com/duriantaco/ravage
 url: https://duriantaco.github.io/ravage/
 license: Apache-2.0
-version: 0.5.0
+version: 0.5.0 # x-release-please-version
 keywords:
   - web security
   - security evaluation

--- a/docs/ai-web-operator-guide.md
+++ b/docs/ai-web-operator-guide.md
@@ -24,6 +24,12 @@ and inside scope.
 Findings are only written after a matching typed probe produces confirmed,
 replayable evidence for the same class, endpoint, and parameter.
 
+The structured HTTP action is request-aware gray-box testing, not white-box
+testing. It follows request templates and typed evidence observed from the
+running application; it does not imply access to source code, server state, or
+internal data. Source-guided workflows apply only when that context is provided
+separately.
+
 HTTP redirects are validated before they are followed. In the optional
 process-capable observe/Docker lane, the runtime records
 `orchestrator/scope_firewall_plan_generated`, applies the container egress
@@ -310,9 +316,25 @@ origin is authorized.
 ## Actions The Model Can Call
 
 The base `ai-web` loop accepts exactly one JSON object per turn. Its public
-action vocabulary is `run_probe`, `run_command`, `run_python`, `validate_poc`,
-`capture_flag`, and `final`. Action-specific fields are top-level; there is no
-generic `args` wrapper:
+action vocabulary is `http_request`, `run_probe`, `run_command`, `run_python`,
+`validate_poc`, `capture_flag`, and `final`. Action-specific fields are
+top-level; there is no generic `args` wrapper. For example, the model can replay
+and mutate an observed form directly:
+
+```json
+{
+  "action": "http_request",
+  "task_id": "<active task id>",
+  "method": "POST",
+  "path": "/search",
+  "headers": {"content-type": "application/x-www-form-urlencoded"},
+  "form": {"q": "bounded test value"},
+  "timeout_seconds": 10,
+  "notes": "preserve the observed search request shape"
+}
+```
+
+A native probe remains a separate action:
 
 ```json
 {
@@ -328,6 +350,11 @@ generic `args` wrapper:
 
 The effective catalog is narrower than the parser vocabulary:
 
+- `http_request` accepts a scoped URL or path and one of `form`, `json`, or
+  textual `body` for methods that allow a body. It preserves one anonymous
+  in-process cookie session, or uses the configured identity's trusted managed
+  owner. Model-authored `Cookie` and `Authorization` overrides remain blocked
+  when a managed identity is active.
 - `run_probe` must select an entry in the current turn's `available_probes`.
 - `validate_poc` replays a short supported control/exploit HTTP sequence. It may
   carry finding metadata, but the executor derives endpoint, proof, and
@@ -340,9 +367,20 @@ The effective catalog is narrower than the parser vocabulary:
 
 A verified `run_probe` result can record a typed finding automatically.
 `report_sqli` and `report_finding` are not public actions; `invalid` is an
-internal parser result, not a model-callable action. Direct `http_*`, `browser_*`,
-scanner-name, and `terminal_*` actions are also not part of the base contract.
-The optional graph uses a separate, profile-dependent tool contract.
+internal parser result, not a model-callable action. Apart from the exact
+`http_request` action, invented `http_*`, `browser_*`, scanner-name, and
+`terminal_*` actions are not part of the base contract. The optional graph uses
+a separate, profile-dependent tool contract.
+
+Observed forms and surface-graph operations are the request templates for
+`http_request`; the agent is instructed to preserve their method, route, body
+location, field names, and active session. When typed evidence creates an
+evidence-lead lock, follow-up dispatches must keep the locked origin, method,
+normalized route, encoding, and affected input locations. Authentication denial
+pauses that exact-route obligation. A real cookie/session change reactivates it,
+while a typed rejection or bounded exhaustion closes it. This reduces guessed
+endpoint and parameter drift; it does not turn a candidate into a finding
+without the normal confirmation gate.
 
 Browser confirmation is reached through an eligible probe such as
 `run_probe dom_execution`, not a direct browser action. In unauthenticated
@@ -567,7 +605,10 @@ Conventional `ravage attack` artifacts under `RUN_DIR`:
   `workspace/transcript.jsonl`;
 - optional process-session records: `workspace/terminal/<session>.jsonl`;
 - larger output artifacts: `workspace/artifacts/`;
-- durable physical-request ledger: `workspace/traffic-policy.json`.
+- durable physical-request ledger: `workspace/traffic-policy.json`;
+- base structured-HTTP state, private traffic, and evidence:
+  `workspace/agent-http-state.json`, `workspace/traffic/`, and
+  `workspace/evidence-blackboard.json`, when the base uses `http_request`.
 
 Canonical JSON finalization is local and does not make model or target requests.
 It atomically replaces an owner-private file. Use `--report` for the additional
@@ -578,8 +619,28 @@ The final `traffic` line and report's `traffic_accounting` object read this
 ledger. `exact` means every target dispatch was metered, `lower bound` means an
 opaque action may have emitted additional traffic, and `unavailable` means the
 ledger is missing or unreadable. If the agent graph starts, its current state
-and events live under `workspace/autonomous-route/agent-graph/`; the root state
-remains the base snapshot.
+and events live under `workspace/autonomous-route/agent-graph/`; its structured
+HTTP state, traffic, and evidence stay in that same nested directory. The root
+state remains the base snapshot, and the two traffic stores are not merged on
+disk.
+
+Inspect either or both automatic HTTP histories from the attack run directory:
+
+```bash
+ravage traffic list RUN_DIR
+ravage traffic show RUN_DIR base:rq_0001
+ravage traffic replay RUN_DIR autonomous_graph:rq_0001
+ravage traffic diff RUN_DIR \
+  autonomous_graph:rq_0001 autonomous_graph:rp_0001
+```
+
+With one traffic lane, the CLI retains short IDs such as `rq_0001`. With both
+base and graph lanes, `list` emits `base:` and `autonomous_graph:` qualified IDs
+because the private stores can reuse their local counters. An unqualified ID is
+accepted only when unique across the run, and `diff` cannot compare records
+from different lane stores. `show` and `diff` are offline; `replay` sends one
+new request under the usual scope and state-change gates. Passing an exact
+manifested workspace path selects only that lane and uses its short local IDs.
 
 Benchmark-run artifacts:
 
@@ -606,6 +667,12 @@ Resume requires the saved traffic-policy ledger and matching configuration. A
 genuinely pre-ledger local/observe workspace with neither a ledger nor its lock
 is migrated once to an observe ledger marked `lower_bound` before target
 traffic; a legacy low-noise workspace without its ledger is rejected.
+
+Structured-HTTP request counts, target bindings, and remote DNS pins survive a
+resume, but anonymous cookie values do not: Ravage never writes the cookie jar
+to disk. A resumed process starts a fresh in-memory session and releases work
+that depended on the old session so the agent must authenticate again. Ravage
+rejects partial or inconsistent HTTP-state, traffic, and evidence artifacts.
 
 Inspect `report.json`, `stdout.log`, `workspace/events.jsonl`, and
 `transcript.jsonl` before resuming so the resumed run has a clear operator

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,12 @@ plan. It distinguishes the **base agent loop** from the optional
 snapshot of the base hybrid proposal/selection loop and its bounded
 specialists; it did not exercise the newer graph or authorized remote runtime.
 
+The structured HTTP path is **request-aware gray-box testing**, not white-box
+testing. It can use request shapes observed from the running application and
+typed evidence produced by Ravage, but it does not assume source-code,
+database, server, or deployment access. Source-guided analysis is a separate
+input when an operator deliberately provides source context.
+
 ## Mental Model
 
 Think of Ravage as five control layers:
@@ -117,9 +123,9 @@ Primary operator commands:
   bounded graph route. Any remote target additionally requires
   `--authorized-remote-target`.
 - `ravage scan`: deterministic DAST without model calls.
-- `ravage traffic`: automatic agent-graph structured HTTP history, optional
-  scoped Playwright capture, redacted inspection, single-request replay, and
-  offline comparison.
+- `ravage traffic`: automatic base and agent-graph structured HTTP history,
+  optional scoped Playwright capture, redacted inspection, single-request
+  replay, and offline comparison.
 - `ravage tools`: tool-runtime list/check helpers. Tool installation lives in
   `scripts/install_tools.sh`.
 - `ravage lab`: local lab management helpers.
@@ -222,11 +228,12 @@ and evidence references.
 
 Automatic production ingestion currently comes from native recon, including
 bounded JavaScript request templates; executor-owned typed probe results,
-including OpenAPI and GraphQL structural findings; and the graph executor's own
-structured HTTP exchanges. Code-level adapters also accept already-fetched
-JavaScript, OpenAPI v2/v3 documents, GraphQL SDL or introspection, typed captured
-exchanges with browser/probe provenance, and strict value-free external
-observation batches. These adapters perform no fetching. Standalone
+including OpenAPI and GraphQL structural findings; and the base and graph
+executors' own structured HTTP exchanges. Code-level adapters also accept
+already-fetched JavaScript, OpenAPI v2/v3 documents, GraphQL SDL or
+introspection, typed captured exchanges with browser/probe provenance, and
+strict value-free external observation batches. These adapters perform no
+fetching. Standalone
 `ravage traffic capture` history and unstructured external-tool stdout are not
 automatically imported into attack state. Strict external batches reject a
 malformed or over-limit batch atomically; captured-exchange and document
@@ -247,11 +254,11 @@ base has no confirmed proof and terminates through model-request or exploration
 exhaustion. A solved base, cost stop, error, or interruption does not
 automatically open more work.
 
-The unauthenticated graph reuses the verified local runtime handoff and can call
-the existing bounded probes, proof validators, command/Python actions, and
-structured HTTP executor under the brief's scope. With a managed identity, its
-execute surface is structured HTTP plus proof capture only; no process executor
-is attached. Its state lives below
+The base loop and unauthenticated graph can call the structured HTTP executor
+under the brief's scope. The graph also reuses the verified local runtime
+handoff for its eligible bounded probes, proof validators, and command/Python
+actions. With a managed identity, its execute surface is structured HTTP plus
+proof capture only; no process executor is attached. Its state lives below
 `workspace/autonomous-route/agent-graph/`, separate from base artifacts.
 
 ## Explicit Authorized Remote Runtime
@@ -344,33 +351,61 @@ ravage traffic replay RUN_DIR REQUEST_ID
 ravage traffic diff RUN_DIR REQUEST_ID REPLAY_ID
 ```
 
-The bounded agent graph uses the same private traffic store without requiring a
-separate `traffic capture` process. Its structured HTTP executor records each
-transport result automatically, including each redirect leg and failures with
-no HTTP status. Redirect legs share one safe observation ID, so their request
-IDs can link back to the same evidence records. Capture is strict at this
-boundary: if the store cannot durably append a request, the action fails before
-its observation can reach evidence promotion.
+The base loop and bounded agent graph record structured HTTP automatically; no
+separate `traffic capture` process is required. Each phase owns a separate
+private traffic store and target-bound evidence blackboard: the base lane lives
+under `workspace/`, and the graph lane lives under
+`workspace/autonomous-route/agent-graph/`. Each executor records every
+transport result, including redirect legs and failures with no HTTP status.
+Redirect legs share one safe observation ID, so their request IDs can link back
+to the same evidence records. Capture is strict at this boundary: if the store
+cannot durably append a request, the action fails before its observation can
+reach evidence promotion.
 
-`ravage traffic list RUN_DIR` and `ravage traffic show RUN_DIR REQUEST_ID`
-discover history below `workspace/autonomous-route/agent-graph/`. They validate
-the target-bound evidence blackboard and join only exact, nonempty observation
-IDs. Their evidence view contains identifiers, kind, source, producer, and
-material status—not evidence payloads or request/response content. Markdown and
-JSON reports include the same request-to-observation-to-evidence links in their
-Agent HTTP Evidence section.
+`ravage traffic list RUN_DIR` discovers and validates both canonical lanes. If
+only one lane exists, short IDs such as `rq_0001` keep working. When both lanes
+exist, output uses qualified IDs because each private store can independently
+contain `rq_0001` or `rp_0001`:
 
-Graph resume reopens the same traffic session and reloads the structured HTTP
-state. The consumed request count and remote DNS pins therefore survive an
-interruption; resume cannot reset the request ceiling or silently accept a new
-address. The owner-only HTTP state stores a one-way target identity rather than
-the raw URL. Resume fails closed if graph state, traffic history, HTTP state,
-captured request counts, or the evidence blackboard no longer agree. For a
-managed identity, the persistent ceiling counts every physical health, login,
-refresh, retry, action, and redirect request; credential-bearing lifecycle
-traffic is not added to operator history, so the persisted physical count may
-be greater than—but never lower than—the captured action count. The request
-store also remains bound to the original target, scope, and capture session.
+```bash
+ravage traffic list RUN_DIR
+ravage traffic show RUN_DIR base:rq_0001
+ravage traffic replay RUN_DIR autonomous_graph:rq_0001
+ravage traffic diff RUN_DIR \
+  autonomous_graph:rq_0001 autonomous_graph:rp_0001
+```
+
+An unqualified ID is accepted only when it identifies one record across all
+discovered lanes. `diff` requires both records to come from the same lane/store.
+Passing an exact manifested workspace path intentionally selects only that lane
+and retains its short local IDs.
+Discovery fails closed if a lane is malformed or if the lane manifests disagree
+on target or scope. The commands validate each lane's evidence blackboard and
+join only exact, nonempty observation IDs. Their evidence view contains
+identifiers, kind, source, producer, and material status—not evidence payloads
+or request/response content. Markdown and JSON reports include the same
+request-to-observation-to-evidence links in their Agent HTTP Evidence section.
+
+Within one running process, anonymous base `http_request` actions share a cookie
+jar; configured identities use their trusted managed-session owner. Ravage does
+not write cookie values to the traffic store or HTTP state. A process-level
+resume therefore reopens the durable lane but starts a new in-memory cookie jar
+and releases session-dependent work so authentication must be re-established.
+Durable request counts, remote DNS pins, target identity, scope, and capture
+session do survive interruption. Resume fails closed if HTTP state, traffic
+history, captured counts, or the adjacent evidence blackboard no longer agree.
+For a managed identity, the persistent ceiling counts every physical health,
+login, refresh, retry, action, and redirect request; credential-bearing
+lifecycle traffic is not added to operator history, so the persisted physical
+count may be greater than—but never lower than—the captured action count.
+
+Observed forms and surface-graph operations act as replay templates. After a
+promising evidence result, the evidence-lead lock can require the same origin,
+method, normalized route, body encoding, and affected input locations for the
+next bounded mutations. An authentication denial pauses that obligation rather
+than sending the agent to an unrelated route; a real session-state change
+reactivates it. This routing discipline keeps follow-up requests tied to the
+observed shape, but it is not itself vulnerability proof.
 
 Manual browser capture comes from an executor-owned adapter around Ravage's
 Playwright context. Routed HTTP(S) navigations, redirects, and subresources are
@@ -438,10 +473,13 @@ isolated environment.
 
 ## Runtime Tools
 
-The base model action contract is `run_command`, `run_python`, `run_probe`,
-`validate_poc`, conditional `capture_flag`, and `final`. Typed HTTP, browser, and
-vulnerability operations sit behind probes and validators; names such as
-`http_get` and `browser_open` are not direct base-model actions.
+The base model action contract is `http_request`, `run_command`, `run_python`,
+`run_probe`, `validate_poc`, conditional `capture_flag`, and `final`.
+`http_request` is a direct, scope-checked base action for replaying or mutating
+an observed request shape through the persistent in-process HTTP session. Typed
+browser and vulnerability-specific operations still sit behind probes and
+validators; names such as `http_get` and `browser_open` are not direct
+base-model actions.
 
 The optional graph has a separate contract. It exposes structured
 `http_request` and, only in a process-capable profile, bounded process actions;
@@ -518,10 +556,12 @@ the ledger is missing or unreadable. Findings, captured proofs, and highest
 outcome stage are separate fields, so a no-flag run can still report
 evidence-backed vulnerabilities.
 
-When agent-graph structured HTTP history is present, report JSON includes an
-`agent_http_evidence` summary and Markdown includes **Agent HTTP Evidence**.
-Both contain identifier-only links; the private traffic and evidence stores
-remain the source of detailed captured metadata.
+When base or agent-graph structured HTTP history is present, report JSON
+includes an `agent_http_evidence` summary and Markdown includes **Agent HTTP
+Evidence**. Report request IDs are lane-qualified, so links remain unambiguous
+when both private stores contain the same local ID. Both report forms contain
+identifier-only links; the private traffic and evidence stores remain the
+source of detailed captured metadata.
 
 ## Safety Model
 
@@ -547,10 +587,10 @@ exploitation.
 
 Important limits still remain:
 
-- `ravage traffic` now covers automatic agent structured HTTP provenance and
-  scoped browser history, replay, and diff, but is not a full Burp/Caido
-  replacement. It has no transparent proxy, interception editor, `curl`/Docker
-  tool/scanner traffic capture, or complete mutation UI.
+- `ravage traffic` now covers automatic base and graph structured HTTP
+  provenance and scoped browser history, replay, and diff, but is not a full
+  Burp/Caido replacement. It has no transparent proxy, interception editor,
+  `curl`/Docker tool/scanner traffic capture, or complete mutation UI.
 - Eligible remote observe-mode browser probes require Playwright. Ravage
   disables the Chrome DevTools fallback remotely because it cannot enforce every
   subresource.
@@ -558,9 +598,9 @@ Important limits still remain:
   rate and concurrency flags must also be chosen to fit the engagement ROE.
 - The whole-run and graph low-noise profiles reduce request rate and variability
   but are not anti-detection systems.
-- Browser cookie state is stable within one process but is not yet restored
-  after a process-level resume. Agent-graph structured HTTP request counts and
-  DNS pins are restored separately.
+- Browser and anonymous structured-HTTP cookie state is stable within one
+  process but is not restored after a process-level resume. Base and graph
+  structured HTTP request counts and DNS pins are restored separately.
 - Provider continuity is not a heterogeneous challenger architecture; workers
   currently use the configured model portfolio rather than independently
   optimized role models.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -31,6 +31,11 @@ The no-model `surface_map` scan is the recommended first check. An included
 lab, observer, agent graph, full probe set, and benchmarks remain
 [optional](#optional-workflows).
 
+Ravage's structured HTTP follow-up is request-aware gray-box testing, not
+white-box testing. It replays and mutates request templates observed from the
+running application and typed Ravage evidence. It does not assume source-code,
+server, database, or deployment access.
+
 ## Install Once
 
 Ravage currently runs from a source checkout. Install Python 3.12, then run:
@@ -289,10 +294,10 @@ Ravage loads `.env.ravage` directly; do not shell-source it.
 
 Authorized remote attacks default to the whole-run low-noise policy. It shares
 one durable physical-request ledger across authentication, recon, probes, PoC
-replay, and structured graph HTTP; defaults to 300 physical requests and 0.5
-requests per second; and disables opaque command, Python, browser-process, and
-external-process actions. Override the conservative limits when the written ROE
-requires less traffic:
+replay, and structured base and graph HTTP; defaults to 300 physical requests
+and 0.5 requests per second; and disables opaque command, Python,
+browser-process, and external-process actions. Override the conservative limits
+when the written ROE requires less traffic:
 
 ```bash
 ravage attack ravage-brief.yaml \
@@ -330,9 +335,10 @@ snapshot is not silently rewritten. Native recon and JavaScript discovery feed
 the base graph. OpenAPI, GraphQL, built-in probes, and strict value-free external
 observation batches contribute when those typed results pass through an
 executor-owned native probe. The graph route also imports its own typed captured
-HTTP exchanges. Standalone `ravage traffic capture` history is not automatically
-merged into either attack snapshot. Query/body/header values and response bodies
-are omitted from the graph.
+HTTP exchanges, while base `http_request` exchanges update the base snapshot.
+Standalone `ravage traffic capture` history is not automatically merged into
+either attack snapshot. Query/body/header values and response bodies are omitted
+from the graph.
 
 For a remote target, `--authorized-remote-target` is mandatory. HTTP requests,
 redirects, and routed HTTP(S) browser subresources are checked at URL scope.
@@ -399,12 +405,16 @@ Every attack writes these main outputs:
 - `RUN_DIR/workspace/transcript.jsonl`: model and tool transcript;
 - `RUN_DIR/workspace/traffic-policy.json`: durable physical-request ledger;
 - `RUN_DIR/workspace/working_state.json`: base state and surface-graph snapshot;
+- `RUN_DIR/workspace/agent-http-state.json`, `traffic/`, and
+  `evidence-blackboard.json`: private base structured-HTTP artifacts, when used;
 - `RUN_DIR/workspace/artifacts/`: larger captured artifacts.
 
 If the bounded agent graph starts, its current state and events live below
 `RUN_DIR/workspace/autonomous-route/agent-graph/`. The base and graph state files
 use the same surface-graph schema, but the nested graph snapshot can advance
-beyond the retained base snapshot.
+beyond the retained base snapshot. The graph's HTTP state, traffic store, and
+evidence blackboard also live below that nested directory; Ravage keeps the two
+lane stores separate on disk.
 
 Verify the audit chain:
 
@@ -427,23 +437,43 @@ ravage report RUN_DIR --brief ravage-brief.yaml
 
 ### Inspect automatic agent HTTP evidence
 
-If the attack enters the bounded `agent-graph` route, its structured HTTP
-requests are captured automatically; do not start a separate browser capture.
-The history includes every followed redirect as its own request and records
-transport-failure metadata when no HTTP status is available. The normal traffic
-commands discover the nested graph workspace from the printed attack run:
+Base `http_request` actions and bounded `agent-graph` structured HTTP actions
+are captured automatically; do not start a separate browser capture for them.
+Each lane has its own private traffic and evidence store. The histories include
+every followed redirect as its own request and record transport-failure metadata
+when no HTTP status is available. The normal traffic commands discover both
+lanes from the printed attack run:
 
 ```bash
 ravage traffic list RUN_DIR
-ravage traffic show RUN_DIR REQUEST_ID
+ravage traffic show RUN_DIR base:rq_0001
+ravage traffic replay RUN_DIR autonomous_graph:rq_0001
+ravage traffic diff RUN_DIR \
+  autonomous_graph:rq_0001 autonomous_graph:rp_0001
 ```
+
+If only one lane exists, short IDs such as `rq_0001` keep working. When both
+lanes exist, `list` emits `base:` and `autonomous_graph:` qualified IDs because
+both stores can contain the same local ID. An unqualified ID is accepted only
+when it is unique across the run. Replay stays in the selected lane, and `diff`
+requires both records to come from that same lane/store. Pass the exact
+manifested workspace path when you deliberately want to inspect only one lane
+with its short local IDs.
 
 Human output shows link status and counts. Add `--json` for stable fields such
 as `observation_id`, `evidence_refs`, and `material_evidence_refs`. These are
 identifier-only joins to the validated evidence blackboard: evidence payloads,
 request values, and response bodies are not copied into CLI output. The
 Markdown report has an **Agent HTTP Evidence** section, and `report.json` has
-the corresponding `agent_http_evidence` object.
+the corresponding `agent_http_evidence` object. Report links are also
+lane-qualified so local request-ID collisions are unambiguous.
+
+Report finalization binds every traffic lane and traffic-policy ledger to the
+report target and the brief's exact scope, so a history copied from another
+engagement is rejected. For an older run whose saved target contains redacted
+query values or normalized path placeholders, omit `--target-url` and let
+`ravage report` use that run's persisted-safe target; the original raw target
+identity cannot be reconstructed from a legacy artifact.
 
 Agent capture is part of the evidence boundary. If Ravage cannot durably save a
 structured agent request, that action fails before its observation can be
@@ -628,7 +658,7 @@ Use `ravage traffic` when you want a short, operator-driven request history
 without starting an attack or spending model credits. For a local application:
 
 This manual Playwright workflow is separate from the automatic structured-HTTP
-history produced by an `agent-graph` attack.
+history produced by base and `agent-graph` attack actions.
 
 This workflow currently requires macOS, Linux, or WSL because its private
 artifact permissions and cross-process locks rely on POSIX filesystem
@@ -830,9 +860,13 @@ lane uses `--tool-runtime docker`. An authenticated remote resume keeps the
 same `--identity` and does not need Docker. Do not reuse an old
 run directory for a fresh attack; leave `--run-dir` unset and let Ravage create
 a timestamped one. Deterministic scans do not use this attack-resume flow.
-For an `agent-graph` resume, Ravage reopens the same traffic session and reloads
-the structured HTTP request count and DNS pins, so interruption cannot reset the
-request ceiling or silently resolve a different destination.
+For base and `agent-graph` structured HTTP, Ravage reopens each durable traffic
+lane and reloads its request count and DNS pins, so interruption cannot reset
+the request ceiling or silently resolve a different destination. Anonymous
+cookie values are deliberately never written to disk: a resumed process starts
+a new in-memory cookie jar and releases work tied to the old session so the
+agent must authenticate again. Partial or inconsistent HTTP-state, traffic, and
+evidence artifacts fail closed.
 The base agent reopens the same `workspace/traffic-policy.json` ledger as well,
 so authentication, recon, native probes, PoC replay, and graph HTTP retain one
 physical-request total across the resume. An eligible opaque process action in

--- a/packages/ravage/pyproject.toml
+++ b/packages/ravage/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "ravage"
-version = "0.5.0"
+version = "0.5.0" # x-release-please-version
 description = "Autonomous web security research agent for controlled authorized targets"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "ravage-schemas==0.5.0",
+    "ravage-schemas==0.5.0", # x-release-please-version
     "pyyaml>=6.0",
     "cryptography>=42.0",
     "rich>=14.1",

--- a/packages/ravage/src/ravage/agent_core/action_executor.py
+++ b/packages/ravage/src/ravage/agent_core/action_executor.py
@@ -8,12 +8,13 @@ import threading
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, TextIO, cast
-from urllib.parse import parse_qsl, unquote_plus, urljoin, urlsplit, urlunsplit
+from typing import TYPE_CHECKING, Any, Protocol, TextIO, cast
+from urllib.parse import parse_qsl, unquote, urljoin, urlsplit, urlunsplit
 from uuid import UUID, uuid5
 
 from ravage.agent_core.agent_state import AgentState, append_unique, merge_signals
 from ravage.agent_core.agent_strategy import observation_digest
+from ravage.agent_core.evidence_lead_lock import remember_from_probe_result
 from ravage.agent_core.live_events import (
     PROBE_HTTP_EVENT_PREFIX,
     http_step_payload,
@@ -22,9 +23,11 @@ from ravage.agent_core.live_events import (
 )
 from ravage.agent_core.observation_analysis import (
     classify_action_result,
+    extract_http_discovery_signals,
     extract_probe_signals,
     extract_signals,
 )
+from ravage.agent_core.surface_graph import SurfaceGraphError
 from ravage.agent_core.surface_graph_ingest import ingest_probe_result, project_surface_graph
 from ravage.auth.sessions import AuthenticationError
 from ravage.finding_evidence import confirmed_finding_evidence_failures
@@ -45,8 +48,11 @@ from ravage.run_data.audit import AuditStore
 from ravage.run_data.workspace import AgentWorkspace
 from ravage.runtime import ToolResult, ToolRuntime
 from ravage.traffic.policy import TrafficPolicyBlocked, TrafficPolicyController
+from ravage.traffic.redaction import redact_text as redact_traffic_text
+from ravage.traffic.redaction import sanitize_url
 from ravage.web_core.poc_validator import ValidationResult, validate_http_poc
 from ravage.web_core.proof_recognizer import is_placeholder_proof, recognize_proofs
+from ravage.web_core.recon import parse_passive_recon_document
 from ravage.web_core.scope_policy import same_origin, url_in_scope_entries
 
 if TYPE_CHECKING:
@@ -170,6 +176,26 @@ class ActionResult:
         return payload
 
 
+class HttpActionExecution(Protocol):
+    """Structural result returned by the scoped structured-HTTP executor."""
+
+    @property
+    def result(self) -> ActionResult: ...
+
+    @property
+    def observation_id(self) -> str: ...
+
+
+class HttpActionExecutor(Protocol):
+    def __call__(
+        self,
+        *,
+        node_id: str,
+        arguments: dict[str, object],
+        action_id: str,
+    ) -> HttpActionExecution: ...
+
+
 @dataclass(frozen=True)
 class _ProbeActionResult:
     text: str
@@ -180,7 +206,7 @@ class _ProbeActionResult:
 ProbeProgressSink = Callable[[dict[str, object]], None]
 
 
-def execute_action(  # noqa: PLR0913
+def execute_action(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0915
     action: dict[str, object],
     *,
     target_url: str,
@@ -196,6 +222,7 @@ def execute_action(  # noqa: PLR0913
     action_id: str = "",
     authentication: ManagedAttackAuthentication | None = None,
     traffic_policy: TrafficPolicyController | None = None,
+    http_executor: HttpActionExecutor | None = None,
 ) -> ActionResult:
     if authentication is not None:
         authentication.assert_traffic_policy(traffic_policy)
@@ -218,7 +245,7 @@ def execute_action(  # noqa: PLR0913
             action_id=action_id,
         )
     if (
-        kind in {"run_command", "run_python", "run_probe", "validate_poc"}
+        kind in {"http_request", "run_command", "run_python", "run_probe", "validate_poc"}
         and repeat_count > MAX_IDENTICAL_ACTION_EXECUTIONS
     ):
         return _repeated(
@@ -240,6 +267,54 @@ def execute_action(  # noqa: PLR0913
         )
         if blocked is not None:
             return blocked
+    if kind == "http_request":
+        if http_executor is None:
+            return _http_request_unavailable(
+                workspace=workspace,
+                audit=audit,
+                engagement_id=engagement_id,
+                action_id=action_id,
+            )
+        from ravage.agent_core.stateful_http import request_arguments  # noqa: PLC0415
+
+        try:
+            execution = http_executor(
+                node_id="base-agent",
+                arguments=request_arguments(action),
+                action_id=action_id,
+            )
+        except ValueError as exc:
+            safe_error = (
+                authentication.redact_text(str(exc))
+                if authentication is not None
+                else str(exc)
+            )
+            return _http_request_blocked(
+                error=safe_error,
+                workspace=workspace,
+                audit=audit,
+                engagement_id=engagement_id,
+                action_id=action_id,
+                session_mode=(
+                    f"identity:{authentication.identity}" if authentication is not None else ""
+                ),
+            )
+        return _record_http_action_result(
+            execution,
+            action=action,
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=engagement_id,
+            proof_recognition_enabled=proof_recognition_enabled,
+            action_id=action_id,
+            repeat_count=repeat_count,
+            max_observation_chars=max_observation_chars,
+            max_transcript_chars=max_transcript_chars,
+            session_mode=(
+                f"identity:{authentication.identity}" if authentication is not None else ""
+            ),
+        )
     if kind == "run_command":
         tool_result = runtime.run_command(
             command=str(action.get("command") or "").strip(),
@@ -359,7 +434,7 @@ def execute_action(  # noqa: PLR0913
             session_mode=session_mode,
             authentication=authentication,
         )
-        return record_verified_probe_findings(
+        verified_result = record_verified_probe_findings(
             probe=probe,
             probe_text=probe_result.text,
             result=result,
@@ -370,9 +445,26 @@ def execute_action(  # noqa: PLR0913
             engagement_id=engagement_id,
             action_id=action_id,
         )
+        if state.surface.get("flag_objective") is True and not verified_result.stop:
+            remember_from_probe_result(
+                state,
+                probe_result.text,
+                {**action, "target_url": target_url},
+                str(state.last_observation.get("observation_id") or ""),
+            )
+        return verified_result
     if kind == "validate_poc":
         session_mode = f"identity:{authentication.identity}" if authentication is not None else ""
         poc_session: ProbeSession | None = None
+        persistent_request = getattr(http_executor, "request", None)
+        if not callable(persistent_request):
+            persistent_request = None
+        begin_validation = getattr(http_executor, "begin_validation", None)
+        consume_validation_proofs = getattr(
+            http_executor,
+            "consume_validation_proofs",
+            None,
+        )
 
         def _emit_http_step(info: dict[str, object]) -> None:
             index_value = info.get("index")
@@ -422,8 +514,11 @@ def execute_action(  # noqa: PLR0913
             workspace.record_event(kind="http_step", payload=payload)
 
         poc_timeout = _timeout(action.get("timeout_seconds")) or 10
+        if persistent_request is not None and callable(begin_validation):
+            begin_validation()
+        executor_recognized_proofs: Sequence[str] = ()
         try:
-            if authentication is not None:
+            if authentication is not None and persistent_request is None:
                 poc_session = authentication.session_for_model_action(
                     timeout_seconds=poc_timeout
                 )
@@ -437,16 +532,23 @@ def execute_action(  # noqa: PLR0913
                 out_of_scope=_surface_string_list(state, "scope_out_of_scope"),
                 max_rps=_surface_int(state, "scope_max_rps"),
                 session=poc_session,
+                request=persistent_request,
                 redact=(authentication.redact if authentication is not None else None),
                 traffic_policy_reference=(
                     traffic_policy.to_reference()
-                    if traffic_policy is not None and poc_session is None
+                    if traffic_policy is not None
+                    and poc_session is None
+                    and persistent_request is None
                     else None
                 ),
             )
         finally:
-            if authentication is not None and poc_session is not None:
-                authentication.retire_probe_session(poc_session)
+            try:
+                if authentication is not None and poc_session is not None:
+                    authentication.retire_probe_session(poc_session)
+            finally:
+                if persistent_request is not None and callable(consume_validation_proofs):
+                    executor_recognized_proofs = consume_validation_proofs()
         validation_text = validation_result.to_text()
         safe_action: Mapping[str, object] = action
         if authentication is not None:
@@ -472,6 +574,7 @@ def execute_action(  # noqa: PLR0913
             max_transcript_chars=max_transcript_chars,
             session_mode=session_mode,
             authentication=authentication,
+            executor_recognized_proofs=executor_recognized_proofs,
         )
         finding = safe_action.get("finding")
         if finding is None:
@@ -569,6 +672,50 @@ def _invalid(
         observation="Invalid action. Return exactly one JSON object matching the action schema. "
         f"Error: {error}",
         outcome="blocked",
+    )
+
+
+def _http_request_unavailable(
+    *,
+    workspace: AgentWorkspace,
+    audit: AuditStore,
+    engagement_id: UUID,
+    action_id: str,
+) -> ActionResult:
+    return _http_request_blocked(
+        error="structured HTTP executor is unavailable for this agent route",
+        workspace=workspace,
+        audit=audit,
+        engagement_id=engagement_id,
+        action_id=action_id,
+    )
+
+
+def _http_request_blocked(  # noqa: PLR0913
+    *,
+    error: str,
+    workspace: AgentWorkspace,
+    audit: AuditStore,
+    engagement_id: UUID,
+    action_id: str,
+    session_mode: str = "",
+) -> ActionResult:
+    payload: dict[str, object] = {
+        "ok": False,
+        "action_id": action_id,
+        "error": error,
+        "outcome": "blocked",
+    }
+    if session_mode:
+        payload["session_mode"] = session_mode
+    _record(audit, engagement_id, actor="tool", action="tool_http_request", payload=payload)
+    workspace.record_event(kind="tool_http_request", payload=payload)
+    return ActionResult(
+        ok=False,
+        observation=json.dumps(payload, sort_keys=True),
+        outcome="blocked",
+        session_mode=session_mode,
+        evidence_source_kind="tool_http_request_blocked",
     )
 
 
@@ -955,7 +1102,7 @@ def _record_validated_finding(  # noqa: PLR0913
             source_observation_id=source_observation_id,
         )
 
-    return _persist_confirmed_finding(
+    persisted = _persist_confirmed_finding(
         payload,
         result=result,
         state=state,
@@ -963,6 +1110,14 @@ def _record_validated_finding(  # noqa: PLR0913
         audit=audit,
         engagement_id=engagement_id,
     )
+    if state.surface.get("flag_objective") is True and not persisted.stop:
+        remember_from_probe_result(
+            state,
+            json.dumps(payload, sort_keys=True),
+            action,
+            source_observation_id,
+        )
+    return persisted
 
 
 def record_verified_probe_findings(  # noqa: C901, PLR0912, PLR0913
@@ -1570,7 +1725,7 @@ def _paired_replay_evidence(
         failures.append("control and exploit replay inputs are identical")
     control_shape = _replay_input_shape(control_raw, target_url=target_url)
     exploit_shape = _replay_input_shape(exploit_raw, target_url=target_url)
-    if control_shape and exploit_shape and control_shape != exploit_shape:
+    if control_shape != exploit_shape:
         failures.append("control and exploit replays must vary the same input shape")
     if not _security_relevant_response_delta(control, exploit):
         failures.append("control and exploit responses lack a security-relevant differential")
@@ -1714,11 +1869,30 @@ def _path_traversal_replay_failures(
 
 
 def _decoded_replay_request_text(step: Mapping[str, object]) -> str:
-    parts = [str(step.get("url") or ""), str(step.get("body") or "")]
+    parts: list[str] = []
+    location = _replay_step_location(step)
+    try:
+        parsed = urlsplit(location)
+        parts.append(unquote(parsed.path))
+        parts.extend(
+            f"{name}={value}"
+            for name, value in parse_qsl(parsed.query, keep_blank_values=True)
+        )
+    except ValueError:
+        parts.append(location)
     form = step.get("form")
     if isinstance(form, Mapping):
         parts.extend(f"{name}={value}" for name, value in form.items())
-    return unquote_plus("\n".join(parts))
+    body = step.get("body")
+    if body is not None:
+        if _replay_content_type(step) == "application/x-www-form-urlencoded":
+            parts.extend(
+                f"{name}={value}"
+                for name, value in parse_qsl(str(body), keep_blank_values=True)
+            )
+        else:
+            parts.append(str(body))
+    return "\n".join(parts)
 
 
 def _sql_injection_input_markers(value: str) -> frozenset[str]:
@@ -1819,9 +1993,8 @@ def _same_replay_endpoint(
 
 
 def _replay_material(step: Mapping[str, object]) -> str:
-    material = {
-        key: step.get(key) for key in ("method", "url", "form", "body", "headers") if key in step
-    }
+    material = {key: step.get(key) for key in ("method", "form", "body", "headers") if key in step}
+    material["url"] = _replay_step_location(step)
     return json.dumps(material, sort_keys=True, default=str, separators=(",", ":"))
 
 
@@ -1830,18 +2003,16 @@ def _replay_input_shape(
     *,
     target_url: str,
 ) -> tuple[str, ...]:
-    names: set[str] = set()
-    raw_url = urljoin(target_url, str(step.get("url") or ""))
+    names: list[str] = []
+    raw_url = urljoin(target_url, _replay_step_location(step))
     for name, _value in parse_qsl(urlsplit(raw_url).query, keep_blank_values=True):
-        names.add(f"query:{name}")
-    form = step.get("form")
-    if isinstance(form, Mapping):
-        names.update(f"body:{name}" for name in form)
-    if step.get("body") is not None:
-        names.add("body:raw")
+        names.append(f"query:{name}")
+    names.extend(
+        f"body:{name}" for name, _value in _replay_body_parameter_values(step)
+    )
     headers = step.get("headers")
     if isinstance(headers, Mapping):
-        names.update(f"header:{str(name).lower()}" for name in headers)
+        names.extend(f"header:{str(name).lower()}" for name in headers)
     return tuple(sorted(names))
 
 
@@ -1944,24 +2115,64 @@ def _replay_parameter_values(
     target_url: str,
 ) -> dict[tuple[str, str], tuple[str, ...]]:
     values: dict[tuple[str, str], list[str]] = {}
-    raw_url = urljoin(target_url, str(step.get("url") or ""))
+    raw_url = urljoin(target_url, _replay_step_location(step))
     for name, value in parse_qsl(urlsplit(raw_url).query, keep_blank_values=True):
         values.setdefault(("query", name.strip()[:120]), []).append(value)
-    form = step.get("form")
-    if isinstance(form, Mapping):
-        for name, value in form.items():
-            values[("body", str(name).strip()[:120])] = [str(value)]
-    if step.get("body") is not None:
-        values[("body", "raw_body")] = [str(step.get("body"))]
+    for name, value in _replay_body_parameter_values(step):
+        values.setdefault(("body", name.strip()[:120]), []).append(value)
     headers = step.get("headers")
     if isinstance(headers, Mapping):
         for name, value in headers.items():
             values[("header", str(name).strip().lower()[:120])] = [str(value)]
-    return {
-        key: tuple(items)
-        for key, items in values.items()
-        if key[1]
-    }
+    return {key: tuple(items) for key, items in values.items() if key[1]}
+
+
+def _replay_body_parameter_values(step: Mapping[str, object]) -> list[tuple[str, str]]:
+    form = step.get("form")
+    if isinstance(form, Mapping):
+        return [(str(name), str(value)) for name, value in form.items()]
+    body = step.get("body")
+    if body is None:
+        return []
+    content_type = _replay_content_type(step)
+    if content_type == "application/x-www-form-urlencoded":
+        text = str(body)
+        pairs = parse_qsl(text, keep_blank_values=True)
+        if (text and not pairs) or any(not name.strip() for name, _value in pairs):
+            return [("raw_body", text)]
+        return [(name, value) for name, value in pairs]
+    if content_type == "application/json" or content_type.endswith("+json"):
+        pairs = _raw_json_object_pairs(body)
+        if pairs is not None:
+            return [
+                (str(name), json.dumps(value, sort_keys=True, separators=(",", ":")))
+                for name, value in pairs
+            ]
+    return [("raw_body", str(body))]
+
+
+def _raw_json_object_pairs(value: object) -> tuple[tuple[str, object], ...] | None:
+    try:
+        decoded = json.loads(str(value), object_pairs_hook=lambda pairs: tuple(pairs))
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(decoded, tuple):
+        return None
+    return tuple((str(name), item) for name, item in decoded)
+
+
+def _replay_content_type(step: Mapping[str, object]) -> str:
+    headers = step.get("headers")
+    if not isinstance(headers, Mapping):
+        return ""
+    for name, value in headers.items():
+        if str(name).strip().casefold() == "content-type":
+            return str(value).split(";", 1)[0].strip().casefold()
+    return ""
+
+
+def _replay_step_location(step: Mapping[str, object]) -> str:
+    return str(step.get("url") or step.get("path") or "")
 
 
 def _finding_url_in_scope(url: str, *, target_url: str, audit: AuditStore) -> bool:
@@ -1995,28 +2206,22 @@ def _canonical_endpoint_url(url: str) -> str:
 
 def _endpoint_params(url: str, *, raw_step: Mapping[str, object]) -> list[dict[str, str]]:
     params: list[dict[str, str]] = []
-    seen: set[tuple[str, str]] = set()
     for name, _value in parse_qsl(urlsplit(url).query, keep_blank_values=True):
-        _append_endpoint_param(params, seen=seen, name=name, location="query")
-    form = raw_step.get("form")
-    if isinstance(form, Mapping):
-        for name in form:
-            _append_endpoint_param(params, seen=seen, name=str(name), location="body")
+        _append_endpoint_param(params, name=name, location="query")
+    for name, _value in _replay_body_parameter_values(raw_step):
+        _append_endpoint_param(params, name=name, location="body")
     return params[:32]
 
 
 def _append_endpoint_param(
     params: list[dict[str, str]],
     *,
-    seen: set[tuple[str, str]],
     name: str,
     location: str,
 ) -> None:
     clean_name = name.strip()[:120]
-    key = (clean_name, location)
-    if not clean_name or key in seen:
+    if not clean_name:
         return
-    seen.add(key)
     params.append({"name": clean_name, "location": location})
 
 
@@ -2288,6 +2493,217 @@ def _record_tool_result(  # noqa: PLR0913
     )
 
 
+def _record_http_action_result(  # noqa: PLR0913
+    execution: HttpActionExecution,
+    *,
+    action: Mapping[str, object],
+    state: AgentState,
+    workspace: AgentWorkspace,
+    audit: AuditStore,
+    engagement_id: UUID,
+    proof_recognition_enabled: bool,
+    action_id: str,
+    repeat_count: int,
+    max_observation_chars: int,
+    max_transcript_chars: int,
+    session_mode: str = "",
+) -> ActionResult:
+    result = execution.result
+    if not isinstance(result, ActionResult):
+        raise TypeError("structured HTTP executor must return ActionResult")
+    observation_id = str(execution.observation_id or uuid.uuid4())
+    evidence_text = result.evidence_observation or result.observation
+    transcript_text = _clip_probe_text(evidence_text, max_chars=max_transcript_chars)
+    response_payload = _http_response_payload(evidence_text)
+    response_text = _http_response_signal_text(response_payload)
+    # The evidence envelope also contains the model-authored request. Trust only
+    # the executor's response-body recognizer so an echoed request value cannot
+    # manufacture a proof candidate.
+    recognized_proofs = [result.flag] if result.flag else []
+    payload: dict[str, object] = {
+        "ok": result.ok,
+        "repeat_count": repeat_count,
+        "result": transcript_text,
+        "action_id": action_id,
+        "observation_id": observation_id,
+        "outcome": result.outcome,
+        "recognized_proofs": recognized_proofs,
+    }
+    if session_mode:
+        payload["session_mode"] = session_mode
+    _record_tool_payload(
+        payload,
+        kind="tool_http_request",
+        workspace=workspace,
+        audit=audit,
+        engagement_id=engagement_id,
+    )
+    # Keep the complete executor envelope in the durable transcript, but derive
+    # working-memory signals only from the target response. The envelope also
+    # contains model-authored request fields and therefore is not evidence that
+    # a route, parameter, marker, or proof was observed from the target.
+    state.last_observation = _observation_digest_with_source(
+        response_text,
+        observation_id=observation_id,
+        source_kind="tool_http_request",
+        recognized_proofs=recognized_proofs,
+    )
+    state.last_observation["http_response"] = _http_response_memory(response_payload)
+    workspace.record_transcript(role="tool", content=transcript_text)
+    if _passive_http_discovery_allowed(action, response_payload):
+        _ingest_passive_http_response(
+            response_payload,
+            state=state,
+            observation_id=observation_id,
+            identity_alias=_probe_identity_alias(session_mode),
+        )
+        merge_signals(state, extract_http_discovery_signals(response_text))
+    known_proof_replayed = _only_known_auto_capture_proofs(
+        evidence_text,
+        enabled=proof_recognition_enabled,
+        state=state,
+        recognized_proofs=recognized_proofs,
+    )
+    found = _capture_recognized_proof(
+        evidence_text,
+        enabled=proof_recognition_enabled,
+        state=state,
+        workspace=workspace,
+        audit=audit,
+        engagement_id=engagement_id,
+        evidence="tool_http_request",
+        action_id=action_id,
+        recognized_proofs=recognized_proofs,
+    )
+    outcome = result.outcome or ("http_response_observed" if result.ok else "blocked")
+    if found:
+        outcome = "flag_candidate"
+    elif known_proof_replayed:
+        outcome = "same_as_before"
+    return _action_result_from_observation(
+        ok=result.ok,
+        repeat_count=repeat_count,
+        text=_clip_probe_text(result.observation, max_chars=max_observation_chars),
+        max_observation_chars=max_observation_chars,
+        outcome=outcome,
+        stop=bool(found),
+        flag=found,
+        timed_out=result.timed_out,
+        evidence_source_kind="tool_http_request",
+        evidence_observation=evidence_text,
+        session_mode=session_mode,
+    )
+
+
+def _http_response_payload(evidence_text: str) -> dict[str, object]:
+    """Return the executor-owned response while excluding the authored request."""
+    try:
+        envelope = json.loads(evidence_text)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(envelope, Mapping):
+        return {}
+    response = envelope.get("response")
+    if not isinstance(response, Mapping):
+        return {}
+    return {str(key): value for key, value in response.items()}
+
+
+def _http_response_signal_text(response: Mapping[str, object]) -> str:
+    """Return only executor-owned target response content for signal extraction."""
+    body = response.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def _http_response_memory(response: Mapping[str, object]) -> dict[str, object]:
+    headers_value = response.get("headers")
+    headers = dict(headers_value) if isinstance(headers_value, Mapping) else {}
+    status = response.get("status")
+    return {
+        "status": (
+            status
+            if isinstance(status, int) and not isinstance(status, bool)
+            else None
+        ),
+        "final_url": sanitize_url(response.get("final_url")),
+        "headers": mask_headers(headers),
+        "header_names": sorted(str(name).casefold() for name in headers)[:32],
+        "set_cookie": any(str(name).casefold() == "set-cookie" for name in headers),
+        "truncated": response.get("truncated") is True,
+        "error": redact_traffic_text(response.get("error"), max_chars=300),
+    }
+
+
+def _passive_http_discovery_allowed(
+    action: Mapping[str, object],
+    response: Mapping[str, object],
+) -> bool:
+    """Admit structure only from a clean navigation response, never a mutation echo."""
+    if str(action.get("method") or "GET").strip().upper() != "GET":
+        return False
+    if any(action.get(name) is not None for name in ("body", "form", "json")):
+        return False
+    authored_headers = action.get("headers")
+    if isinstance(authored_headers, Mapping) and authored_headers:
+        return False
+    requested = str(action.get("url") or action.get("path") or "").strip()
+    final_url = str(response.get("final_url") or "").strip()
+    try:
+        requested_parts = urlsplit(requested)
+        urlsplit(final_url)
+    except ValueError:
+        return False
+    # Query/path payloads are commonly reflected. Restrict passive parsing to a
+    # static navigation shape; the response remains visible but cannot teach
+    # the planner attacker-authored forms or fields.
+    if (
+        requested_parts.query
+        or requested_parts.fragment
+        or not re.fullmatch(r"[A-Za-z0-9._~/-]*", requested_parts.path or "/")
+    ):
+        return False
+    status = response.get("status")
+    return isinstance(status, int) and not isinstance(status, bool) and 200 <= status < 300
+
+
+def _ingest_passive_http_response(
+    response: Mapping[str, object],
+    *,
+    state: AgentState,
+    observation_id: str,
+    identity_alias: str,
+) -> None:
+    final_url = str(response.get("final_url") or "").strip()
+    body = response.get("body")
+    headers_value = response.get("headers")
+    if not final_url or not isinstance(body, str) or not isinstance(headers_value, Mapping):
+        return
+    headers = {str(name): str(value) for name, value in headers_value.items()}
+    document = parse_passive_recon_document(final_url, headers, body)
+    for operation in document.operations:
+        try:
+            state.surface_graph.add(
+                url=operation.url,
+                method=operation.method,
+                parameters=(
+                    {"name": parameter.name, "location": parameter.location}
+                    for parameter in operation.parameters
+                ),
+                header_names=operation.header_names,
+                hints=operation.hints,
+                source_kind=operation.source_kind,
+                identity_alias=identity_alias,
+                access_level="declared",
+                response_status=None,
+                scope_decision="unknown",
+                evidence_refs=(observation_id,),
+            )
+        except SurfaceGraphError:
+            # Cross-origin or malformed declarations are not part of this target.
+            continue
+    state.surface = project_surface_graph(state.surface_graph, state.surface)
+
+
 def _tool_result_payload(
     result: ToolResult,
     *,
@@ -2361,13 +2777,29 @@ def record_probe_result(  # noqa: PLR0913
     max_transcript_chars: int,
     session_mode: str = "",
     authentication: ManagedAttackAuthentication | None = None,
+    executor_recognized_proofs: Sequence[str] = (),
 ) -> ActionResult:
     observation_id = str(uuid.uuid4())
-    recognized_proofs = _probe_recognized_proofs(
-        text,
-        kind=kind,
+    # The PoC validator summary contains model-authored expectations such as
+    # ``expect_contains``. Proofs from that synthesized JSON are not target
+    # evidence; only the HTTP executor may attest proofs observed while replaying
+    # validator steps. Native probe output remains eligible for normal scanning.
+    scanned_proofs = (
+        []
+        if kind == "tool_validate_poc"
+        else _probe_recognized_proofs(
+            text,
+            kind=kind,
+            authentication=authentication,
+            known_proofs=state.flags,
+        )
+    )
+    recognized_proofs = _trusted_executor_proofs(
+        executor_recognized_proofs,
         authentication=authentication,
-        known_proofs=state.flags,
+    )
+    recognized_proofs.extend(
+        proof for proof in scanned_proofs if proof not in recognized_proofs
     )
     if kind == "tool_run_probe":
         _ingest_probe_surface_graph(
@@ -2657,6 +3089,23 @@ def _probe_recognized_proofs(
     # so an earlier known token cannot hide later evidence.
     known = {str(proof) for proof in known_proofs}
     return [next((proof for proof in candidates if proof not in known), candidates[0])]
+
+
+def _trusted_executor_proofs(
+    values: Sequence[str],
+    *,
+    authentication: ManagedAttackAuthentication | None,
+) -> list[str]:
+    proofs: list[str] = []
+    for value in values[:12]:
+        proof = str(value).strip()
+        if not proof or proof not in recognize_proofs(proof):
+            continue
+        if authentication is not None and authentication.contains_secret(proof):
+            continue
+        if proof not in proofs:
+            proofs.append(proof)
+    return proofs
 
 
 def _structured_finding_proofs(text: str) -> list[str]:

--- a/packages/ravage/src/ravage/agent_core/action_parser.py
+++ b/packages/ravage/src/ravage/agent_core/action_parser.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 VALID_ACTIONS = {
+    "http_request",
     "run_command",
     "run_python",
     "run_probe",
@@ -13,6 +14,10 @@ VALID_ACTIONS = {
     "final",
     "invalid",
 }
+
+_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"})
+_BODYLESS_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_MAX_VALIDATE_POC_STEPS = 12
 
 REQUIRED_TEXT_FIELDS = {
     "run_command": "command",
@@ -65,6 +70,16 @@ def normalize_action(payload: dict[str, Any]) -> dict[str, object]:
 
     normalized: dict[str, object] = dict(payload)
     normalized["action"] = action
+    if action == "http_request":
+        normalized["method"] = _canonical_http_method(payload.get("method"))
+    elif action == "validate_poc":
+        steps = payload.get("steps")
+        assert isinstance(steps, list)
+        normalized["steps"] = [
+            {**step, "method": _canonical_http_method(step.get("method"))}
+            for step in steps
+            if isinstance(step, dict)
+        ]
     return normalized
 
 
@@ -76,16 +91,90 @@ def _action_name(payload: dict[str, Any]) -> str:
     return str(payload.get("action") or "").strip()
 
 
+def _canonical_http_method(value: object) -> str:
+    return str(value or "GET").strip().upper()
+
+
 def _validation_error(action: str, payload: dict[str, Any]) -> str:
     if action not in VALID_ACTIONS:
         return f"invalid action: {action}"
     required_text_field = REQUIRED_TEXT_FIELDS.get(action)
     if required_text_field and not _has_text(payload.get(required_text_field)):
         return f"{action} requires {required_text_field}"
-    if action == "validate_poc" and not isinstance(payload.get("steps"), list):
-        return "validate_poc requires steps list"
-    if action == "validate_poc" and payload.get("finding") is not None:
-        return _finding_validation_error(payload.get("finding"))
+    if action == "http_request":
+        return _http_request_validation_error(payload)
+    if action == "validate_poc":
+        step_error = _validate_poc_steps_validation_error(payload.get("steps"))
+        if step_error:
+            return step_error
+        if payload.get("finding") is not None:
+            return _finding_validation_error(payload.get("finding"))
+    return ""
+
+
+def _http_request_validation_error(payload: dict[str, Any]) -> str:  # noqa: PLR0911
+    if not (_has_text(payload.get("url")) or _has_text(payload.get("path"))):
+        return "http_request requires url or path"
+    method = _canonical_http_method(payload.get("method"))
+    if method not in _HTTP_METHODS:
+        return f"http_request method is not allowed: {method}"
+    if payload.get("headers") is not None and not isinstance(payload.get("headers"), dict):
+        return "http_request headers must be an object"
+    body_fields = [
+        name for name in ("body", "json", "form") if payload.get(name) is not None
+    ]
+    if len(body_fields) > 1:
+        return "http_request accepts only one of body, json, or form"
+    if method in _BODYLESS_HTTP_METHODS and body_fields:
+        return f"{method} http_request cannot include a body"
+    if payload.get("form") is not None and not isinstance(payload.get("form"), dict):
+        return "http_request form must be an object"
+    if payload.get("json") is not None and not isinstance(payload.get("json"), (dict, list)):
+        return "http_request json must be an object or list"
+    if payload.get("body") is not None and not isinstance(payload.get("body"), str):
+        return "http_request body must be a string"
+    return ""
+
+
+def _validate_poc_steps_validation_error(value: object) -> str:
+    if not isinstance(value, list) or not value:
+        return "validate_poc requires a non-empty steps list"
+    if len(value) > _MAX_VALIDATE_POC_STEPS:
+        return f"validate_poc accepts at most {_MAX_VALIDATE_POC_STEPS} steps"
+    for index, step in enumerate(value, start=1):
+        step_error = _validate_poc_step_validation_error(step)
+        if step_error:
+            return f"validate_poc step {index} {step_error}"
+    return ""
+
+
+def _validate_poc_step_validation_error(value: object) -> str:  # noqa: C901, PLR0911
+    if not isinstance(value, dict):
+        return "must be an object"
+    for location_field in ("url", "path"):
+        location = value.get(location_field)
+        if location is not None and not isinstance(location, str):
+            return f"{location_field} must be a string"
+    if not (_has_text(value.get("url")) or _has_text(value.get("path"))):
+        return "requires url or path"
+
+    method = _canonical_http_method(value.get("method"))
+    if method not in _HTTP_METHODS:
+        return f"method is not allowed: {method}"
+    if value.get("headers") is not None and not isinstance(value.get("headers"), dict):
+        return "headers must be an object"
+    if value.get("json") is not None:
+        return "does not support json; encode JSON in body and set Content-Type"
+
+    body_fields = [name for name in ("body", "form") if value.get(name) is not None]
+    if len(body_fields) > 1:
+        return "accepts only one of body or form"
+    if method in _BODYLESS_HTTP_METHODS and body_fields:
+        return f"{method} request cannot include a body"
+    if value.get("form") is not None and not isinstance(value.get("form"), dict):
+        return "form must be an object"
+    if value.get("body") is not None and not isinstance(value.get("body"), str):
+        return "body must be a string"
     return ""
 
 

--- a/packages/ravage/src/ravage/agent_core/agent_strategy.py
+++ b/packages/ravage/src/ravage/agent_core/agent_strategy.py
@@ -6,6 +6,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from hashlib import sha256
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+_NON_PERSISTED_FINGERPRINT_PREFIXES = (
+    "http_request:",
+    "validate_poc:",
+)
 
 
 @dataclass(frozen=True)
@@ -47,7 +53,14 @@ class ActionLedger:
         return max(self.fingerprints.get(item, 0) for item in fingerprints)
 
     def to_json(self) -> dict[str, int]:
-        return dict(sorted(self.fingerprints.items()))
+        # Exact HTTP fingerprints include caller-supplied bodies, credentials,
+        # and query values. Even a one-way digest becomes an offline verifier
+        # for low-entropy secrets, so keep those repeat checks in memory only.
+        return {
+            fingerprint: count
+            for fingerprint, count in sorted(self.fingerprints.items())
+            if not fingerprint.startswith(_NON_PERSISTED_FINGERPRINT_PREFIXES)
+        }
 
 
 STRATEGY_BOOK: tuple[StrategyCard, ...] = (
@@ -199,14 +212,35 @@ def action_fingerprint(action: Mapping[str, object], *, context: str = "") -> st
         # Only canonical dispatch material can cause physical requests. Mutable
         # expectations and report prose cannot disguise a third replay.
         body = json.dumps(
-            _validate_poc_dispatch_steps(action.get("steps")),
+            _validate_poc_dispatch_steps(action.get("steps"), context=context),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    elif kind == "http_request":
+        body = json.dumps(
+            {
+                "method": _fingerprint_method(action.get("method")),
+                "url": _fingerprint_url(
+                    action.get("url") or action.get("path"),
+                    context=context,
+                ),
+                "headers": _fingerprint_request_headers(action),
+                "form": _fingerprint_string_dict(action.get("form")),
+                "json": action.get("json"),
+                "body": action.get("body"),
+            },
             sort_keys=True,
             separators=(",", ":"),
             default=str,
         )
     else:
         body = str(action)
-    normalized = body if kind == "validate_poc" else re.sub(r"\s+", " ", body.strip())
+    normalized = (
+        body
+        if kind in {"http_request", "validate_poc"}
+        else re.sub(r"\s+", " ", body.strip())
+    )
     normalized = re.sub(r"ravage-[a-z0-9_:-]+", "ravage-*", normalized, flags=re.I)
     material_digest = sha256(normalized.encode("utf-8")).hexdigest()
 
@@ -217,7 +251,11 @@ def action_fingerprint(action: Mapping[str, object], *, context: str = "") -> st
     return f"{kind}:sha256:{material_digest}{suffix}"
 
 
-def _validate_poc_dispatch_steps(value: object) -> list[dict[str, object]]:
+def _validate_poc_dispatch_steps(
+    value: object,
+    *,
+    context: str = "",
+) -> list[dict[str, object]]:
     if not isinstance(value, list):
         return []
     dispatch_steps: list[dict[str, object]] = []
@@ -226,27 +264,73 @@ def _validate_poc_dispatch_steps(value: object) -> list[dict[str, object]]:
             continue
         headers = _fingerprint_header_dict(raw_step.get("headers"))
         form = _fingerprint_string_dict(raw_step.get("form"))
-        if form:
-            method = "POST"
+        method = _fingerprint_method(raw_step.get("method"))
+        if isinstance(raw_step.get("form"), dict):
             body: str | None = None
             headers = {
                 "content-type": "application/x-www-form-urlencoded",
                 **headers,
             }
         else:
-            method = str(raw_step.get("method") or "GET").upper()
             raw_body = raw_step.get("body")
             body = None if raw_body is None else str(raw_body)
         dispatch_steps.append(
             {
                 "method": method,
-                "url": str(raw_step.get("url") or ""),
+                "url": _fingerprint_url(
+                    raw_step.get("url") or raw_step.get("path"),
+                    context=context,
+                ),
                 "headers": headers,
                 "form": form,
                 "body": body,
             }
         )
     return dispatch_steps
+
+
+def _fingerprint_method(value: object) -> str:
+    return str(value or "GET").strip().upper()
+
+
+def _fingerprint_url(value: object, *, context: str = "") -> str:
+    """Return only URL material that an HTTP client can put on the wire."""
+    raw = str(value or "").strip()
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        return raw
+    path = parsed.path or ("/" if parsed.netloc else "")
+    target_origin = _fingerprint_context_origin(context)
+    if parsed.netloc and target_origin and _fingerprint_origin(raw) == target_origin:
+        return urlunsplit(("", "", path, parsed.query, ""))
+    return urlunsplit((parsed.scheme.casefold(), parsed.netloc, path, parsed.query, ""))
+
+
+def _fingerprint_context_origin(context: str) -> str:
+    for part in context.split("|"):
+        if part.startswith("origin:"):
+            return _fingerprint_origin(part.removeprefix("origin:"))
+    return ""
+
+
+def _fingerprint_origin(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return ""
+    scheme = parsed.scheme.casefold()
+    hostname = str(parsed.hostname or "").casefold().rstrip(".")
+    if scheme not in {"http", "https"} or not hostname:
+        return ""
+    if parsed.username is not None or parsed.password is not None:
+        return ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    default_port = 80 if scheme == "http" else 443
+    authority = hostname if port in {None, default_port} else f"{hostname}:{port}"
+    return f"{scheme}://{authority}"
 
 
 def _fingerprint_string_dict(value: object) -> dict[str, str]:
@@ -258,7 +342,25 @@ def _fingerprint_string_dict(value: object) -> dict[str, str]:
 def _fingerprint_header_dict(value: object) -> dict[str, str]:
     if not isinstance(value, dict):
         return {}
-    return {str(key).casefold(): str(item) for key, item in value.items()}
+    headers = {str(key).strip().casefold(): str(item) for key, item in value.items()}
+    content_type = headers.get("content-type")
+    if content_type is not None:
+        media_type, separator, parameters = content_type.partition(";")
+        headers["content-type"] = media_type.strip().casefold() + (
+            f";{parameters.strip()}" if separator else ""
+        )
+    return headers
+
+
+def _fingerprint_request_headers(action: Mapping[str, object]) -> dict[str, str]:
+    headers = _fingerprint_header_dict(action.get("headers"))
+    if "content-type" in headers:
+        return headers
+    if isinstance(action.get("form"), dict):
+        headers["content-type"] = "application/x-www-form-urlencoded"
+    elif action.get("json") is not None:
+        headers["content-type"] = "application/json"
+    return headers
 
 
 def _legacy_action_fingerprint(action: Mapping[str, object], *, context: str = "") -> str:

--- a/packages/ravage/src/ravage/agent_core/ai_agent.py
+++ b/packages/ravage/src/ravage/agent_core/ai_agent.py
@@ -13,8 +13,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
-from urllib.parse import urlparse
-from uuid import uuid4
+from urllib.parse import parse_qsl, urlparse
+from uuid import UUID, uuid4
 
 from ravage.agent_core.action_executor import (
     MAX_IDENTICAL_ACTION_EXECUTIONS,
@@ -40,6 +40,15 @@ from ravage.agent_core.agent_tasks import (
     update_mission_from_action,
 )
 from ravage.agent_core.attack_surface import merge_surface_state, surface_from_recon
+from ravage.agent_core.evidence_lead_lock import (
+    action_matches_lead,
+    awaiting_session_lead,
+    lead_replay_generation,
+    pending_lead,
+    record_aligned_outcome,
+    unresolved_lead,
+)
+from ravage.agent_core.evidence_lead_lock import directive as evidence_lead_directive
 from ravage.agent_core.frontier_closure_obligation import pending_closure_obligation
 from ravage.agent_core.harness_trace import (
     attempt_record_payload,
@@ -65,6 +74,7 @@ from ravage.agent_core.recovery_action_contract import select_recovery_branch_ac
 from ravage.agent_core.recovery_policy import RecoveryDecision, RecoveryRole, RecoveryStatus
 from ravage.agent_core.recovery_runtime import RecoveryCampaign, RecoveryTurnResult
 from ravage.agent_core.semantic_routes import semantic_action_fingerprint
+from ravage.agent_core.stateful_http import StatefulHttpActionSession
 from ravage.agent_core.surface_graph import SurfaceGraphState
 from ravage.agent_core.surface_graph_ingest import ingest_recon_surface, project_surface_graph
 from ravage.agent_knowledge import (
@@ -114,6 +124,7 @@ from ravage.traffic.policy import (
     TrafficPolicyError,
     TrafficPolicyMode,
 )
+from ravage.traffic.redaction import safe_field_names, semantic_url_shape
 from ravage.web_core.recon import run_recon
 from ravage.web_core.scope_policy import assert_authorized_target, is_local_url
 
@@ -129,6 +140,7 @@ MAX_OBSERVATION_CHARS = 10_000
 MAX_TRANSCRIPT_CHARS = 80_000
 MODEL_TIMEOUT_PADDING_SECONDS = 10
 DOCKER_SCOPE_GATEWAY_HOST = "ravage-target"
+_DEFAULT_STRUCTURED_HTTP_REQUEST_CEILING = 10_000
 _CONTEXT_PROOF_RE = re.compile(r"\b(?:flag|FLAG|HTB|CTF)\{[^}\s]{3,512}\}")
 _AUTHENTICATED_ACTION_PROTOCOL_KEYS = (
     "action",
@@ -145,6 +157,7 @@ _AUTHENTICATED_ACTION_PROTOCOL_KEYS = (
     "expected_signal",
     "exploit_steps",
     "fallback",
+    "field",
     "finding",
     "flag",
     "form",
@@ -398,87 +411,122 @@ def run_ai_web_agent(
             state_label="agent",
         )
     audit = AuditStore(settings.db_path or workspace.root / "audit.db", scope=brief.scope)
-    runtime = _make_tool_runtime(settings, brief, target_url=target_url)
-    state.surface["flag_objective"] = flag_objective
-    state.surface["stop_after_first_finding"] = stop_after_first_finding
-    recovery_state_path = workspace.root / "recovery-state.json"
-    recovery = _initial_recovery_campaign(
-        settings=settings,
-        state=state,
-        target_url=target_url,
-        state_path=recovery_state_path,
-    )
-    route = _select_model_route(settings)
-    client = settings.model_client or ChatClient(route)
+    runtime: ToolRuntime | None = None
+    http_session: StatefulHttpActionSession | None = None
+    recovery = None
+    route: ResolvedModelRoute | None = None
+    client: Any | None = None
     run_error: BaseException | None = None
     spent_cost_usd = 0.0
     cost_accounting_complete = True
     termination_reason: str | None = None
-    knowledge_pack_metadata = _knowledge_pack_metadata_payload(settings)
-    knowledge_pack_sha256 = (
-        str(knowledge_pack_metadata["sha256"]) if knowledge_pack_metadata is not None else None
-    )
-
-    started_payload: dict[str, object] = {
-        "target_url": target_url,
-        "model": route.model,
-        "provider": route.provider,
-        "agent_mode": settings.agent_mode,
-        "reference_architecture": "planner-executor with working memory",
-        "knowledge_pack": knowledge_pack_metadata,
-        "flag_objective": flag_objective,
-        "stop_after_first_finding": stop_after_first_finding,
-        "traffic_policy": traffic_policy.config.to_json(),
-        "traffic_policy_snapshot": traffic_policy.snapshot().to_json(),
-    }
-    session_mode = _authentication_session_mode(settings.authentication)
-    if session_mode:
-        started_payload["session_mode"] = session_mode
-    if recovery is not None:
-        started_payload["recovery_profile"] = settings.recovery_profile
-        started_payload["global_model_request_budget"] = (
-            recovery.scheduler.config.max_model_requests
-        )
-    _record(
-        audit,
-        brief.engagement_id,
-        actor="agent",
-        action="agent_started",
-        payload=started_payload,
-    )
-    workspace_started_payload: dict[str, object] = {
-        "target_url": target_url,
-        "provider": route.provider,
-        "model": route.model,
-        "agent_mode": settings.agent_mode,
-        "max_turns": settings.max_turns,
-        "tool_runtime": settings.tool_runtime_mode,
-        "autonomous_route": settings.autonomous_route,
-        "flag_objective": flag_objective,
-        "stop_after_first_finding": stop_after_first_finding,
-    }
-    if session_mode:
-        workspace_started_payload["session_mode"] = session_mode
-    if recovery is not None:
-        workspace_started_payload["recovery_profile"] = settings.recovery_profile
-    workspace.record_event(kind="agent_started", payload=workspace_started_payload)
-    traffic_started_payload = {
-        "state_path": str(traffic_policy.state_path),
-        "config": traffic_policy.config.to_json(),
-        "snapshot": traffic_policy.snapshot().to_json(),
-    }
-    _record(
-        audit,
-        brief.engagement_id,
-        actor="agent",
-        action="traffic_policy_started",
-        payload=traffic_started_payload,
-    )
-    workspace.record_event(kind="traffic_policy_started", payload=traffic_started_payload)
-    if knowledge_pack_metadata:
-        workspace.record_event(kind="knowledge_pack_loaded", payload=knowledge_pack_metadata)
-
+    recovery_state_path = workspace.root / "recovery-state.json"
     try:
+        runtime = _make_tool_runtime(settings, brief, target_url=target_url)
+        state.surface["flag_objective"] = flag_objective
+        state.surface["stop_after_first_finding"] = stop_after_first_finding
+        recovery = _initial_recovery_campaign(
+            settings=settings,
+            state=state,
+            target_url=target_url,
+            state_path=recovery_state_path,
+        )
+        http_session = StatefulHttpActionSession(
+            target_url=target_url,
+            scope=brief.scope,
+            allow_remote_target=settings.allow_remote_target,
+            roe_max_rps=brief.roe.max_rps,
+            max_total_requests=(
+                traffic_policy.config.max_physical_requests
+                or _DEFAULT_STRUCTURED_HTTP_REQUEST_CEILING
+            ),
+            workspace_dir=workspace.root,
+            state=state,
+            proof_recognition_enabled=(settings.proof_recognition_enabled and flag_objective),
+            authentication=settings.authentication,
+            traffic_policy=traffic_policy,
+            low_noise=settings.traffic_policy_mode == "low-noise",
+            resume_expected=resumed_state,
+        )
+        persisted_http_surface = {
+            key: state.surface[key]
+            for key in (
+                "evidence_lead_lock",
+                "evidence_lead_replay_generation",
+                "http_session_dirty",
+                "http_state_epoch",
+            )
+            if key in state.surface
+        }
+        route = _select_model_route(settings)
+        client = settings.model_client or ChatClient(route)
+        knowledge_pack_metadata = _knowledge_pack_metadata_payload(settings)
+        knowledge_pack_sha256 = (
+            str(knowledge_pack_metadata["sha256"])
+            if knowledge_pack_metadata is not None
+            else None
+        )
+
+        started_payload: dict[str, object] = {
+            "target_url": target_url,
+            "model": route.model,
+            "provider": route.provider,
+            "agent_mode": settings.agent_mode,
+            "reference_architecture": "planner-executor with working memory",
+            "knowledge_pack": knowledge_pack_metadata,
+            "flag_objective": flag_objective,
+            "stop_after_first_finding": stop_after_first_finding,
+            "traffic_policy": traffic_policy.config.to_json(),
+            "traffic_policy_snapshot": traffic_policy.snapshot().to_json(),
+            "structured_http_replay": True,
+        }
+        session_mode = _authentication_session_mode(settings.authentication)
+        if session_mode:
+            started_payload["session_mode"] = session_mode
+        if recovery is not None:
+            started_payload["recovery_profile"] = settings.recovery_profile
+            started_payload["global_model_request_budget"] = (
+                recovery.scheduler.config.max_model_requests
+            )
+        _record(
+            audit,
+            brief.engagement_id,
+            actor="agent",
+            action="agent_started",
+            payload=started_payload,
+        )
+        workspace_started_payload: dict[str, object] = {
+            "target_url": target_url,
+            "provider": route.provider,
+            "model": route.model,
+            "agent_mode": settings.agent_mode,
+            "max_turns": settings.max_turns,
+            "tool_runtime": settings.tool_runtime_mode,
+            "autonomous_route": settings.autonomous_route,
+            "flag_objective": flag_objective,
+            "stop_after_first_finding": stop_after_first_finding,
+        }
+        if session_mode:
+            workspace_started_payload["session_mode"] = session_mode
+        if recovery is not None:
+            workspace_started_payload["recovery_profile"] = settings.recovery_profile
+        workspace.record_event(kind="agent_started", payload=workspace_started_payload)
+        traffic_started_payload = {
+            "state_path": str(traffic_policy.state_path),
+            "config": traffic_policy.config.to_json(),
+            "snapshot": traffic_policy.snapshot().to_json(),
+        }
+        _record(
+            audit,
+            brief.engagement_id,
+            actor="agent",
+            action="traffic_policy_started",
+            payload=traffic_started_payload,
+        )
+        workspace.record_event(kind="traffic_policy_started", payload=traffic_started_payload)
+        if knowledge_pack_metadata:
+            workspace.record_event(kind="knowledge_pack_loaded", payload=knowledge_pack_metadata)
+
         safe_context = _safe_runtime_context(brief.context or {}, brief_path=brief_path)
         description = str(safe_context.get("description") or "")
         _write_runtime_context(
@@ -504,6 +552,7 @@ def run_ai_web_agent(
             authentication=settings.authentication,
             traffic_policy=traffic_policy,
         )
+        state.surface.update(persisted_http_surface)
         # Recon replaces the discovered-surface mapping. Reapply policy and mission
         # metadata afterward so both fresh runs and resumes retain their controls.
         state.surface["scope_in_scope"] = list(brief.scope.in_scope)
@@ -718,7 +767,17 @@ def run_ai_web_agent(
                 max_turns=max(settings.max_turns, 1),
                 allow_premature_final=allow_premature_final,
             )
-            if recovery is not None and recovery.scheduler.role is not RecoveryRole.CORE:
+            if unresolved_lead(state) is not None:
+                # Exact replay and auth-recovery obligations remain executor-owned;
+                # a delegated recovery branch must not replace either one.
+                action = _model_action_from_parsed(
+                    proposed_action,
+                    state=state,
+                    turn=turn,
+                    max_turns=max(settings.max_turns, 1),
+                    allow_premature_final=allow_premature_final,
+                )
+            elif recovery is not None and recovery.scheduler.role is not RecoveryRole.CORE:
                 action = select_recovery_branch_action(
                     proposed_action,
                     role=recovery.scheduler.role,
@@ -746,6 +805,10 @@ def run_ai_web_agent(
                     action = resolved_action
                     shadow_action = resolved_action
                     shadow_reason = resolution_reason
+            action, lead_selection_reason = _enforce_evidence_lead_action(state, action)
+            if lead_selection_reason is not None:
+                shadow_action = action
+                shadow_reason = lead_selection_reason
             selection_payload = selection_trace_payload(
                 turn=turn,
                 action_id=action_id,
@@ -753,7 +816,7 @@ def run_ai_web_agent(
                 selected_action=action,
                 shadow_action=shadow_action,
                 shadow_reason=shadow_reason,
-                repeat_context=_repeat_context(state),
+                repeat_context=_repeat_context(state, action=action),
             )
             selection_payload = _authenticated_artifact_mapping(
                 settings.authentication,
@@ -767,7 +830,10 @@ def run_ai_web_agent(
                 action="harness_selection",
                 payload=selection_payload,
             )
-            repeat_count = state.ledger.remember(action, context=_repeat_context(state))
+            repeat_count = state.ledger.remember(
+                action,
+                context=_repeat_context(state, action=action),
+            )
             selected_action_payload = _authenticated_artifact_mapping(
                 settings.authentication,
                 {
@@ -823,6 +889,7 @@ def run_ai_web_agent(
                     action_id=action_id,
                     authentication=settings.authentication,
                     traffic_policy=traffic_policy,
+                    http_executor=http_session,
                 )
             else:
                 outcome = execute_action(
@@ -840,12 +907,24 @@ def run_ai_web_agent(
                     action_id=action_id,
                     authentication=settings.authentication,
                     traffic_policy=traffic_policy,
+                    http_executor=http_session,
                 )
             if settings.authentication is not None and not outcome.session_mode:
                 outcome = replace(outcome, session_mode=session_mode)
             outcome = _continue_after_proof_outcome(state, outcome)
             outcome = _stop_after_finding_outcome(state, outcome)
             outcome_json = outcome.to_json()
+            # Also evaluate auth-paused routes: an exact replay carrying a newly
+            # established bearer/header session can resume the obligation.
+            lead_outcome = outcome_json
+            if outcome.evidence_observation:
+                # Executor evidence is used only for in-memory attempt
+                # accounting. It is intentionally excluded from action memory.
+                lead_outcome = {
+                    **outcome_json,
+                    "_evidence_observation": outcome.evidence_observation,
+                }
+            record_aligned_outcome(state, action, lead_outcome)
             _update_state_from_action(state, action=action, outcome=outcome_json)
             post_action_state_trace = state_trace_snapshot(state)
             attempt_record = attempt_record_payload(
@@ -854,7 +933,7 @@ def run_ai_web_agent(
                 proposed_action=proposed_action,
                 selected_action=action,
                 selection_reason=str(selection_payload.get("selection_reason") or ""),
-                repeat_context=_repeat_context(state),
+                repeat_context=_repeat_context(state, action=action),
                 pre_state=pre_state_trace,
                 post_state=post_action_state_trace,
                 outcome=outcome_json,
@@ -973,120 +1052,223 @@ def run_ai_web_agent(
         raise
     finally:
         cleanup_error: BaseException | None = None
+        http_terminal: dict[str, object] | None = None
         try:
-            runtime.close()
+            if runtime is not None:
+                runtime.close()
         except BaseException as exc:  # noqa: BLE001 - cleanup must be reported.
-            cleanup_error = exc
-        finish_status = "completed"
-        if isinstance(run_error, KeyboardInterrupt):
-            finish_status = "cancelled"
-            termination_reason = "keyboard_interrupt"
-        elif run_error is not None:
-            finish_status = "failed"
-            termination_reason = "error"
-        elif termination_reason is None:
-            termination_reason = (
-                "max_turns_reached" if state.turn >= max(settings.max_turns, 1) else "agent_final"
+            cleanup_error = _merge_finalization_error(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                error=exc,
+                stage="tool runtime cleanup",
             )
-        expected_proof_count = _state_expected_proof_count(state)
-        captured_proof_count = _captured_proof_count(state)
-        required_proof_count_unmet = (
-            expected_proof_count is not None
-            and captured_proof_count < expected_proof_count
-        )
-        completion_requirements_met = (
-            not flag_objective
-            or _proof_objective_completion_met(state, settings=settings)
-        )
-        if required_proof_count_unmet and termination_reason in {
-            "agent_final",
-            "objective_met",
-        }:
-            termination_reason = "required_proof_count_unmet"
-        if termination_reason in {
-            "max_turns_reached",
-            "cost_budget_exhausted",
-            "required_proof_count_unmet",
-        } or (run_error is None and not completion_requirements_met):
-            finish_status = "incomplete"
-        finished_payload: dict[str, object] = {
-            "status": finish_status,
-            "termination_reason": termination_reason,
-            "flags": state.flags,
-            "flag_record_path": str(workspace.events_path),
-            "finding_count": audit.count_findings(
-                status="confirmed",
-                engagement_id=brief.engagement_id,
-            ),
-            "finding_record_path": str(workspace.events_path),
-            "audit_path": str(settings.db_path or workspace.root / "audit.db"),
-            "flag_objective": flag_objective,
-            "expected_proof_count": expected_proof_count,
-            "captured_proof_count": captured_proof_count,
-            "required_proof_count_unmet": required_proof_count_unmet,
-            "completion_requirements_met": completion_requirements_met,
-            "turns": state.turn,
-            "phase": state.phase,
-            "cost_usd": round(spent_cost_usd, 6),
-            "cost_accounting_complete": cost_accounting_complete,
-            "traffic_policy": traffic_policy.config.to_json(),
-            "traffic_policy_snapshot": traffic_policy.snapshot().to_json(),
-        }
-        if settings.report_path is not None or settings.report_agent:
-            finished_payload["report_path"] = str(
-                settings.report_path or workspace.root.parent / "report.md"
+        try:
+            if http_session is not None:
+                terminal = http_session.finalize()
+                if terminal is not None:
+                    http_terminal = terminal.to_json()
+        except BaseException as exc:  # noqa: BLE001 - cleanup must be reported.
+            cleanup_error = _merge_finalization_error(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                error=exc,
+                stage="structured HTTP cleanup",
             )
-        if run_error is not None:
-            finished_payload["error_type"] = type(run_error).__name__
-        if recovery is not None:
-            finished_payload.update(
-                {
-                    "recovery_profile": settings.recovery_profile,
-                    "recovery_status": recovery.scheduler.status.value,
-                    "global_model_requests": recovery.scheduler.total_model_requests,
-                    "interrupted_model_requests": recovery.interrupted_model_requests,
-                }
-            )
-        _record(
-            audit,
-            brief.engagement_id,
-            actor="agent",
-            action="agent_finished",
-            payload=finished_payload,
-        )
-        workspace.record_event(kind="agent_finished", payload=finished_payload)
-        traffic_finished_payload = {
-            "state_path": str(traffic_policy.state_path),
-            "config": traffic_policy.config.to_json(),
-            "snapshot": traffic_policy.snapshot().to_json(),
-        }
-        _record(
-            audit,
-            brief.engagement_id,
-            actor="agent",
-            action="traffic_policy_finished",
-            payload=traffic_finished_payload,
-        )
-        workspace.record_event(kind="traffic_policy_finished", payload=traffic_finished_payload)
-        if run_error is None and cleanup_error is None:
-            _handle_memory_after_run(
+        try:
+            termination_reason = _record_agent_finish(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                termination_reason=termination_reason,
+                state=state,
                 settings=settings,
+                flag_objective=flag_objective,
+                spent_cost_usd=spent_cost_usd,
+                cost_accounting_complete=cost_accounting_complete,
+                audit=audit,
+                engagement_id=brief.engagement_id,
+                workspace=workspace,
+                traffic_policy=traffic_policy,
+                http_terminal=http_terminal,
+                recovery=recovery,
                 route=route,
                 client=client,
-                audit_db_path=settings.db_path or workspace.root / "audit.db",
             )
-        audit.close()
-        _write_report_if_requested(
-            brief_path=brief_path,
-            target_url=target_url,
-            settings=settings,
-            workspace=workspace,
-            state=state,
-            error=run_error or cleanup_error,
-            termination_reason=termination_reason,
-        )
+        except BaseException as exc:  # noqa: BLE001 - preserve the primary failure.
+            cleanup_error = _merge_finalization_error(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                error=exc,
+                stage="finish telemetry",
+            )
+        try:
+            audit.close()
+        except BaseException as exc:  # noqa: BLE001 - preserve the primary failure.
+            cleanup_error = _merge_finalization_error(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                error=exc,
+                stage="audit store cleanup",
+            )
+        try:
+            _write_report_if_requested(
+                brief_path=brief_path,
+                target_url=target_url,
+                settings=settings,
+                workspace=workspace,
+                state=state,
+                error=run_error or cleanup_error,
+                termination_reason=termination_reason,
+            )
+        except BaseException as exc:  # noqa: BLE001 - preserve the primary failure.
+            cleanup_error = _merge_finalization_error(
+                run_error=run_error,
+                cleanup_error=cleanup_error,
+                error=exc,
+                stage="report cleanup",
+            )
         if cleanup_error is not None and run_error is None:
             raise cleanup_error
+
+
+def _merge_finalization_error(
+    *,
+    run_error: BaseException | None,
+    cleanup_error: BaseException | None,
+    error: BaseException,
+    stage: str,
+) -> BaseException | None:
+    """Keep the first failure while retaining secret-free cleanup context."""
+    primary = run_error if run_error is not None else cleanup_error
+    if primary is None:
+        return error
+    primary.add_note(f"{stage} also failed: {type(error).__name__}")
+    return cleanup_error
+
+
+def _record_agent_finish(  # noqa: PLR0913
+    *,
+    run_error: BaseException | None,
+    cleanup_error: BaseException | None,
+    termination_reason: str | None,
+    state: AgentState,
+    settings: AIWebAgentSettings,
+    flag_objective: bool,
+    spent_cost_usd: float,
+    cost_accounting_complete: bool,
+    audit: AuditStore,
+    engagement_id: UUID,
+    workspace: AgentWorkspace,
+    traffic_policy: TrafficPolicyController,
+    http_terminal: dict[str, object] | None,
+    recovery: RecoveryCampaign | None,
+    route: ResolvedModelRoute | None,
+    client: Any | None,
+) -> str | None:
+    """Emit terminal telemetry before independently owned resources are closed."""
+    finish_status = "completed"
+    if isinstance(run_error, KeyboardInterrupt):
+        finish_status = "cancelled"
+        termination_reason = "keyboard_interrupt"
+    elif run_error is not None:
+        finish_status = "failed"
+        termination_reason = "error"
+    elif termination_reason is None:
+        termination_reason = (
+            "max_turns_reached" if state.turn >= max(settings.max_turns, 1) else "agent_final"
+        )
+    expected_proof_count = _state_expected_proof_count(state)
+    captured_proof_count = _captured_proof_count(state)
+    required_proof_count_unmet = (
+        expected_proof_count is not None and captured_proof_count < expected_proof_count
+    )
+    completion_requirements_met = not flag_objective or _proof_objective_completion_met(
+        state,
+        settings=settings,
+    )
+    if required_proof_count_unmet and termination_reason in {
+        "agent_final",
+        "objective_met",
+    }:
+        termination_reason = "required_proof_count_unmet"
+    if termination_reason in {
+        "max_turns_reached",
+        "cost_budget_exhausted",
+        "required_proof_count_unmet",
+    } or (run_error is None and not completion_requirements_met):
+        finish_status = "incomplete"
+    finished_payload: dict[str, object] = {
+        "status": finish_status,
+        "termination_reason": termination_reason,
+        "flags": state.flags,
+        "flag_record_path": str(workspace.events_path),
+        "finding_count": audit.count_findings(
+            status="confirmed",
+            engagement_id=engagement_id,
+        ),
+        "finding_record_path": str(workspace.events_path),
+        "audit_path": str(settings.db_path or workspace.root / "audit.db"),
+        "flag_objective": flag_objective,
+        "expected_proof_count": expected_proof_count,
+        "captured_proof_count": captured_proof_count,
+        "required_proof_count_unmet": required_proof_count_unmet,
+        "completion_requirements_met": completion_requirements_met,
+        "turns": state.turn,
+        "phase": state.phase,
+        "cost_usd": round(spent_cost_usd, 6),
+        "cost_accounting_complete": cost_accounting_complete,
+        "traffic_policy": traffic_policy.config.to_json(),
+        "traffic_policy_snapshot": traffic_policy.snapshot().to_json(),
+    }
+    if http_terminal is not None:
+        finished_payload["structured_http"] = http_terminal
+        workspace.record_event(kind="structured_http_finished", payload=http_terminal)
+    if settings.report_path is not None or settings.report_agent:
+        finished_payload["report_path"] = str(
+            settings.report_path or workspace.root.parent / "report.md"
+        )
+    if run_error is not None:
+        finished_payload["error_type"] = type(run_error).__name__
+    if recovery is not None:
+        finished_payload.update(
+            {
+                "recovery_profile": settings.recovery_profile,
+                "recovery_status": recovery.scheduler.status.value,
+                "global_model_requests": recovery.scheduler.total_model_requests,
+                "interrupted_model_requests": recovery.interrupted_model_requests,
+            }
+        )
+    _record(
+        audit,
+        engagement_id,
+        actor="agent",
+        action="agent_finished",
+        payload=finished_payload,
+    )
+    workspace.record_event(kind="agent_finished", payload=finished_payload)
+    traffic_finished_payload = {
+        "state_path": str(traffic_policy.state_path),
+        "config": traffic_policy.config.to_json(),
+        "snapshot": traffic_policy.snapshot().to_json(),
+    }
+    _record(
+        audit,
+        engagement_id,
+        actor="agent",
+        action="traffic_policy_finished",
+        payload=traffic_finished_payload,
+    )
+    workspace.record_event(kind="traffic_policy_finished", payload=traffic_finished_payload)
+    if run_error is None and cleanup_error is None:
+        if route is None or client is None:
+            raise RuntimeError("completed agent run is missing its model route")
+        _handle_memory_after_run(
+            settings=settings,
+            route=route,
+            client=client,
+            audit_db_path=settings.db_path or workspace.root / "audit.db",
+        )
+    return termination_reason
 
 
 def _model_action(
@@ -1108,6 +1290,13 @@ def _model_action_from_parsed(
     max_turns: int,
     allow_premature_final: bool = False,
 ) -> dict[str, object]:
+    lead_action, lead_reason = _enforce_evidence_lead_action(state, action)
+    if lead_reason is not None:
+        return lead_action
+    if unresolved_lead(state) is not None:
+        # An aligned exact replay or an auth-establishing HTTP action outranks
+        # generic primitive and description-based harness rewrites this turn.
+        return lead_action
     if allow_premature_final and action.get("action") == "final":
         return dict(action)
     if not allow_premature_final and _final_is_premature(
@@ -1139,6 +1328,16 @@ def _shadow_harness_action(
     max_turns: int,
     allow_premature_final: bool = False,
 ) -> tuple[dict[str, object] | None, str]:
+    lead_action, lead_reason = _enforce_evidence_lead_action(state, proposed_action)
+    if lead_reason is not None:
+        return lead_action, lead_reason
+    if unresolved_lead(state) is not None:
+        reason = (
+            "evidence_lead_session_recovery"
+            if awaiting_session_lead(state) is not None
+            else "evidence_lead_aligned"
+        )
+        return None, reason
     if not allow_premature_final and _final_is_premature(
         action=proposed_action, state=state, turn=turn, max_turns=max_turns
     ):
@@ -1158,7 +1357,49 @@ def _shadow_harness_action(
     return None, "no_shadow_route"
 
 
-_REPEAT_GUARDED_ACTIONS = frozenset({"run_command", "run_python", "run_probe", "validate_poc"})
+def _enforce_evidence_lead_action(
+    state: AgentState,
+    action: Mapping[str, object],
+) -> tuple[dict[str, object], str | None]:
+    lead = pending_lead(state)
+    selected = dict(action)
+    if lead is not None:
+        if action_matches_lead(
+            selected,
+            lead,
+            primary_origin=state.surface_graph.target_origin,
+        ):
+            return selected, None
+        return (
+            {
+                "action": "invalid",
+                "error": evidence_lead_directive(state),
+                "raw": f"blocked action kind: {selected.get('action')}",
+            },
+            "evidence_lead_lock",
+        )
+    if awaiting_session_lead(state) is None:
+        return selected, None
+    if _is_evidence_session_recovery_action(selected):
+        return selected, None
+    return (
+        {
+            "action": "invalid",
+            "error": evidence_lead_directive(state),
+            "raw": f"blocked action kind: {selected.get('action')}",
+        },
+        "evidence_lead_session_recovery",
+    )
+
+
+def _is_evidence_session_recovery_action(action: Mapping[str, object]) -> bool:
+    """Allow only the persistent HTTP lane or trusted proof closure while paused."""
+    return str(action.get("action") or "") in {"http_request", "capture_flag"}
+
+
+_REPEAT_GUARDED_ACTIONS = frozenset(
+    {"http_request", "run_command", "run_python", "run_probe", "validate_poc"}
+)
 _ACTIVE_TASK_STATUSES = frozenset({"pending", "in_progress"})
 
 
@@ -1322,7 +1563,7 @@ def _would_hit_repeat_guard(state: AgentState, action: Mapping[str, object]) -> 
     if str(action.get("action") or "") not in _REPEAT_GUARDED_ACTIONS:
         return False
     return (
-        state.ledger.count(action, context=_repeat_context(state))
+        state.ledger.count(action, context=_repeat_context(state, action=action))
         >= MAX_IDENTICAL_ACTION_EXECUTIONS
     )
 
@@ -1373,6 +1614,8 @@ def _assessment_ready_for_terminal(
     if not state.tasks or _has_open_assessment_tasks(state):
         return False
     if pending_closure_obligation(state) is not None:
+        return False
+    if unresolved_lead(state) is not None:
         return False
     if _has_executable_live_primitive_route(state, settings=settings):
         return False
@@ -1481,7 +1724,7 @@ def _forced_primitive_probe_action(
         "fallback": "If the locked specialist exhausts this primitive twice, move to the next confirmed primitive or distinct evidence.",
         "memory_updates": [f"forced locked primitive probe: {primitive_name} -> {rule.probe}"],
     }
-    if state.ledger.count(action, context=_repeat_context(state)) >= 2:
+    if state.ledger.count(action, context=_repeat_context(state, action=action)) >= 2:
         return None
     return action
 
@@ -1911,7 +2154,7 @@ def _forced_evidence_probe_action(
             ),
             "memory_updates": [f"forced evidence route: {route.name} -> {route.probe}"],
         }
-        if state.ledger.count(action, context=_repeat_context(state)) >= 2:
+        if state.ledger.count(action, context=_repeat_context(state, action=action)) >= 2:
             continue
         return action
     return None
@@ -1968,7 +2211,7 @@ def _forced_multi_finding_url_fetch_action(
             "preserved structured URL-fetch form requires SSRF closure after an earlier proof"
         ],
     }
-    if state.ledger.count(action, context=_repeat_context(state)) >= 2:
+    if state.ledger.count(action, context=_repeat_context(state, action=action)) >= 2:
         return None
     return action
 
@@ -2297,7 +2540,7 @@ def _forced_cookie_identity_idor_action(
         "fallback": "If idor_boundary exhausts twice, resume model-driven exploration with a different primitive.",
         "memory_updates": ["forced cookie identity IDOR loop -> idor_boundary"],
     }
-    if state.ledger.count(action, context=_repeat_context(state)) >= 2:
+    if state.ledger.count(action, context=_repeat_context(state, action=action)) >= 2:
         return None
     return action
 
@@ -2337,7 +2580,7 @@ def _forced_authenticated_object_idor_action(
         "fallback": "If idor_boundary exhausts twice, resume model-driven exploration with a different primitive.",
         "memory_updates": ["forced authenticated object-route IDOR loop -> idor_boundary"],
     }
-    if state.ledger.count(action, context=_repeat_context(state)) >= 2:
+    if state.ledger.count(action, context=_repeat_context(state, action=action)) >= 2:
         return None
     return action
 
@@ -2475,6 +2718,7 @@ def _final_is_premature(
         return (
             _has_open_assessment_tasks(state)
             or pending_closure_obligation(state) is not None
+            or unresolved_lead(state) is not None
             or _has_executable_live_primitive_route(state, settings=settings)
         )
     return not _proof_objective_completion_met(state, settings=settings)
@@ -2489,6 +2733,7 @@ def _proof_objective_completion_met(
         _proof_count_requirement_unmet(state)
         or _captured_proof_count(state) == 0
         or pending_closure_obligation(state) is not None
+        or unresolved_lead(state) is not None
     ):
         return False
     if not _continue_after_proof_enabled(state):
@@ -2814,6 +3059,7 @@ def _execute_recovery_action(  # noqa: PLR0913 - mirrors the executor boundary.
     action_id: str,
     authentication: ManagedAttackAuthentication | None,
     traffic_policy: TrafficPolicyController,
+    http_executor: StatefulHttpActionSession,
 ) -> tuple[ActionResult, bool]:
     specialist = recovery.scheduler.role is not RecoveryRole.CORE
     if specialist and action.get("action") == "final":
@@ -2838,7 +3084,27 @@ def _execute_recovery_action(  # noqa: PLR0913 - mirrors the executor boundary.
         )
 
     route_fingerprint = semantic_action_fingerprint(action)
-    if not recovery.scheduler.route_is_available(route_fingerprint):
+    lead = pending_lead(state)
+    lead_owned_route = (
+        lead is not None
+        and action_matches_lead(
+            action,
+            lead,
+            primary_origin=state.surface_graph.target_origin,
+        )
+    ) or (
+        awaiting_session_lead(state) is not None
+        and _is_evidence_session_recovery_action(action)
+    )
+    # An exact evidence replay has its own executor-owned lifecycle: two
+    # completed no-progress attempts, with authentication pauses excluded.
+    # Auth recovery is likewise bounded by the repeat/global budgets. The
+    # generic recovery throttle may already have counted the pre-auth 401/403,
+    # so letting it block here can strand the lead before a usable session or
+    # after only one real replay.
+    if not lead_owned_route and not recovery.scheduler.route_is_available(
+        route_fingerprint
+    ):
         payload = {
             "turn": state.turn,
             "branch_id": recovery.scheduler.active_branch_id,
@@ -2883,6 +3149,7 @@ def _execute_recovery_action(  # noqa: PLR0913 - mirrors the executor boundary.
             action_id=action_id,
             authentication=authentication,
             traffic_policy=traffic_policy,
+            http_executor=http_executor,
         ),
         False,
     )
@@ -3001,6 +3268,8 @@ def _seed_recon(
     authentication: ManagedAttackAuthentication | None = None,
     traffic_policy: TrafficPolicyController | None = None,
 ) -> None:
+    if not state.surface_graph.target_origin:
+        state.surface_graph = SurfaceGraphState.for_target(target_url)
     try:
         recon = run_recon(
             target_url,
@@ -3039,8 +3308,6 @@ def _seed_recon(
         description=safe_description,
         recon_payload=recon_payload,
     )
-    if not state.surface_graph.target_origin:
-        state.surface_graph = SurfaceGraphState.for_target(target_url)
     ingest_recon_surface(
         state.surface_graph,
         recon_payload,
@@ -3161,6 +3428,8 @@ def _authenticated_model_action(
         action,
         protected_keys={
             (): _AUTHENTICATED_ACTION_PROTOCOL_KEYS,
+            ("form",): _AUTHENTICATED_HTTP_PARAMETER_KEYS,
+            ("json",): _AUTHENTICATED_HTTP_PARAMETER_KEYS,
             ("finding",): _AUTHENTICATED_FINDING_KEYS,
             ("steps", "*"): _AUTHENTICATED_HTTP_STEP_KEYS,
             ("steps", "*", "form"): _AUTHENTICATED_HTTP_PARAMETER_KEYS,
@@ -3177,7 +3446,9 @@ def _authenticated_model_action(
                 "medium",
             ),
             ("finding", "vuln_class"): _AUTHENTICATED_FINDING_CLASSES,
+            ("method",): _AUTHENTICATED_HTTP_METHODS,
             ("probe",): probe_names,
+            ("vuln_class",): _AUTHENTICATED_FINDING_CLASSES,
             ("steps", "*", "evidence_role"): ("control", "exploit"),
             ("steps", "*", "method"): _AUTHENTICATED_HTTP_METHODS,
         },
@@ -3440,19 +3711,21 @@ def _build_messages(
             "no flag is required and do not spend turns searching for one"
         )
     if low_noise:
-        execution_loop = "run one useful native metered HTTP probe or PoC replay"
+        execution_loop = "run one useful structured HTTP request, native probe, or PoC replay"
         execution_boundary = (
             "The whole-run low-noise policy permits native metered HTTP lanes only; "
             "opaque command, Python, browser-process, and external-process actions are unavailable."
         )
     elif settings.authentication is None:
-        execution_loop = "run one useful command or Python script"
+        execution_loop = "replay one observed HTTP request or run one useful command or script"
         execution_boundary = "Use the available tools directly."
     else:
-        execution_loop = "run one useful managed HTTP probe or managed PoC replay"
+        execution_loop = (
+            "run one useful structured HTTP request, managed HTTP probe or managed PoC replay"
+        )
         execution_boundary = (
-            "Use only the managed probe and PoC request lanes; raw shell and Python "
-            "execution cannot receive authenticated credentials."
+            "Use only managed structured HTTP, probe, and PoC request lanes; raw shell "
+            "and Python execution cannot receive authenticated credentials."
         )
     system = (
         "You are Ravage, an autonomous web exploitation agent running only against "
@@ -3462,6 +3735,12 @@ def _build_messages(
         f"{completion_goal}. Do not call canned drivers, route by tags, "
         f"or assume the answer key. {execution_boundary}"
     )
+    plan_directives = planner_directives(state)
+    unresolved_evidence_lead = unresolved_lead(state)
+    session_paused_evidence_lead = awaiting_session_lead(state)
+    lead_instruction = evidence_lead_directive(state)
+    if lead_instruction:
+        plan_directives.insert(0, lead_instruction)
     user: dict[str, object] = {
         "target_url": target_url,
         "scope": {
@@ -3483,9 +3762,25 @@ def _build_messages(
         "confirmed_primitives": dict(state.primitives),
         "locked_primitive": locked_primitive(state),
         "active_strategy_cards": strategies,
-        "planner_directives": planner_directives(state),
+        "planner_directives": plan_directives,
         "memory_hints": _memory_hints_for_prompt(settings, route=route),
         "action_schema": {
+            "http_request": {
+                "action": "http_request",
+                "task_id": "one active_tasks id",
+                "vuln_class": "canonical family when continuing an evidence lead",
+                "method": "GET, HEAD, OPTIONS, POST, PUT, or PATCH",
+                "url": "exact same-origin URL or path observed on the target",
+                "headers": {"content-type": "optional explicit content type"},
+                "form": {"observed_field": "one control or test value"},
+                "timeout_seconds": 10,
+                "strategy": "evidence-derived vulnerability family or workflow",
+                "notes": "what exact observed request this replays or mutates",
+                "expected_signal": "the response change that would advance or reject the lead",
+                "fallback": "one material mutation on this same request template",
+                "hypotheses": ["candidate inferred from target evidence"],
+                "memory_updates": ["short facts learned or hypotheses"],
+            },
             "run_probe": {
                 "action": "run_probe",
                 "task_id": "one active_tasks id",
@@ -3584,10 +3879,30 @@ def _build_messages(
             "Use active strategy cards as checklists, not as answer keys.",
             "Choose exactly one active task and include its task_id in every non-final action.",
             "Do not repeat an action from repetition_ledger unless you change a material variable.",
+            "Treat surface_graph operations and discovered forms as canonical request templates. Preserve their exact method, route, body location, field names, and active session.",
+            "When a real form or API request exists, use http_request to mutate that observed template before inventing query parameters, alternate methods, or guessed endpoints.",
+            (
+                "When evidence_lead_lock.status is awaiting_session, use http_request in "
+                "the persistent lane to establish authentication; do not switch to an "
+                "unrelated probe or finish. The exact request-shape lock resumes after "
+                "session state changes."
+                if session_paused_evidence_lead is not None
+                else "When evidence_lead_lock is present, do not change vulnerability "
+                "family, method, endpoint, encoding, or exact request fields. Continue it "
+                "with http_request or validate_poc; run_probe metadata cannot enforce an "
+                "exact physical replay. Include vuln_class on http_request."
+            )
+            + (
+                " capture_flag remains allowed when exact target proof is visible."
+                if flag_objective
+                else ""
+            ),
+            "Anonymous http_request actions share one persistent cookie session for this run. Establish workflows such as login with it, then keep using it for the authenticated follow-up surface; configured managed identities are attached by their trusted session owner.",
+            "For http_request request bodies, emit exactly one of form, json, or body. The schema example uses form; replace it with json or body when the observed request requires that encoding.",
             "If recommended_specialists is non-empty, pick the highest-scored specialist with run_probe before writing an equivalent run_command/run_python loop.",
             "If locked_primitive is set, you have already confirmed an exploitable primitive: run its locked run_probe specialist (top of recommended_specialists) and drive it to validated target evidence. Do not run recon/surface probes or switch to an unrelated vulnerability class until that primitive is exploited or genuinely exhausted.",
             "After a specialist returns same_as_before, either change a material endpoint/parameter/payload family or move to the next specialist; do not reimplement the same probe by hand.",
-            "Use run_command or run_python only for custom follow-up, exploitation logic, or payload adaptation not covered by an available probe.",
+            "Use http_request for custom HTTP follow-up and payload adaptation. Use run_command or run_python only for non-HTTP tooling not covered by an available probe.",
             "Do not spend more than two consecutive run_command/run_python turns while a matching run_probe specialist remains untried.",
             "Use validate_poc after a promising signal to replay the shortest stable HTTP evidence.",
             (
@@ -3626,6 +3941,8 @@ def _build_messages(
             "Inspect full response bodies, headers, cookies, redirects, forms, links, and errors.",
         ],
     }
+    if unresolved_evidence_lead is not None:
+        user["evidence_lead_lock"] = unresolved_evidence_lead.to_json()
     if traffic_budget is not None:
         user["traffic_budget"] = dict(traffic_budget)
     action_schema = user["action_schema"]
@@ -3658,8 +3975,8 @@ def _build_messages(
                 item for item in tool_guidance if not _authenticated_external_guidance(str(item))
             ]
             tool_guidance.append(
-                "Whole-run low-noise mode permits run_probe and validate_poc only through "
-                "native metered HTTP transports; do not propose opaque process or browser lanes."
+                "Whole-run low-noise mode permits http_request, run_probe, and validate_poc "
+                "through native metered HTTP transports; do not propose opaque process or browser lanes."
             )
     if settings.allow_remote_target and not is_local_url(target_url):
         tool_guidance = user["tool_guidance"]
@@ -3860,7 +4177,7 @@ def _focus_authenticated_prompt(  # noqa: C901, PLR0912 - prompt policy is expli
 
     schema_actions = list(action_schema) if isinstance(action_schema, dict) else []
     managed_http_actions = [
-        name for name in ("run_probe", "validate_poc") if name in schema_actions
+        name for name in ("http_request", "run_probe", "validate_poc") if name in schema_actions
     ]
     user["managed_http_identity"] = {
         "mode": _authentication_session_mode(authentication),
@@ -3894,13 +4211,14 @@ def _focus_authenticated_methodology(methodology: dict[str, object]) -> None:
     methodology["loop"] = [
         "Observe: gather one new fact from target responses or prior output.",
         "Orient: connect that fact to an active task and hypothesis.",
-        "Act: run one eligible managed in-process probe or structured validate_poc replay.",
+        "Act: replay one exact observed request, run one eligible managed probe, or validate a PoC.",
         (
             "Review: record whether the result was new surface, a candidate signal, "
             "blocked, or confirmed evidence."
         ),
     ]
     methodology["tool_use"] = [
+        "Use http_request to preserve an observed method, route, fields, and managed identity.",
         "Use run_probe for scoped authenticated discovery and specialist workflows.",
         "Use validate_poc for short same-origin HTTP control/exploit comparisons.",
         "Let the managed executor own cookies, authentication headers, refresh, pacing, and scope.",
@@ -4358,7 +4676,11 @@ def _float_value(value: object, *, default: float) -> float:
         return default
 
 
-def _repeat_context(state: AgentState) -> str:
+def _repeat_context(
+    state: AgentState,
+    *,
+    action: Mapping[str, object] | None = None,
+) -> str:
     """
     Material replay-context signature for repeat-action de-duplication.
 
@@ -4372,7 +4694,23 @@ def _repeat_context(state: AgentState) -> str:
             if str(value).strip()
         }
     )
-    return "host:" + ",".join(hosts) if hosts else ""
+    parts = ["host:" + ",".join(hosts)] if hosts else []
+    kind = str(action.get("action") or "") if action is not None else ""
+    session_sensitive = action is None or kind in {"http_request", "validate_poc"}
+    if session_sensitive:
+        target_origin = str(state.surface_graph.target_origin or "").strip()
+        if target_origin:
+            parts.append(f"origin:{target_origin}")
+        lead = pending_lead(state)
+        if lead is not None:
+            parts.append(lead.fingerprint)
+            replay_generation = lead_replay_generation(state)
+            if replay_generation:
+                parts.append(f"lead-replay:{replay_generation}")
+        http_state_epoch = state.surface.get("http_state_epoch")
+        if isinstance(http_state_epoch, int) and not isinstance(http_state_epoch, bool):
+            parts.append(f"http-state:{max(0, http_state_epoch)}")
+    return "|".join(parts)
 
 
 def _update_state_from_action(
@@ -4395,6 +4733,14 @@ def _update_state_from_action(
         "repeat_count": outcome.get("repeat_count"),
         "outcome": outcome.get("outcome"),
     }
+    if action.get("action") == "http_request":
+        record["request_shape"] = _http_request_memory(action)
+    elif action.get("action") == "validate_poc":
+        steps = action.get("steps")
+        if isinstance(steps, list):
+            record["request_shapes"] = [
+                _http_request_memory(step) for step in steps[:12] if isinstance(step, Mapping)
+            ]
     state.actions.append(record)
     update_mission_from_action(state, action=dict(action), outcome=dict(outcome))
     for item in _string_list(action.get("memory_updates")):
@@ -4404,8 +4750,12 @@ def _update_state_from_action(
     observation = str(outcome.get("observation") or "")
     if observation and not state.last_observation:
         state.last_observation = observation_digest(observation)
-    for item in observation_facts(observation):
-        append_unique(state.facts, item, limit=80)
+    if action.get("action") != "http_request":
+        # The structured HTTP executor has already mined response-only
+        # discovery. This visible envelope also contains the model-authored
+        # request, which must never promote a target-evidence primitive.
+        for item in observation_facts(observation):
+            append_unique(state.facts, item, limit=80)
     if action.get("action") == "invalid":
         append_unique(state.facts, "previous model response violated action schema", limit=80)
     promote_primitives(state)
@@ -4416,6 +4766,67 @@ def _update_state_from_action(
     elif state.primitives or state.turn >= 3:
         state.phase = "exploit"
     state.summary = summarize_state(state)
+
+
+def _http_request_memory(action: Mapping[str, object]) -> dict[str, object]:
+    """Keep a replayable request shape without retaining caller-authored values."""
+    raw_url = str(action.get("url") or action.get("path") or "")
+    encoding, field_names = _http_request_body_memory(action)
+    headers = action.get("headers")
+    header_names = (
+        sorted(
+            {
+                str(name).strip().casefold()
+                for name in headers
+                if str(name).strip() and "\n" not in str(name) and "\r" not in str(name)
+            }
+        )[:32]
+        if isinstance(headers, Mapping)
+        else []
+    )
+    return {
+        "method": str(action.get("method") or "GET").strip().upper(),
+        "url_shape": semantic_url_shape(raw_url),
+        "body_encoding": encoding,
+        "field_names": list(safe_field_names(field_names)),
+        "header_names": header_names,
+        "values_retained": False,
+    }
+
+
+def _http_request_body_memory(
+    action: Mapping[str, object],
+) -> tuple[str, tuple[object, ...]]:
+    form = action.get("form")
+    if isinstance(form, Mapping):
+        return "form", tuple(form)
+    json_body = action.get("json")
+    if json_body is not None:
+        return "json", tuple(json_body) if isinstance(json_body, Mapping) else ()
+    raw_body = action.get("body")
+    if raw_body is None:
+        return "none", ()
+    content_type = _http_request_content_type(action.get("headers"))
+    if content_type == "application/x-www-form-urlencoded":
+        return "form", tuple(
+            name for name, _value in parse_qsl(str(raw_body), keep_blank_values=True)
+        )
+    if content_type == "application/json" or content_type.endswith("+json"):
+        try:
+            decoded = json.loads(str(raw_body))
+        except (TypeError, json.JSONDecodeError):
+            decoded = None
+        return "json", tuple(decoded) if isinstance(decoded, Mapping) else ()
+    return "raw", ()
+
+
+def _http_request_content_type(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    for name, header_value in value.items():
+        if str(name).strip().casefold() == "content-type":
+            return str(header_value).split(";", 1)[0].strip().casefold()
+    return ""
 
 
 def _write_runtime_context(

--- a/packages/ravage/src/ravage/agent_core/autonomous_graph/scoped_http.py
+++ b/packages/ravage/src/ravage/agent_core/autonomous_graph/scoped_http.py
@@ -8,6 +8,7 @@ import hashlib
 import ipaddress
 import json
 import os
+import re
 import socket
 import ssl
 import stat
@@ -21,7 +22,7 @@ from http.client import HTTPConnection, HTTPMessage, HTTPResponse, HTTPSConnecti
 from http.cookiejar import CookieJar
 from typing import IO, TYPE_CHECKING, Protocol, cast
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
+from urllib.parse import unquote_plus, urlencode, urljoin, urlsplit, urlunsplit
 from urllib.request import (
     HTTPCookieProcessor,
     HTTPHandler,
@@ -48,6 +49,8 @@ from ravage.traffic.policy import (
     TrafficPolicyController,
     TrafficPolicyError,
 )
+from ravage.traffic.redaction import redact_text as redact_traffic_text
+from ravage.traffic.redaction import sanitize_url
 from ravage.web_core.proof_recognizer import recognize_proofs
 from ravage.web_core.scope_policy import (
     assert_authorized_target,
@@ -98,8 +101,10 @@ _MAX_HTTP_STATE_BYTES = 262_144
 _HTTP_STATE_READ_CHUNK_BYTES = 65_536
 _PRIVATE_FILE_MODE = 0o600
 _MAX_NETWORK_PORT = 65_535
+_MAX_PROOF_CANONICALIZATION_PASSES = 16
 _IPV6_VERSION = 6
 _MANAGED_AUTH_HEADERS = frozenset({"authorization", "cookie"})
+_REQUEST_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 
 
 class ScopedHttpError(ValueError):
@@ -198,25 +203,57 @@ class ManagedGraphAuthentication(Protocol):
 class ManagedAuthenticationScopedHttpTransport:
     """Adapt managed ``ProbeSession`` requests to the graph HTTP transport."""
 
-    def __init__(self, authentication: ManagedGraphAuthentication) -> None:
+    def __init__(
+        self,
+        authentication: ManagedGraphAuthentication,
+        *,
+        persistent_session: bool = False,
+    ) -> None:
         identity = str(getattr(authentication, "identity", "")).strip()
         if not identity:
             raise ScopedHttpError("managed graph authentication identity is required")
         self.authentication = authentication
+        self.persistent_session = persistent_session
         self._session: ProbeSession | None = None
+        self._action_active = False
+
+    @property
+    def cookies(self) -> object | None:
+        session = self._session
+        return getattr(session, "cookies", None) if session is not None else None
 
     def begin_action(self, *, timeout_seconds: float) -> None:
         """Lease one disposable identity lane for a complete redirect chain."""
-        if self._session is not None:
+        if self._action_active:
             raise ScopedHttpError("managed authentication action session is already active")
-        try:
-            self._session = self.authentication.session_for_model_action(
-                timeout_seconds=max(int(timeout_seconds), 1)
-            )
-        except Exception:  # noqa: BLE001 - owner failures are never artifact-safe.
-            raise ScopedHttpError("managed authentication action session failed") from None
+        if self._session is None:
+            try:
+                self._session = self.authentication.session_for_model_action(
+                    timeout_seconds=max(int(timeout_seconds), 1)
+                )
+            except Exception:  # noqa: BLE001 - owner failures are never artifact-safe.
+                raise ScopedHttpError("managed authentication action session failed") from None
+        self._action_active = True
 
     def end_action(self) -> None:
+        if not self._action_active:
+            return
+        self._action_active = False
+        if self.persistent_session:
+            return
+        session = self._session
+        self._session = None
+        if session is None:
+            return
+        try:
+            self.authentication.retire_probe_session(session)
+        except Exception:  # noqa: BLE001 - cleanup details can contain auth material.
+            raise ScopedHttpError("managed authentication action cleanup failed") from None
+
+    def close(self) -> None:
+        """Retire a retained managed session exactly once at lane shutdown."""
+        if self._action_active:
+            raise ScopedHttpError("managed authentication action session is still active")
         session = self._session
         self._session = None
         if session is None:
@@ -659,7 +696,7 @@ class ScopedGraphHttpExecutor:
     request, including each redirect hop, is validated and independently counted.
     """
 
-    def __init__(
+    def __init__(  # noqa: C901 - validates all executor ownership boundaries.
         self,
         *,
         target_url: str,
@@ -677,6 +714,8 @@ class ScopedGraphHttpExecutor:
         minimum_request_count: int = 0,
         authentication: ManagedGraphAuthentication | None = None,
         traffic_policy: TrafficPolicyController | None = None,
+        cache_anonymous_gets: bool = True,
+        persistent_managed_session: bool = False,
     ) -> None:
         assert_authorized_target(
             target_url,
@@ -721,6 +760,7 @@ class ScopedGraphHttpExecutor:
         ):
             raise ScopedHttpError("traffic policy belongs to a different target origin")
         self.authentication = authentication
+        self.cache_anonymous_gets = cache_anonymous_gets
         policy_config = getattr(bound_traffic_policy, "config", None)
         self._require_public_addresses = bool(
             getattr(policy_config, "require_public_addresses", False)
@@ -734,7 +774,10 @@ class ScopedGraphHttpExecutor:
             else ""
         )
         self.transport = (
-            ManagedAuthenticationScopedHttpTransport(authentication)
+            ManagedAuthenticationScopedHttpTransport(
+                authentication,
+                persistent_session=persistent_managed_session,
+            )
             if authentication is not None
             else transport or UrllibScopedHttpTransport(self._validated_transport_pins)
         )
@@ -743,7 +786,7 @@ class ScopedGraphHttpExecutor:
         self.traffic_observer = traffic_observer
         self._require_existing_state = require_existing_state
         self._minimum_request_count = minimum_request_count
-        request_count, pins = self._load_state()
+        request_count, pins, session_dirty = self._load_state()
         if request_count < minimum_request_count:
             raise ScopedHttpError(
                 "remote HTTP state request count is behind captured traffic history"
@@ -757,6 +800,7 @@ class ScopedGraphHttpExecutor:
                 "remote HTTP state request count does not match captured traffic history"
             )
         self._pins = pins
+        self._session_dirty = session_dirty
         self._pin_lock = threading.Lock()
         self._execution_lock = threading.Lock()
         self._gate = _RequestGate(
@@ -767,15 +811,44 @@ class ScopedGraphHttpExecutor:
             on_acquire=self._persist_state,
         )
         self._managed_request_acquisitions: list[tuple[int, float]] = []
-        if authentication is not None:
-            authentication.configure_request_gate(
-                cast(Callable[[str, str], None], self._account_managed_request)
-            )
         self._persist_state(request_count)
 
     @property
     def request_count(self) -> int:
         return self._gate.request_count
+
+    @property
+    def session_dirty(self) -> bool:
+        """Whether an anonymous cookie jar changed since its last clean start."""
+        return self._session_dirty
+
+    def mark_session_dirty(self) -> None:
+        if self._session_dirty:
+            return
+        self._session_dirty = True
+        self._persist_state(self.request_count)
+
+    def clear_session_dirty(self) -> None:
+        if not self._session_dirty:
+            return
+        self._session_dirty = False
+        self._persist_state(self.request_count)
+
+    def close(self) -> None:
+        transport = self.transport
+        if isinstance(transport, ManagedAuthenticationScopedHttpTransport):
+            try:
+                transport.close()
+            except BaseException as exc:
+                if self.authentication is not None:
+                    _cleanup_preserving(
+                        exc,
+                        lambda: self.authentication.configure_request_gate(None),
+                        message="managed authentication gate cleanup also failed",
+                    )
+                raise
+            if self.authentication is not None:
+                self.authentication.configure_request_gate(None)
 
     def __call__(
         self,
@@ -798,6 +871,7 @@ class ScopedGraphHttpExecutor:
         arguments: dict[str, object],
         action_id: str,
     ) -> ActionExecution:
+        authored_proofs = _request_authored_proofs(arguments)
         method, url, headers, body, timeout = _request_from_arguments(
             arguments,
             target_url=self.target_url,
@@ -820,7 +894,19 @@ class ScopedGraphHttpExecutor:
             if not isinstance(self.transport, ManagedAuthenticationScopedHttpTransport):
                 raise ScopedHttpError("managed authentication transport binding is invalid")
             managed_transport = self.transport
-            managed_transport.begin_action(timeout_seconds=timeout)
+            self.authentication.configure_request_gate(
+                cast("Callable[[str, str], None]", self._account_managed_request)
+            )
+            try:
+                managed_transport.begin_action(timeout_seconds=timeout)
+            except BaseException as exc:
+                _cleanup_preserving(
+                    exc,
+                    lambda: self.authentication.configure_request_gate(None),
+                    message="managed authentication gate cleanup also failed",
+                )
+                raise
+        action_error: BaseException | None = None
         try:
             for redirect_index in range(self.profile.max_redirects + 1):
                 if redirect_index > 0:
@@ -828,14 +914,51 @@ class ScopedGraphHttpExecutor:
                     self._verify_dns_pin(url)
                 attempt_index = 0
                 while True:
-                    dispatch = self._dispatch_request(
-                        method=method,
-                        url=url,
-                        headers=headers,
-                        body=body,
-                        timeout=timeout,
-                        attempt_index=attempt_index,
-                    )
+                    request_count_before = self.request_count
+                    try:
+                        dispatch = self._dispatch_request(
+                            method=method,
+                            url=url,
+                            headers=headers,
+                            body=body,
+                            timeout=timeout,
+                            attempt_index=attempt_index,
+                        )
+                    except BaseException as exc:
+                        # The gate commits at the physical dispatch boundary. If
+                        # transport control flow is then interrupted, close the
+                        # matching traffic half before preserving the interrupt.
+                        if (
+                            self.authentication is None
+                            and self.request_count > request_count_before
+                        ):
+                            interrupted = ScopedHttpTransportResponse(
+                                status=None,
+                                url=self._safe_url(url),
+                                headers={},
+                                body=b"",
+                                elapsed_ms=0,
+                                error=(
+                                    f"{type(exc).__name__}:"
+                                    "transport dispatch interrupted"
+                                ),
+                            )
+                            try:
+                                self._record_traffic(
+                                    observation_id=observation_id,
+                                    method=method,
+                                    url=self._safe_url(url),
+                                    headers=headers,
+                                    body=body,
+                                    response=interrupted,
+                                    response_body=b"",
+                                )
+                            except BaseException as capture_error:
+                                exc.add_note(
+                                    "interrupted HTTP traffic capture also failed: "
+                                    f"{type(capture_error).__name__}"
+                                )
+                        raise
                     raw_response = dispatch.response
                     raw_location = _header(raw_response.headers, "location")
                     response, decoded_body = self._redacted_response(raw_response)
@@ -843,7 +966,7 @@ class ScopedGraphHttpExecutor:
                         traffic_exchange_id = self._record_traffic(
                             observation_id=observation_id,
                             method=method,
-                            url=self._redact_text(url),
+                            url=self._safe_url(url),
                             headers=headers,
                             body=body,
                             response=response,
@@ -857,7 +980,7 @@ class ScopedGraphHttpExecutor:
                             redirect_index=redirect_index,
                             attempt_index=attempt_index,
                             method=method,
-                            url=self._redact_text(url),
+                            url=self._safe_url(url),
                             headers=headers,
                             body=body,
                             delay_seconds=dispatch.delay_seconds,
@@ -904,9 +1027,37 @@ class ScopedGraphHttpExecutor:
                     }
                 headers = next_headers
                 url = next_url
+        except BaseException as exc:
+            action_error = exc
+            raise
         finally:
+            cleanup_error = action_error
             if managed_transport is not None:
-                managed_transport.end_action()
+                if cleanup_error is None:
+                    try:
+                        managed_transport.end_action()
+                    except BaseException as exc:
+                        cleanup_error = exc
+                else:
+                    _cleanup_preserving(
+                        cleanup_error,
+                        managed_transport.end_action,
+                        message="managed authentication action cleanup also failed",
+                    )
+            if self.authentication is not None:
+                if cleanup_error is None:
+                    try:
+                        self.authentication.configure_request_gate(None)
+                    except BaseException as exc:
+                        cleanup_error = exc
+                else:
+                    _cleanup_preserving(
+                        cleanup_error,
+                        lambda: self.authentication.configure_request_gate(None),
+                        message="managed authentication gate cleanup also failed",
+                    )
+            if action_error is None and cleanup_error is not None:
+                raise cleanup_error
         if response is None:
             raise RuntimeError("remote HTTP executor produced no response")
 
@@ -946,11 +1097,15 @@ class ScopedGraphHttpExecutor:
             sort_keys=True,
         )
         proofs = []
-        if self.proof_recognition_enabled and response.status is not None:
+        if (
+            self.proof_recognition_enabled
+            and response.status is not None
+            and authored_proofs is not None
+        ):
             proofs = [
                 proof
                 for proof in recognize_proofs(decoded_body)
-                if not self._contains_secret(proof)
+                if proof not in authored_proofs and not self._contains_secret(proof)
             ]
         return ActionExecution(
             result=ActionResult(
@@ -1023,7 +1178,7 @@ class ScopedGraphHttpExecutor:
             lane="agent_http",
             identity_alias="anonymous",
             identity_generation=0,
-            cacheable=method in {"GET", "HEAD"},
+            cacheable=self.cache_anonymous_gets and method in {"GET", "HEAD"},
             retryable=method in {"GET", "HEAD"},
         )
         try:
@@ -1141,17 +1296,22 @@ class ScopedGraphHttpExecutor:
         response: ScopedHttpTransportResponse,
     ) -> tuple[ScopedHttpTransportResponse, str]:
         decoded_body = _decode_body(response.body, response.headers)
-        if self.authentication is None:
-            return response, decoded_body
-        safe_body = self._redact_text(decoded_body)
-        safe_error = self._redact_text(response.error)
-        safe_headers = {
-            str(name): self._redact_text(str(value)) for name, value in response.headers.items()
-        }
+        safe_body = (
+            decoded_body if self.authentication is None else self._redact_text(decoded_body)
+        )
+        safe_error = redact_traffic_text(self._redact_text(response.error), max_chars=2_048)
+        safe_headers = (
+            dict(response.headers)
+            if self.authentication is None
+            else {
+                str(name): self._redact_text(str(value))
+                for name, value in response.headers.items()
+            }
+        )
         return (
             ScopedHttpTransportResponse(
                 status=response.status,
-                url=self._redact_text(response.url),
+                url=self._safe_url(response.url),
                 headers=safe_headers,
                 body=safe_body.encode("utf-8"),
                 elapsed_ms=response.elapsed_ms,
@@ -1160,6 +1320,9 @@ class ScopedGraphHttpExecutor:
             ),
             safe_body,
         )
+
+    def _safe_url(self, value: str) -> str:
+        return sanitize_url(self._redact_text(value))
 
     def _redact_text(self, value: str) -> str:
         authentication = self.authentication
@@ -1265,11 +1428,11 @@ class ScopedGraphHttpExecutor:
 
     def _load_state(  # noqa: C901, PLR0912, PLR0915 - one fail-closed state boundary.
         self,
-    ) -> tuple[int, dict[tuple[str, int], tuple[str, ...]]]:
+    ) -> tuple[int, dict[tuple[str, int], tuple[str, ...]], bool]:
         if self.state_path is None:
             if self._require_existing_state or self._minimum_request_count:
                 raise ScopedHttpError("remote HTTP resume state path is required")
-            return 0, {}
+            return 0, {}, False
         try:
             descriptor = os.open(
                 self.state_path,
@@ -1280,7 +1443,7 @@ class ScopedGraphHttpExecutor:
                 raise ScopedHttpError(
                     "remote HTTP resume state is missing; refusing to reset request limits"
                 ) from None
-            return 0, {}
+            return 0, {}, False
         except OSError as exc:
             raise ScopedHttpError(f"cannot read remote HTTP state: {exc}") from exc
         try:
@@ -1338,7 +1501,10 @@ class ScopedGraphHttpExecutor:
             if key in pins:
                 raise ScopedHttpError("remote HTTP state DNS pin is duplicated")
             pins[key] = tuple(sorted(set(addresses)))
-        return raw_count, pins
+        raw_session_dirty = payload.get("session_dirty", False)
+        if not isinstance(raw_session_dirty, bool):
+            raise ScopedHttpError("remote HTTP state session marker is invalid")
+        return raw_count, pins, raw_session_dirty
 
     def _persist_state(self, request_count: int) -> None:
         if self.state_path is None:
@@ -1358,6 +1524,7 @@ class ScopedGraphHttpExecutor:
             "profile": self.profile.to_json(),
             "request_count": request_count,
             "dns_pins": pins,
+            "session_dirty": self._session_dirty,
         }
         encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
         if len(encoded) > _MAX_HTTP_STATE_BYTES:
@@ -1421,6 +1588,40 @@ def _target_identity(target_url: str) -> str:
     return f"target:{digest}"
 
 
+def _request_authored_proofs(
+    arguments: Mapping[str, object],
+) -> frozenset[str] | None:
+    """Return proof-shaped tokens supplied by the caller, including URL encoding."""
+    texts: list[str] = []
+    for key in ("url", "path", "body"):
+        value = arguments.get(key)
+        if value is not None:
+            texts.append(str(value))
+    for key in ("form", "json"):
+        value = arguments.get(key)
+        if value is not None:
+            texts.append(json.dumps(value, ensure_ascii=False, sort_keys=True, default=str))
+    headers = arguments.get("headers")
+    if isinstance(headers, Mapping):
+        for name, value in headers.items():
+            texts.extend((str(name), str(value)))
+
+    proofs: set[str] = set()
+    for text in texts:
+        decoded = text
+        for _index in range(_MAX_PROOF_CANONICALIZATION_PASSES):
+            proofs.update(recognize_proofs(decoded))
+            unquoted = unquote_plus(decoded)
+            if unquoted == decoded:
+                break
+            decoded = unquoted
+        else:
+            # If canonicalization cannot reach a stable form within the work
+            # bound, fail closed by disabling automatic proof capture.
+            return None
+    return frozenset(proofs)
+
+
 def _request_from_arguments(
     arguments: Mapping[str, object],
     *,
@@ -1452,7 +1653,7 @@ def _request_from_arguments(
     return method, url, headers, body, timeout
 
 
-def _request_headers(
+def _request_headers(  # noqa: C901 - validates each header trust boundary.
     value: object,
     *,
     stable_user_agent: str,
@@ -1469,11 +1670,15 @@ def _request_headers(
         "Accept-Encoding": "identity",
         "User-Agent": stable_user_agent,
     }
+    seen_names: set[str] = set()
     for raw_name, raw_value in raw_headers.items():
-        name = str(raw_name).strip()
-        if not name or "\n" in name or "\r" in name:
+        name = str(raw_name)
+        if _REQUEST_HEADER_NAME_RE.fullmatch(name) is None:
             raise ScopedHttpError("http_request header name is invalid")
         lowered = name.lower()
+        if lowered in seen_names:
+            raise ScopedHttpError(f"http_request header is duplicated: {name}")
+        seen_names.add(lowered)
         if lowered in _BLOCKED_REQUEST_HEADERS:
             raise ScopedHttpError(f"http_request header is blocked: {name}")
         if managed_authentication and lowered in _MANAGED_AUTH_HEADERS:
@@ -1485,6 +1690,9 @@ def _request_headers(
         rendered = str(raw_value)
         if "\n" in rendered or "\r" in rendered:
             raise ScopedHttpError(f"http_request header value is invalid: {name}")
+        for existing_name in tuple(headers):
+            if existing_name.casefold() == lowered:
+                headers.pop(existing_name)
         headers[name] = rendered
     return headers
 
@@ -1513,7 +1721,7 @@ def _request_body(
         if not isinstance(value, (Mapping, list)):
             raise ScopedHttpError("http_request json must be an object or list")
         encoded = json.dumps(value, ensure_ascii=False, sort_keys=True).encode()
-        headers.setdefault("Content-Type", "application/json")
+        _set_default_header(headers, "Content-Type", "application/json")
     else:
         if not isinstance(value, Mapping):
             raise ScopedHttpError("http_request form must be an object")
@@ -1525,13 +1733,20 @@ def _request_body(
         if len(fields) != len(value):
             raise ScopedHttpError("http_request form values must be scalar")
         encoded = urlencode(fields).encode()
-        headers.setdefault(
+        _set_default_header(
+            headers,
             "Content-Type",
             "application/x-www-form-urlencoded",
         )
     if len(encoded) > _MAX_REQUEST_BODY_BYTES:
         raise ScopedHttpError("http_request body exceeds the byte limit")
     return encoded
+
+
+def _set_default_header(headers: dict[str, str], name: str, value: str) -> None:
+    if any(existing.casefold() == name.casefold() for existing in headers):
+        return
+    headers[name] = value
 
 
 def _request_receipt(
@@ -1559,7 +1774,9 @@ def _request_receipt(
         "url": url,
         "request_header_names": sorted(headers),
         "request_body_bytes": len(body or b""),
-        "request_body_sha256": hashlib.sha256(body or b"").hexdigest(),
+        # A digest of a password, token, or short form value is an offline
+        # verifier. Preserve size/shape only, matching the traffic contract.
+        "request_body_sha256": "unavailable",
         "scheduled_delay_seconds": round(delay_seconds, 6),
         "status": response.status,
         "response_url": response.url,
@@ -1683,7 +1900,11 @@ def _header(headers: Mapping[str, str], name: str) -> str:
 def _observation_response_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {
         str(name): (
-            "[REDACTED]" if str(name).lower() in _SENSITIVE_RESPONSE_HEADERS else str(value)
+            "[REDACTED]"
+            if str(name).lower() in _SENSITIVE_RESPONSE_HEADERS
+            else sanitize_url(value)
+            if str(name).lower() == "location"
+            else redact_traffic_text(value, max_chars=1_024)
         )
         for name, value in headers.items()
     }

--- a/packages/ravage/src/ravage/agent_core/evidence_lead_lock.py
+++ b/packages/ravage/src/ravage/agent_core/evidence_lead_lock.py
@@ -1,0 +1,1326 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, unquote, urlsplit
+
+from ravage.agent_core.semantic_routes import semantic_action_route
+from ravage.outcome_evidence import (
+    OutcomeStage,
+    QualifiedProbeFinding,
+    outcome_stage_rank,
+    qualify_probe_findings,
+)
+
+if TYPE_CHECKING:
+    from ravage.agent_core.agent_state import AgentState
+
+_SURFACE_KEY = "evidence_lead_lock"
+_REPLAY_GENERATION_KEY = "evidence_lead_replay_generation"
+_STATE_VERSION = 2
+_MAX_ALIGNED_NO_PROGRESS = 2
+_MAX_VALIDATION_STEPS = 12
+_MAX_REQUEST_INPUTS = 32
+_MAX_REFERENCE_LENGTH = 160
+_QUALIFICATION_ORIGIN = "http://lead-lock.invalid/"
+_ACTIVE = "active"
+_AWAITING_SESSION = "awaiting_session"
+_RESOLVED = "resolved"
+_REJECTED = "rejected"
+_EXHAUSTED = "exhausted"
+_ALLOWED_ACTIONS = frozenset({"capture_flag", "http_request", "validate_poc"})
+_NON_ATTEMPT_OUTCOMES = frozenset(
+    {
+        "blocked",
+        "policy_blocked",
+        "same_as_before",
+        "timeout",
+        "timed_out",
+    }
+)
+_CONFIRMED_OUTCOMES = frozenset(
+    {
+        "flag_candidate",
+        "flag_captured",
+        "proof_confirmed",
+    }
+)
+_REJECTED_OUTCOMES = frozenset({"hypothesis_disproved", "lead_rejected"})
+_AUTH_FAMILIES = frozenset({"auth", "authentication", "authorization_session"})
+_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"})
+_INPUT_LOCATIONS = frozenset({"body", "query"})
+_AFFECTED_INPUT_LOCATIONS = frozenset({"body", "query"})
+_BODY_ENCODINGS = frozenset({"form", "json", "none", "raw"})
+_INPUT_RE = re.compile(r"^[A-Za-z0-9_.\[\]:-]{1,120}$")
+_FAMILY_RE = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+_FAMILY_ALIASES = {
+    "arbitrary_file_read": "path_traversal",
+    "file_read": "path_traversal",
+    "idor": "object_authorization",
+    "lfi": "path_traversal",
+    "server_side_template_injection": "template_injection",
+    "sqli": "sql_injection",
+    "ssrf": "server_side_request_forgery",
+    "ssti": "template_injection",
+    "xss": "cross_site_scripting",
+    "xxe": "xml_external_entity",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceLead:
+    """Secret-free, executor-owned route that remains locked until disposition."""
+
+    fingerprint: str
+    family: str
+    probe: str
+    finding_type: str
+    method: str
+    origin: str
+    endpoint: str
+    inputs: tuple[str, ...]
+    input_locations: tuple[tuple[str, str], ...]
+    request_inputs: tuple[tuple[str, str], ...]
+    body_encoding: str
+    source_kind: str
+    source_observation_id: str
+    stage: str
+    aligned_no_progress: int = 0
+    status: str = _ACTIVE
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "version": _STATE_VERSION,
+            "fingerprint": self.fingerprint,
+            "family": self.family,
+            "probe": self.probe,
+            "finding_type": self.finding_type,
+            "method": self.method,
+            "origin": self.origin,
+            "endpoint": self.endpoint,
+            "inputs": list(self.inputs),
+            "input_locations": _input_specs_json(self.input_locations),
+            "request_inputs": _input_specs_json(self.request_inputs),
+            "body_encoding": self.body_encoding,
+            "source_kind": self.source_kind,
+            "source_observation_id": self.source_observation_id,
+            "stage": self.stage,
+            "aligned_no_progress": self.aligned_no_progress,
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _DispatchShape:
+    declared_method: str
+    method: str
+    origin: str
+    endpoint: str
+    inputs: tuple[tuple[str, str], ...]
+    body_encoding: str
+
+
+def remember_from_probe_result(
+    state: AgentState,
+    text: str,
+    action: Mapping[str, object],
+    source_observation_id: str,
+) -> EvidenceLead | None:
+    """
+    Persist a trusted material lead, refusing untyped or auth-only observations.
+
+    The caller owns provenance: ``source_observation_id`` must identify the
+    executor observation associated with ``text``. This function additionally
+    requires either a valid native ``run_probe`` result or the executor's final
+    confirmed-finding payload for ``validate_poc``.
+    """
+    observation_id = _safe_reference(source_observation_id)
+    if not observation_id:
+        return None
+    kind = str(action.get("action") or "")
+    if kind == "run_probe":
+        candidate = _lead_from_native_probe(
+            text=text,
+            action=action,
+            source_observation_id=observation_id,
+        )
+    elif kind == "validate_poc":
+        candidate = _lead_from_confirmed_validate_poc(
+            text=text,
+            action=action,
+            source_observation_id=observation_id,
+        )
+    else:
+        # Raw HTTP and Python/shell output are observations, not typed findings.
+        return None
+    if candidate is None:
+        return None
+
+    current = _stored_lead(state)
+    if current is not None and current.status in {_ACTIVE, _AWAITING_SESSION}:
+        # A later observation cannot silently preempt an unresolved exact route.
+        return current
+    state.surface[_SURFACE_KEY] = candidate.to_json()
+    return candidate
+
+
+def pending_lead(state: AgentState) -> EvidenceLead | None:
+    """Return the active persisted lead, failing closed on malformed state."""
+    lead = unresolved_lead(state)
+    if lead is None or lead.status != _ACTIVE:
+        return None
+    return lead
+
+
+def awaiting_session_lead(state: AgentState) -> EvidenceLead | None:
+    """Return an auth-paused lead without treating it as an exact replay lock."""
+    lead = unresolved_lead(state)
+    if lead is None or lead.status != _AWAITING_SESSION:
+        return None
+    return lead
+
+
+def unresolved_lead(state: AgentState) -> EvidenceLead | None:
+    """Return an active or auth-paused persisted lead, failing closed."""
+    lead = _stored_lead(state)
+    if lead is None or lead.status not in {_ACTIVE, _AWAITING_SESSION}:
+        return None
+    return lead
+
+
+def release_for_session_reset(state: AgentState) -> EvidenceLead | None:
+    """Release a lead whose in-memory request session cannot be resumed."""
+    lead = _stored_lead(state)
+    if lead is None or lead.status not in {_ACTIVE, _AWAITING_SESSION}:
+        return None
+    released = replace(lead, status=_EXHAUSTED)
+    payload = released.to_json()
+    payload["release_reason"] = "http_session_reset"
+    state.surface[_SURFACE_KEY] = payload
+    return released
+
+
+def reactivate_for_session_change(state: AgentState) -> EvidenceLead | None:
+    """Reactivate an auth-paused lead after the persistent lane gains a session."""
+    lead = _stored_lead(state)
+    if lead is None or lead.status != _AWAITING_SESSION:
+        return None
+    return _reactivate_lead(state, lead)
+
+
+def lead_replay_generation(state: AgentState) -> int:
+    """Return the secret-free generation for a genuinely reactivated lead."""
+    value = state.surface.get(_REPLAY_GENERATION_KEY)
+    if not isinstance(value, int) or isinstance(value, bool):
+        return 0
+    return max(0, value)
+
+
+def action_matches_lead(
+    action: Mapping[str, object],
+    lead: EvidenceLead,
+    *,
+    primary_origin: str = "",
+) -> bool:
+    """Require every physically dispatched request shape to align with the lead."""
+    kind = str(action.get("action") or "")
+    if kind not in _ALLOWED_ACTIONS:
+        return False
+    # The executor independently requires the exact proof to have appeared in
+    # recent trusted target evidence. Let that strict closure action through.
+    if kind == "capture_flag":
+        return True
+    route = semantic_action_route(action)
+    action_family = _action_family(action, route=route)
+    if lead.family and action_family != lead.family:
+        return False
+    dispatches = _action_dispatch_shapes(action)
+    if not dispatches:
+        return False
+    return all(
+        _dispatch_matches_lead(
+            dispatch,
+            lead,
+            primary_origin=primary_origin,
+        )
+        for dispatch in dispatches
+    )
+
+
+def record_aligned_outcome(  # noqa: PLR0911 - explicit fail-closed lifecycle states.
+    state: AgentState,
+    action: Mapping[str, object],
+    outcome: Mapping[str, object],
+) -> EvidenceLead | None:
+    """
+    Record one aligned execution and return the lead if it remains pending.
+
+    Request-boundary failures, timeouts, and deduplicated actions do not
+    consume either of the two complete no-progress attempts. A ``validate_poc``
+    result that contains a response for every aligned replay step does count,
+    even when the executor rejects the finding claim built from those replies.
+    """
+    lead = _stored_lead(state)
+    if lead is None or lead.status not in {_ACTIVE, _AWAITING_SESSION}:
+        return None
+    if not action_matches_lead(
+        action,
+        lead,
+        primary_origin=state.surface_graph.target_origin,
+    ):
+        return lead if lead.status == _ACTIVE else None
+
+    auth_status = _authentication_required_http_status(state, action, outcome)
+    if auth_status is not None:
+        waiting = replace(lead, status=_AWAITING_SESSION)
+        payload = waiting.to_json()
+        payload["pause_reason"] = "authentication_required"
+        payload["response_status"] = auth_status
+        state.surface[_SURFACE_KEY] = payload
+        fact = (
+            f"evidence route {lead.method} {lead.endpoint} paused after HTTP {auth_status}; "
+            "establish authentication in the persistent http_request lane, then replay it"
+        )
+        if fact not in state.facts:
+            state.facts.append(fact)
+            del state.facts[:-80]
+        return None
+    outcome_name = str(outcome.get("outcome") or "").strip().lower()
+    if _outcome_confirmed(outcome, outcome_name=outcome_name):
+        _store(state, replace(lead, status=_RESOLVED))
+        return None
+    if outcome_name in _REJECTED_OUTCOMES:
+        _store(state, replace(lead, status=_REJECTED))
+        return None
+    completed = (
+        _complete_attempt(outcome, outcome_name=outcome_name)
+        or _completed_validate_attempt(action, outcome)
+    )
+    if lead.status == _AWAITING_SESSION:
+        if not completed:
+            return None
+        lead = _reactivate_lead(state, lead)
+    if not completed:
+        return lead
+
+    count = lead.aligned_no_progress + 1
+    status = _EXHAUSTED if count >= _MAX_ALIGNED_NO_PROGRESS else _ACTIVE
+    updated = replace(lead, aligned_no_progress=count, status=status)
+    _store(state, updated)
+    return updated if status == _ACTIVE else None
+
+
+def directive(state: AgentState) -> str:
+    """Render concise prompt guidance for the active exact-route obligation."""
+    lead = _stored_lead(state)
+    if lead is None:
+        return ""
+    inputs = ", ".join(lead.inputs) if lead.inputs else "the observed request shape"
+    if lead.status == _AWAITING_SESSION:
+        return (
+            f"Evidence route {lead.method} {lead.endpoint} is paused because its prior session "
+            "was unavailable. Establish authentication in the persistent http_request lane; "
+            "the exact route lock will reactivate when session state changes."
+        )
+    if lead.status != _ACTIVE:
+        return ""
+    remaining = _MAX_ALIGNED_NO_PROGRESS - lead.aligned_no_progress
+    return (
+        "Evidence lead lock active: continue "
+        f"{lead.family} on {lead.method or 'the observed method'} "
+        f"{lead.endpoint or 'the observed endpoint'} using {inputs}. "
+        "Stay on this route until it yields the target proof or a typed rejection; "
+        f"{remaining} complete aligned no-progress attempt(s) remain."
+    )
+
+
+def _lead_from_native_probe(
+    *,
+    text: str,
+    action: Mapping[str, object],
+    source_observation_id: str,
+) -> EvidenceLead | None:
+    probe = str(action.get("probe") or "").strip()
+    if not probe:
+        return None
+    candidates = qualify_probe_findings(
+        probe=probe,
+        probe_text=text,
+        target_url=_qualification_origin(action, text=text),
+    )
+    eligible = [item for item in candidates if _material_native_finding(item)]
+    if not eligible:
+        return None
+    qualified = max(
+        eligible,
+        key=lambda item: (outcome_stage_rank(item.stage), item.finding_type),
+    )
+    raw_endpoint = str(qualified.endpoint.get("url") or "")
+    endpoint = _normalize_endpoint(raw_endpoint)
+    origin = _normalize_origin(raw_endpoint) or _normalize_origin(
+        _qualification_origin(action, text=text)
+    )
+    method = _safe_method(qualified.endpoint.get("method") or qualified.request.get("method"))
+    family = _normalize_family(qualified.contract.vuln_class)
+    if not family or family in _AUTH_FAMILIES or not origin or not endpoint or not method:
+        return None
+    if _has_unmodelled_parameter(qualified.request.get("params")):
+        return None
+    native_shape, native_request_seen = _native_dispatch_shape(text, qualified)
+    if native_request_seen and native_shape is None:
+        return None
+    request_inputs = (
+        native_shape.inputs
+        if native_shape is not None
+        else _parameter_specs(qualified.request.get("params") or qualified.endpoint.get("params"))
+    )
+    input_locations = _qualified_affected_inputs(qualified) or request_inputs
+    body_encoding = (
+        native_shape.body_encoding
+        if native_shape is not None
+        else _native_body_encoding(text, qualified)
+    )
+    return _build_lead(
+        family=family,
+        probe=qualified.probe,
+        finding_type=qualified.finding_type,
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+        input_locations=input_locations,
+        request_inputs=request_inputs,
+        body_encoding=body_encoding,
+        source_kind="tool_run_probe",
+        source_observation_id=source_observation_id,
+        stage=qualified.stage.value,
+    )
+
+
+def _lead_from_confirmed_validate_poc(
+    *,
+    text: str,
+    action: Mapping[str, object],
+    source_observation_id: str,
+) -> EvidenceLead | None:
+    payload = _json_object(text)
+    provenance = payload.get("provenance")
+    provenance_map = provenance if isinstance(provenance, Mapping) else {}
+    checks = payload.get("evidence_checks")
+    check_map = checks if isinstance(checks, Mapping) else {}
+    stage = str(payload.get("outcome_stage") or "")
+    source_matches = (
+        str(payload.get("source_kind") or "") == "tool_validate_poc"
+        and str(payload.get("source_observation_id") or "") == source_observation_id
+        and str(provenance_map.get("source_kind") or "") == "tool_validate_poc"
+        and str(provenance_map.get("source_observation_id") or "") == source_observation_id
+    )
+    required = _nonnegative_int(check_map.get("required"))
+    passed = _nonnegative_int(check_map.get("passed"))
+    if not (
+        payload.get("status") == "confirmed"
+        and payload.get("validator_vote") == "confirm"
+        and payload.get("assessment_source") == "executor_policy"
+        and payload.get("evidence_kind") == "http_poc_replay"
+        and provenance_map.get("model_claims_used") is False
+        and source_matches
+        and required >= 1
+        and passed >= required
+        and outcome_stage_rank(stage) >= outcome_stage_rank(OutcomeStage.VERIFIED_VULNERABILITY)
+    ):
+        return None
+
+    endpoint_value = payload.get("endpoint")
+    endpoint_map = endpoint_value if isinstance(endpoint_value, Mapping) else {}
+    input_value = payload.get("input")
+    input_map = input_value if isinstance(input_value, Mapping) else {}
+    family = _normalize_family(payload.get("vuln_class"))
+    raw_endpoint = str(endpoint_map.get("url") or "")
+    endpoint = _normalize_endpoint(raw_endpoint)
+    origin = _normalize_origin(raw_endpoint)
+    method = _safe_method(endpoint_map.get("method") or input_map.get("method"))
+    if any(
+        _has_unmodelled_parameter(value)
+        for value in (
+            input_map.get("parameters"),
+            input_map.get("affected_parameters"),
+            endpoint_map.get("params"),
+        )
+    ):
+        return None
+    input_locations = _parameter_specs(input_map.get("affected_parameters"))
+    dispatch = _validated_dispatch_shape(
+        action,
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+    )
+    if (
+        not family
+        or family in _AUTH_FAMILIES
+        or not origin
+        or not endpoint
+        or not method
+        or dispatch is None
+    ):
+        return None
+    request_inputs = dispatch.inputs
+    if not input_locations:
+        input_locations = request_inputs
+    body_encoding = dispatch.body_encoding
+    finding_type = str(provenance_map.get("finding_type") or "confirmed_validate_poc")
+    return _build_lead(
+        family=family,
+        probe=str(provenance_map.get("probe") or "validate_poc"),
+        finding_type=finding_type,
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+        input_locations=input_locations,
+        request_inputs=request_inputs,
+        body_encoding=body_encoding,
+        source_kind="tool_validate_poc",
+        source_observation_id=source_observation_id,
+        stage=stage,
+    )
+
+
+def _material_native_finding(finding: QualifiedProbeFinding) -> bool:
+    verified_rank = outcome_stage_rank(OutcomeStage.VERIFIED_VULNERABILITY)
+    return (
+        finding.promotable
+        and finding.contract_status == "registered"
+        and outcome_stage_rank(finding.stage) >= verified_rank
+        and _normalize_family(finding.contract.vuln_class) not in _AUTH_FAMILIES
+    )
+
+
+def _qualified_affected_inputs(
+    finding: QualifiedProbeFinding,
+) -> tuple[tuple[str, str], ...]:
+    affected = finding.request.get("affected_parameter")
+    if isinstance(affected, Mapping):
+        return _parameter_specs([affected])
+    return ()
+
+
+def _parameter_specs(value: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, list):
+        return ()
+    specs = [
+        (location, name)
+        for item in value[:_MAX_REQUEST_INPUTS]
+        if isinstance(item, Mapping)
+        if (name := _safe_input(item.get("name")))
+        if (location := _safe_input_location(item.get("location")))
+    ]
+    return tuple(sorted(specs))
+
+
+def _has_unmodelled_parameter(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    return any(
+        isinstance(item, Mapping)
+        and str(item.get("location") or "").strip().casefold()
+        not in _AFFECTED_INPUT_LOCATIONS
+        for item in value[:_MAX_REQUEST_INPUTS]
+    )
+
+
+def _native_dispatch_shape(
+    text: str,
+    finding: QualifiedProbeFinding,
+) -> tuple[_DispatchShape | None, bool]:
+    payload = _json_object(text)
+    raw_findings = payload.get("findings")
+    if not isinstance(raw_findings, list):
+        return None, False
+    expected_method = _safe_method(
+        finding.endpoint.get("method") or finding.request.get("method")
+    )
+    expected_endpoint = _normalize_endpoint(str(finding.endpoint.get("url") or ""))
+    expected_origin = _normalize_origin(str(finding.endpoint.get("url") or ""))
+    request_seen = False
+    for raw_finding in raw_findings:
+        if not isinstance(raw_finding, Mapping):
+            continue
+        if str(raw_finding.get("type") or "") != finding.finding_type:
+            continue
+        for key in finding.contract.request_keys:
+            raw_request = raw_finding.get(key)
+            if not isinstance(raw_request, Mapping):
+                continue
+            request_seen = True
+            request = _request_with_declared_encoding(raw_request)
+            shape = _dispatch_shape(request, validator_step=False)
+            if shape is None:
+                continue
+            if (
+                shape.method == expected_method
+                and shape.endpoint == expected_endpoint
+                and (not shape.origin or not expected_origin or shape.origin == expected_origin)
+            ):
+                return shape, True
+    return None, request_seen
+
+
+def _request_with_declared_encoding(
+    request: Mapping[str, object],
+) -> dict[str, object]:
+    prepared = dict(request)
+    encoding = _encoding_label(request.get("encoding"))
+    if encoding not in {"form", "json"} or _request_content_type(request):
+        return prepared
+    headers = request.get("headers")
+    copied_headers = dict(headers) if isinstance(headers, Mapping) else {}
+    copied_headers["Content-Type"] = (
+        "application/x-www-form-urlencoded" if encoding == "form" else "application/json"
+    )
+    prepared["headers"] = copied_headers
+    return prepared
+
+
+def _native_body_encoding(  # noqa: C901 - typed native shapes vary by specialist.
+    text: str,
+    finding: QualifiedProbeFinding,
+) -> str:
+    payload = _json_object(text)
+    raw_findings = payload.get("findings")
+    if isinstance(raw_findings, list):
+        for raw_finding in raw_findings:
+            if not isinstance(raw_finding, Mapping):
+                continue
+            if str(raw_finding.get("type") or "") != finding.finding_type:
+                continue
+            for key in finding.contract.request_keys:
+                request = raw_finding.get(key)
+                if not isinstance(request, Mapping):
+                    continue
+                declared = _safe_method(request.get("method") or "GET")
+                endpoint = _normalize_endpoint(str(request.get("url") or ""))
+                if declared != str(finding.endpoint.get("method") or "").upper():
+                    continue
+                if endpoint != _normalize_endpoint(str(finding.endpoint.get("url") or "")):
+                    continue
+                encoding = _encoding_label(request.get("encoding"))
+                if encoding:
+                    return encoding
+                inferred = _request_body_encoding(request, validator_step=False)
+                if inferred:
+                    return inferred
+    encoding = _encoding_label(finding.request.get("encoding"))
+    if encoding:
+        return encoding
+    request_inputs = _parameter_specs(
+        finding.request.get("params") or finding.endpoint.get("params")
+    )
+    return "raw" if any(location == "body" for location, _name in request_inputs) else "none"
+
+
+def _validated_dispatch_shape(
+    action: Mapping[str, object],
+    *,
+    method: str,
+    origin: str,
+    endpoint: str,
+) -> _DispatchShape | None:
+    steps = action.get("steps")
+    if not isinstance(steps, list):
+        return None
+    ordered = sorted(
+        (step for step in steps if isinstance(step, Mapping)),
+        key=lambda step: str(step.get("evidence_role") or "") != "exploit",
+    )
+    for step in ordered:
+        shape = _dispatch_shape(step, validator_step=True)
+        if shape is None:
+            continue
+        if (
+            shape.method == method
+            and shape.endpoint == endpoint
+            and (not shape.origin or shape.origin == origin)
+        ):
+            return shape
+    return None
+
+
+def _encoding_label(value: object) -> str:
+    label = str(value or "").strip().casefold()
+    if label in _BODY_ENCODINGS:
+        return label
+    media_type = label.split(";", 1)[0].strip()
+    if media_type == "application/x-www-form-urlencoded":
+        return "form"
+    if media_type == "application/json" or media_type.endswith("+json"):
+        return "json"
+    return ""
+
+
+def _safe_body_encoding(
+    value: object,
+    *,
+    request_inputs: tuple[tuple[str, str], ...],
+) -> str:
+    encoding = _encoding_label(value)
+    if encoding:
+        return encoding
+    return "raw" if any(location == "body" for location, _name in request_inputs) else "none"
+
+
+def _safe_input_location(value: object) -> str:
+    location = str(value or "").strip().casefold()
+    return location if location in _INPUT_LOCATIONS else ""
+
+
+def _input_specs_json(specs: tuple[tuple[str, str], ...]) -> list[dict[str, str]]:
+    return [{"location": location, "name": name} for location, name in specs]
+
+
+def _build_lead(  # noqa: PLR0913
+    *,
+    family: str,
+    probe: str,
+    finding_type: str,
+    method: str,
+    origin: str,
+    endpoint: str,
+    input_locations: tuple[tuple[str, str], ...],
+    request_inputs: tuple[tuple[str, str], ...],
+    body_encoding: str,
+    source_kind: str,
+    source_observation_id: str,
+    stage: str,
+) -> EvidenceLead | None:
+    affected = tuple(sorted(set(input_locations)))
+    request_shape_items = list(request_inputs)
+    request_shape_items.extend(item for item in affected if item not in request_shape_items)
+    request_shape = tuple(sorted(request_shape_items))
+    encoding = _safe_body_encoding(body_encoding, request_inputs=request_shape)
+    if (
+        not affected
+        or len(request_shape) > _MAX_REQUEST_INPUTS
+        or any(location not in _AFFECTED_INPUT_LOCATIONS for location, _name in affected)
+        or any(name.startswith("path[") for _location, name in affected)
+        or any(name == "raw_body" for _location, name in affected)
+        or _is_structural_endpoint(endpoint)
+        or encoding == "raw"
+        or (
+            any(location == "body" for location, _name in affected)
+            and encoding not in {"form", "json"}
+        )
+    ):
+        # The lock matcher mutates named query/form/JSON slots only. Header
+        # names may constrain the exact request shape, but never become an
+        # affected input because their values cannot be persisted safely.
+        return None
+    lead = EvidenceLead(
+        fingerprint="",
+        family=family,
+        probe=probe,
+        finding_type=finding_type,
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+        inputs=tuple(sorted({name for _location, name in affected})),
+        input_locations=affected,
+        request_inputs=request_shape,
+        body_encoding=encoding,
+        source_kind=source_kind,
+        source_observation_id=source_observation_id,
+        stage=stage,
+    )
+    return replace(lead, fingerprint=_lead_fingerprint(lead))
+
+
+def _lead_fingerprint(lead: EvidenceLead) -> str:
+    identity = {
+        "family": lead.family,
+        "probe": lead.probe,
+        "finding_type": lead.finding_type,
+        "method": lead.method,
+        "origin": lead.origin,
+        "endpoint": lead.endpoint,
+        "inputs": list(lead.inputs),
+        "input_locations": _input_specs_json(lead.input_locations),
+        "request_inputs": _input_specs_json(lead.request_inputs),
+        "body_encoding": lead.body_encoding,
+        "source_kind": lead.source_kind,
+        "source_observation_id": lead.source_observation_id,
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    return "lead:" + hashlib.sha256(encoded.encode()).hexdigest()[:20]
+
+
+def _lead_from_json(value: Mapping[str, object]) -> EvidenceLead | None:
+    if value.get("version") != _STATE_VERSION:
+        return None
+    family = _normalize_family(value.get("family"))
+    method = _safe_method(value.get("method"))
+    origin = _normalize_origin(str(value.get("origin") or ""))
+    endpoint = _normalize_endpoint(str(value.get("endpoint") or ""))
+    fingerprint = str(value.get("fingerprint") or "")
+    source_observation_id = _safe_reference(value.get("source_observation_id"))
+    status = str(value.get("status") or "")
+    inputs_value = value.get("inputs")
+    inputs = (
+        tuple(
+            sorted(
+                {
+                    name
+                    for item in inputs_value
+                    if (name := _safe_input(item))
+                }
+            )
+        )
+        if isinstance(inputs_value, list)
+        else ()
+    )
+    no_progress = _nonnegative_int(value.get("aligned_no_progress"))
+    source_kind = str(value.get("source_kind") or "")
+    input_locations = _parameter_specs(value.get("input_locations"))
+    request_inputs = _parameter_specs(value.get("request_inputs"))
+    body_encoding = _safe_body_encoding(
+        value.get("body_encoding"),
+        request_inputs=request_inputs,
+    )
+    expected_inputs = tuple(sorted({name for _location, name in input_locations}))
+    if (
+        not fingerprint.startswith("lead:")
+        or not family
+        or not method
+        or not origin
+        or not endpoint
+        or not source_observation_id
+        or status not in {_ACTIVE, _AWAITING_SESSION, _EXHAUSTED, _REJECTED, _RESOLVED}
+        or source_kind not in {"tool_run_probe", "tool_validate_poc"}
+        or no_progress > _MAX_ALIGNED_NO_PROGRESS
+        or tuple(sorted(inputs)) != expected_inputs
+        or len(request_inputs) > _MAX_REQUEST_INPUTS
+        or input_locations != tuple(sorted(set(input_locations)))
+        or not set(input_locations).issubset(request_inputs)
+        or any(
+            location not in _AFFECTED_INPUT_LOCATIONS
+            for location, _name in input_locations
+        )
+        or any(name.startswith("path[") for _location, name in input_locations)
+        or any(name == "raw_body" for _location, name in input_locations)
+        or _is_structural_endpoint(endpoint)
+        or body_encoding == "raw"
+        or (
+            any(location == "body" for location, _name in input_locations)
+            and body_encoding not in {"form", "json"}
+        )
+    ):
+        return None
+    lead = EvidenceLead(
+        fingerprint="",
+        family=family,
+        probe=str(value.get("probe") or ""),
+        finding_type=str(value.get("finding_type") or ""),
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+        inputs=inputs,
+        input_locations=input_locations,
+        request_inputs=request_inputs,
+        body_encoding=body_encoding,
+        source_kind=source_kind,
+        source_observation_id=source_observation_id,
+        stage=str(value.get("stage") or ""),
+        aligned_no_progress=no_progress,
+        status=status,
+    )
+    expected = _lead_fingerprint(lead)
+    return replace(lead, fingerprint=expected) if fingerprint == expected else None
+
+
+def _action_family(
+    action: Mapping[str, object],
+    *,
+    route: Mapping[str, object],
+) -> str:
+    explicit = action.get("family") or action.get("vuln_class")
+    finding = action.get("finding")
+    if not explicit and isinstance(finding, Mapping):
+        explicit = finding.get("vuln_class")
+    return _normalize_family(explicit or route.get("family"))
+
+
+def _normalize_family(value: object) -> str:
+    family = str(value or "").strip().lower()
+    normalized = _FAMILY_ALIASES.get(family, family)
+    return normalized if _FAMILY_RE.fullmatch(normalized) else ""
+
+
+def _action_dispatch_shapes(action: Mapping[str, object]) -> tuple[_DispatchShape, ...]:
+    kind = str(action.get("action") or "")
+    if kind == "http_request":
+        shape = _dispatch_shape(action, validator_step=False)
+        return (shape,) if shape is not None else ()
+    if kind != "validate_poc":
+        return ()
+    steps = action.get("steps")
+    if not isinstance(steps, list) or not steps or len(steps) > _MAX_VALIDATION_STEPS:
+        return ()
+    shapes: list[_DispatchShape] = []
+    for step in steps:
+        if not isinstance(step, Mapping):
+            return ()
+        shape = _dispatch_shape(step, validator_step=True)
+        if shape is None:
+            return ()
+        shapes.append(shape)
+    return tuple(shapes)
+
+
+def _dispatch_shape(
+    request: Mapping[str, object],
+    *,
+    validator_step: bool,
+) -> _DispatchShape | None:
+    declared_method = _safe_method(request.get("method") or "GET")
+    raw_endpoint = str(request.get("url") or request.get("path") or "")
+    endpoint = _normalize_endpoint(raw_endpoint)
+    origin = _normalize_origin(raw_endpoint)
+    try:
+        parsed_endpoint = urlsplit(raw_endpoint)
+    except ValueError:
+        return None
+    if (parsed_endpoint.scheme or parsed_endpoint.netloc) and not origin:
+        return None
+    if (
+        not declared_method
+        or not endpoint
+        or _is_structural_endpoint(endpoint)
+        or _has_duplicate_case_insensitive_headers(request)
+    ):
+        return None
+    method = declared_method
+    body_encoding = _request_body_encoding(request, validator_step=validator_step)
+    if body_encoding not in _BODY_ENCODINGS or not _headers_are_modelled(
+        request,
+        body_encoding=body_encoding,
+    ):
+        return None
+    inputs = _request_input_specs(request, body_encoding=body_encoding)
+    if inputs is None:
+        return None
+    return _DispatchShape(
+        declared_method=declared_method,
+        method=method,
+        origin=origin,
+        endpoint=endpoint,
+        inputs=inputs,
+        body_encoding=body_encoding,
+    )
+
+
+def _dispatch_matches_lead(
+    dispatch: _DispatchShape,
+    lead: EvidenceLead,
+    *,
+    primary_origin: str,
+) -> bool:
+    effective_origin = dispatch.origin or _normalize_origin(primary_origin)
+    return (
+        dispatch.declared_method == lead.method
+        and dispatch.method == lead.method
+        and effective_origin == lead.origin
+        and dispatch.endpoint == lead.endpoint
+        and dispatch.inputs == lead.request_inputs
+        and dispatch.body_encoding == lead.body_encoding
+        and set(lead.input_locations).issubset(dispatch.inputs)
+    )
+
+
+def _request_input_specs(
+    request: Mapping[str, object],
+    *,
+    body_encoding: str,
+) -> tuple[tuple[str, str], ...] | None:
+    raw_url = str(request.get("url") or request.get("path") or "")
+    try:
+        query_pairs = parse_qsl(urlsplit(raw_url).query, keep_blank_values=True)
+    except ValueError:
+        query_pairs = []
+    specs = [
+        ("query", name)
+        for raw_name, _value in query_pairs
+        if (name := _safe_input(raw_name))
+    ]
+    container = request.get("form") if body_encoding == "form" else request.get("json")
+    if body_encoding == "json" and container is not None and not isinstance(
+        container,
+        Mapping,
+    ):
+        # JSON arrays/scalars have no stable named slots for this lock.
+        return None
+    if isinstance(container, Mapping):
+        if any(not _safe_input(raw_name) for raw_name in container):
+            return None
+        specs.extend(
+            ("body", name)
+            for raw_name in container
+            if (name := _safe_input(raw_name))
+        )
+    elif body_encoding in {"form", "json"} and request.get("body") is not None:
+        raw_specs = _raw_body_input_specs(request.get("body"), encoding=body_encoding)
+        if raw_specs is None:
+            return None
+        specs.extend(raw_specs)
+    return tuple(sorted(specs))
+
+
+def _headers_are_modelled(
+    request: Mapping[str, object],
+    *,
+    body_encoding: str,
+) -> bool:
+    headers = request.get("headers")
+    if not isinstance(headers, Mapping) or not headers:
+        return True
+    normalized = {
+        str(name).strip().casefold(): str(value).split(";", 1)[0].strip().casefold()
+        for name, value in headers.items()
+    }
+    if set(normalized) != {"content-type"}:
+        return False
+    content_type = normalized["content-type"]
+    if body_encoding == "form":
+        return content_type == "application/x-www-form-urlencoded"
+    if body_encoding == "json":
+        return content_type == "application/json" or content_type.endswith("+json")
+    return False
+
+
+def _raw_body_input_specs(
+    value: object,
+    *,
+    encoding: str,
+) -> list[tuple[str, str]] | None:
+    text = str(value or "")
+    if encoding == "form":
+        try:
+            pairs = parse_qsl(
+                text,
+                keep_blank_values=True,
+                max_num_fields=_MAX_REQUEST_INPUTS,
+            )
+        except ValueError:
+            return None
+        names = [_safe_input(raw_name) for raw_name, _item in pairs]
+        if (text and not pairs) or any(not name for name in names):
+            return None
+        return [
+            ("body", name)
+            for name in names
+        ]
+    if encoding != "json":
+        return []
+    try:
+        payload = json.loads(text, object_pairs_hook=lambda pairs: tuple(pairs))
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, tuple):
+        return None
+    names = [_safe_input(raw_name) for raw_name, _value in payload]
+    if any(not name for name in names):
+        return None
+    return [("body", name) for name in names]
+
+
+def _request_body_encoding(  # noqa: PLR0911 - fail closed by physical encoding.
+    request: Mapping[str, object],
+    *,
+    validator_step: bool,
+) -> str:
+    form = request.get("form")
+    if isinstance(form, Mapping):
+        content_type = _request_content_type(request)
+        return (
+            "form"
+            if not content_type or content_type == "application/x-www-form-urlencoded"
+            else ""
+        )
+    if request.get("json") is not None:
+        # validate_http_poc does not dispatch its json key. Refuse to treat
+        # declarative JSON metadata as a physical body in that lane.
+        if validator_step:
+            return ""
+        content_type = _request_content_type(request)
+        return (
+            "json"
+            if not content_type
+            or content_type == "application/json"
+            or content_type.endswith("+json")
+            else ""
+        )
+    if request.get("body") is None:
+        return "none"
+    content_type = _request_content_type(request)
+    if content_type == "application/x-www-form-urlencoded":
+        return "form"
+    if content_type == "application/json" or content_type.endswith("+json"):
+        return "json"
+    return "raw"
+
+
+def _request_content_type(request: Mapping[str, object]) -> str:
+    headers = request.get("headers")
+    if not isinstance(headers, Mapping):
+        return ""
+    for name, value in headers.items():
+        if str(name).strip().casefold() == "content-type":
+            return str(value).split(";", 1)[0].strip().casefold()
+    return ""
+
+
+def _has_duplicate_case_insensitive_headers(request: Mapping[str, object]) -> bool:
+    headers = request.get("headers")
+    if not isinstance(headers, Mapping):
+        return False
+    normalized_names = [str(name).strip().casefold() for name in headers]
+    return len(normalized_names) != len(set(normalized_names))
+
+
+def _normalize_endpoint(value: str) -> str:
+    if not value.strip():
+        return ""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return ""
+    return parsed.path or "/"
+
+
+def _is_structural_endpoint(value: str) -> bool:
+    """Reject redacted/templated paths that are not concrete replay targets."""
+    try:
+        path = urlsplit(value).path
+    except ValueError:
+        return True
+    for raw_segment in path.split("/"):
+        decoded = raw_segment
+        for _attempt in range(2):
+            expanded = unquote(decoded)
+            if expanded == decoded:
+                break
+            decoded = expanded
+        lowered = decoded.strip().casefold()
+        if (
+            "{" in lowered
+            or "}" in lowered
+            or "<" in lowered
+            or ">" in lowered
+            or lowered in {":id", ":redacted"}
+        ):
+            return True
+    return False
+
+
+def _normalize_origin(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return ""
+    scheme = parsed.scheme.casefold()
+    hostname = str(parsed.hostname or "").casefold().rstrip(".")
+    if scheme not in {"http", "https"} or not hostname or parsed.username or parsed.password:
+        return ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    default_port = 80 if scheme == "http" else 443
+    authority = hostname if port in {None, default_port} else f"{hostname}:{port}"
+    return f"{scheme}://{authority}"
+
+
+def _safe_method(value: object) -> str:
+    method = str(value or "").strip().upper()
+    return method if method in _HTTP_METHODS else ""
+
+
+def _safe_input(value: object) -> str:
+    name = str(value or "").strip()
+    return name if _INPUT_RE.fullmatch(name) else ""
+
+
+def _safe_reference(value: object) -> str:
+    reference = str(value or "").strip()
+    if not reference or len(reference) > _MAX_REFERENCE_LENGTH:
+        return ""
+    allowed = "-_.:"
+    if any(
+        not (character.isascii() and (character.isalnum() or character in allowed))
+        for character in reference
+    ):
+        return ""
+    return reference
+
+
+def _qualification_origin(action: Mapping[str, object], *, text: str) -> str:
+    for candidate in (action.get("target_url"), action.get("url")):
+        value = str(candidate or "").strip()
+        if _absolute_http_url(value):
+            parsed = urlsplit(value)
+            return f"{parsed.scheme}://{parsed.netloc}/"
+    payload = _json_object(text)
+    absolute = _first_absolute_url(payload)
+    if absolute:
+        parsed = urlsplit(absolute)
+        return f"{parsed.scheme}://{parsed.netloc}/"
+    return _QUALIFICATION_ORIGIN
+
+
+def _first_absolute_url(value: object) -> str:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key) in {"url", "target", "endpoint", "final_url", "replay_url"}:
+                candidate = str(item or "").strip()
+                if _absolute_http_url(candidate):
+                    return candidate
+            nested = _first_absolute_url(item)
+            if nested:
+                return nested
+    elif isinstance(value, list):
+        for item in value:
+            nested = _first_absolute_url(item)
+            if nested:
+                return nested
+    return ""
+
+
+def _absolute_http_url(value: str) -> bool:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _json_object(text: str) -> dict[str, object]:
+    try:
+        value = json.JSONDecoder(strict=False).decode(text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _nonnegative_int(value: object) -> int:
+    try:
+        return max(0, int(str(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _outcome_confirmed(outcome: Mapping[str, object], *, outcome_name: str) -> bool:
+    return bool(
+        outcome.get("flag")
+        or outcome.get("flag_captured")
+        or outcome_name in _CONFIRMED_OUTCOMES
+    )
+
+
+def _complete_attempt(outcome: Mapping[str, object], *, outcome_name: str) -> bool:
+    if outcome.get("timed_out") is True or outcome_name in _NON_ATTEMPT_OUTCOMES:
+        return False
+    return outcome.get("ok") is True
+
+
+def _completed_validate_attempt(  # noqa: PLR0911 - strict evidence gate.
+    action: Mapping[str, object],
+    outcome: Mapping[str, object],
+) -> bool:
+    """Recognize a physically completed paired replay without trusting its vote."""
+    if str(action.get("action") or "") != "validate_poc" or outcome.get("timed_out") is True:
+        return False
+    raw_steps = action.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        return False
+    evidence_text = outcome.get("_evidence_observation")
+    if not isinstance(evidence_text, str) or not evidence_text:
+        return False
+    payload = _json_object(evidence_text)
+    completed_steps = payload.get("steps")
+    if not isinstance(completed_steps, list) or len(completed_steps) != len(raw_steps):
+        return False
+    for step in completed_steps:
+        if not isinstance(step, Mapping):
+            return False
+        response = step.get("response")
+        if not isinstance(response, Mapping):
+            return False
+        status = response.get("status")
+        if not isinstance(status, int) or isinstance(status, bool) or response.get("error"):
+            return False
+    return True
+
+
+def _authentication_required_http_status(  # noqa: C901, PLR0911
+    state: AgentState,
+    action: Mapping[str, object],
+    outcome: Mapping[str, object],
+) -> int | None:
+    kind = str(action.get("action") or "")
+    if kind == "http_request":
+        evidence_text = outcome.get("_evidence_observation")
+        if isinstance(evidence_text, str) and evidence_text:
+            response = _json_object(evidence_text).get("response")
+            if not isinstance(response, Mapping):
+                return None
+            return _auth_required_status(response.get("status"))
+        # A pre-dispatch block does not replace ``last_observation``. Do not let
+        # a prior request's auth response pause the current aligned attempt.
+        if outcome.get("ok") is not True:
+            return None
+        response = state.last_observation.get("http_response")
+        if not isinstance(response, Mapping):
+            return None
+        return _auth_required_status(response.get("status"))
+    if kind != "validate_poc":
+        return None
+    raw_steps = action.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        return None
+    evidence_text = outcome.get("_evidence_observation")
+    if not isinstance(evidence_text, str) or not evidence_text:
+        return None
+    steps = _json_object(evidence_text).get("steps")
+    if not isinstance(steps, list) or len(steps) != len(raw_steps):
+        return None
+    statuses: list[int] = []
+    for step in steps:
+        response = step.get("response") if isinstance(step, Mapping) else None
+        status = _auth_required_status(
+            response.get("status") if isinstance(response, Mapping) else None
+        )
+        if status is None:
+            return None
+        statuses.append(status)
+    return statuses[0]
+
+
+def _auth_required_status(value: object) -> int | None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None
+    return value if value in {401, 403, 407} else None
+
+
+def _stored_lead(state: AgentState) -> EvidenceLead | None:
+    value = state.surface.get(_SURFACE_KEY)
+    return _lead_from_json(value) if isinstance(value, Mapping) else None
+
+
+def _store(state: AgentState, lead: EvidenceLead) -> None:
+    state.surface[_SURFACE_KEY] = lead.to_json()
+
+
+def _reactivate_lead(state: AgentState, lead: EvidenceLead) -> EvidenceLead:
+    active = replace(lead, status=_ACTIVE, aligned_no_progress=0)
+    _store(state, active)
+    state.surface[_REPLAY_GENERATION_KEY] = lead_replay_generation(state) + 1
+    return active

--- a/packages/ravage/src/ravage/agent_core/harness_trace.py
+++ b/packages/ravage/src/ravage/agent_core/harness_trace.py
@@ -13,6 +13,7 @@ from ravage.agent_core.agent_strategy import (
 )
 from ravage.agent_core.recovery_action_contract import RECOVERY_OBJECTIVE_ACTION_STRATEGY
 from ravage.agent_core.semantic_routes import semantic_action_fingerprint, semantic_action_route
+from ravage.traffic.redaction import redact_headers, redact_text, sanitize_url
 
 if TYPE_CHECKING:
     from ravage.agent_core.agent_state import AgentState
@@ -33,6 +34,9 @@ _SENSITIVE_HEADER_RE = re.compile(
 )
 _INLINE_SENSITIVE_HEADER_RE = re.compile(
     r"(?i)((?:authorization|cookie|x-api-key|x-auth-token|x-access-token)\s*:\s*)[^'\"\n]+"
+)
+_EMBEDDED_URL_RE = re.compile(
+    r"(?i)(?:https?://[^\s'\"<>]+|(?<![A-Za-z0-9:/])/[^\s'\"<>]*[?#][^\s'\"<>]+)"
 )
 
 
@@ -120,7 +124,8 @@ def selection_trace_payload(  # noqa: PLR0913 - flat fields define the trace sch
             "would_route": shadow_action is not None,
             "reason": shadow_reason,
             "suggested_action": sanitize_action(shadow_action or {}),
-            "suggestion_matches_selected": bool(shadow_action)
+            "suggestion_matches_selected": shadow_action is not None
+            and bool(shadow_action)
             and _action_signature(shadow_action) == _action_signature(selected_action),
         },
         "repeat_context": _sanitize_string(repeat_context),
@@ -178,7 +183,7 @@ def attempt_record_payload(  # noqa: PLR0913 - mirrors the turn boundary.
         ),
         "exact_selected_fingerprint": _stable_digest(
             action_fingerprint(
-                selected_action,
+                sanitize_action(selected_action),
                 context=repeat_context,
             )
         ),
@@ -239,12 +244,40 @@ def turn_trace_payload(  # noqa: PLR0913 - flat fields define the trace schema.
 
 
 def sanitize_action(action: Mapping[str, object]) -> dict[str, object]:
+    kind = str(action.get("action") or "")
+    if kind == "http_request":
+        return _sanitize_http_step(action)
     sanitized: dict[str, object] = {}
     for key, value in action.items():
         if _SENSITIVE_KEY_RE.search(str(key)):
             sanitized[str(key)] = "[redacted]"
             continue
+        if kind == "validate_poc" and str(key) == "steps" and isinstance(value, list):
+            sanitized[str(key)] = [
+                _sanitize_http_step(item) if isinstance(item, Mapping) else _sanitize_value(item)
+                for item in value[:20]
+            ]
+            continue
+        if kind == "validate_poc" and str(key) in {"url", "path"}:
+            sanitized[str(key)] = sanitize_url(value)
+            continue
         sanitized[str(key)] = _sanitize_value(value)
+    return sanitized
+
+
+def _sanitize_http_step(step: Mapping[str, object]) -> dict[str, object]:
+    sanitized: dict[str, object] = {}
+    for key, value in step.items():
+        text_key = str(key)
+        lowered = text_key.casefold()
+        if _SENSITIVE_KEY_RE.search(text_key):
+            sanitized[text_key] = "[redacted]"
+        elif lowered in {"url", "path"}:
+            sanitized[text_key] = sanitize_url(value)
+        elif lowered == "headers" and isinstance(value, Mapping):
+            sanitized[text_key] = _sanitize_headers(value, response=False)
+        else:
+            sanitized[text_key] = _sanitize_value(value)
     return sanitized
 
 
@@ -264,21 +297,44 @@ def _sanitize_mapping(value: Mapping[str, object] | Mapping[object, object]) -> 
     sanitized: dict[str, object] = {}
     for key, item in value.items():
         text_key = str(key)
+        lowered = text_key.casefold()
         if _SENSITIVE_KEY_RE.search(text_key):
             sanitized[text_key] = "[redacted]"
+            continue
+        if lowered in {"url", "final_url", "location"}:
+            sanitized[text_key] = sanitize_url(item)
+            continue
+        if lowered in {"headers", "response_headers"} and isinstance(item, Mapping):
+            sanitized[text_key] = _sanitize_headers(item, response=True)
+            continue
+        if lowered == "error" and isinstance(item, str):
+            sanitized[text_key] = redact_text(
+                _sanitize_embedded_urls(item),
+                max_chars=_MAX_SANITIZED_CHARS,
+            )
             continue
         sanitized[text_key] = _sanitize_value(item)
     return sanitized
 
 
+def _sanitize_headers(headers: Mapping[object, object], *, response: bool) -> dict[str, str]:
+    normalized = {str(name): value for name, value in headers.items()}
+    return dict(redact_headers(normalized, response=response))
+
+
 def _sanitize_string(value: str) -> str:
-    text = _PROOF_RE.sub(lambda match: _mask_proof(match.group(0)), value)
+    text = _sanitize_embedded_urls(value)
+    text = _PROOF_RE.sub(lambda match: _mask_proof(match.group(0)), text)
     text = _SENSITIVE_HEADER_RE.sub(r"\1[redacted]", text)
     text = _INLINE_SENSITIVE_HEADER_RE.sub(r"\1[redacted]", text)
     text = _SENSITIVE_ASSIGNMENT_RE.sub(r"\1=[redacted]", text)
     if len(text) > _MAX_SANITIZED_CHARS:
         return text[:_MAX_SANITIZED_CHARS] + "... [truncated]"
     return text
+
+
+def _sanitize_embedded_urls(value: str) -> str:
+    return _EMBEDDED_URL_RE.sub(lambda match: sanitize_url(match.group(0)), value)
 
 
 def _mask_proof(value: str) -> str:

--- a/packages/ravage/src/ravage/agent_core/live_events.py
+++ b/packages/ravage/src/ravage/agent_core/live_events.py
@@ -6,7 +6,7 @@ from html import unescape
 from typing import Any
 from urllib.parse import parse_qsl, unquote, urlparse
 
-from ravage.traffic.redaction import REDACTED, redact_text, sanitize_url
+from ravage.traffic.redaction import REDACTED, redact_headers, redact_text, sanitize_url
 
 MASK = "••••"
 
@@ -46,6 +46,9 @@ _QUOTED_SECRET_ASSIGNMENT_RE = re.compile(
     r"access[_-]?key|authorization|session|cookie|credential|private[_-]?key|code|pin)"
     r"[^\"']*[\"']\s*:\s*[\"'])([^\"']*)([\"'])"
 )
+_EMBEDDED_URL_RE = re.compile(
+    r"(?i)(?:https?://[^\s'\"<>]+|(?<![A-Za-z0-9:/])/[^\s'\"<>]*[?#][^\s'\"<>]+)"
+)
 
 
 def looks_secret(key: str) -> bool:
@@ -63,21 +66,11 @@ def mask_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
     return {str(key): mask_value(str(key), value) for key, value in mapping.items()}
 
 
-_SECRET_HEADERS = frozenset(
-    {"set-cookie", "cookie", "authorization", "x-api-key", "x-auth-token", "x-csrf-token"}
-)
-
-
 def mask_headers(headers: object) -> dict[str, str]:
     if not isinstance(headers, dict):
         return {}
-    out: dict[str, str] = {}
-    for key, value in list(headers.items())[:24]:
-        if str(key).lower() in _SECRET_HEADERS:
-            out[str(key)] = MASK
-        else:
-            out[str(key)] = _clip(str(value), 200)
-    return out
+    bounded = dict(list(headers.items())[:24])
+    return dict(redact_headers(bounded, response=True))
 
 
 def mask_command_string(text: str) -> str:
@@ -89,6 +82,15 @@ def mask_command_string(text: str) -> str:
 
 def describe_action(action: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0911
     kind = str(action.get("action") or "")
+    if kind == "http_request":
+        step = _describe_http_step(action)
+        method = str(step.get("method") or "GET")
+        path = str(step.get("path") or "")
+        return {
+            "summary": f"HTTP {method}",
+            "detail": _clip(path),
+            "params": step,
+        }
     if kind == "validate_poc":
         return _describe_validate_poc(action)
     if kind == "run_command":
@@ -118,7 +120,7 @@ def describe_action(action: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0911
     if kind == "invalid":
         return {
             "summary": "Invalid action",
-            "detail": _clip(str(action.get("error") or "")),
+            "detail": _safe_error_text(action.get("error"), max_chars=_MAX_DETAIL_CHARS),
             "params": {},
         }
     return {"summary": kind or "action", "detail": "", "params": {}}
@@ -152,7 +154,7 @@ def _describe_validate_poc(action: dict[str, Any]) -> dict[str, Any]:
 
 def _describe_http_step(step: dict[str, Any]) -> dict[str, Any]:
     method = str(step.get("method") or "GET").upper()
-    url = str(step.get("url") or "")
+    url = sanitize_url(step.get("url") or step.get("path") or "")
     path = _path_of(url)
     if not path:
         path = url
@@ -182,12 +184,13 @@ def http_step_payload(  # noqa: PLR0913 - flat kwargs mirror the recorded payloa
     response_headers: object = None,
     body: object = None,
 ) -> dict[str, Any]:
+    safe_url = sanitize_url(url)
     return {
         "action_id": action_id,
         "index": index,
         "method": str(method or "GET").upper(),
-        "path": _path_of(url) or url,
-        "url": url,
+        "path": _path_of(safe_url) or safe_url,
+        "url": safe_url,
         "fields": mask_mapping(form) if isinstance(form, dict) else {},
         "status": status,
         "ok": ok,
@@ -230,8 +233,16 @@ def probe_http_exchange_payload(
         "elapsed_ms": elapsed_ms,
         "response_summary": response_body,
         "disposition": _clip(str(event.get("disposition") or "sent"), 24),
-        "error": redact_text(event.get("error") or "", max_chars=160),
+        "error": _safe_error_text(event.get("error"), max_chars=160),
     }
+
+
+def _safe_error_text(value: object, *, max_chars: int) -> str:
+    text = _EMBEDDED_URL_RE.sub(
+        lambda match: sanitize_url(match.group(0)),
+        str(value or ""),
+    )
+    return redact_text(text, max_chars=max_chars)
 
 
 def _trace_request_target(value: object) -> tuple[str, list[dict[str, str]]]:

--- a/packages/ravage/src/ravage/agent_core/observation_analysis.py
+++ b/packages/ravage/src/ravage/agent_core/observation_analysis.py
@@ -51,6 +51,22 @@ def extract_probe_signals(text: str) -> dict[str, list[str]]:
     return signals
 
 
+def extract_http_discovery_signals(text: str) -> dict[str, list[str]]:
+    """Extract structural discovery only from an untyped direct HTTP response.
+
+    Direct requests are model-authored mutations. Their responses can reflect
+    those mutations, so raw marker/error/file-content classification must stay
+    with typed probes and validators. HTML and JavaScript request structure is
+    still useful for choosing the next exact replay.
+    """
+    signals: dict[str, list[str]] = {}
+    _collect_form_signals(signals, text)
+    _collect_named_input_signals(signals, text)
+    _collect_attribute_url_signals(signals, text)
+    _collect_javascript_endpoint_signals(signals, text)
+    return signals
+
+
 def observation_facts(text: str) -> list[str]:
     facts: list[str] = []
     lower = text.lower()

--- a/packages/ravage/src/ravage/agent_core/primitive_state.py
+++ b/packages/ravage/src/ravage/agent_core/primitive_state.py
@@ -249,12 +249,13 @@ PRIMITIVE_RULES: tuple[PrimitiveRule, ...] = (
     ),
     PrimitiveRule(
         name="default_credentials_confirmed",
-        probe="idor_boundary",
+        probe="stateful_session",
         task_id="stateful-session",
         directive=(
-            "Default credentials are confirmed. Keep the authenticated context and run "
-            "run_probe idor_boundary to enumerate profile/admin/API object routes for the proof. "
-            "Do not re-spray credentials unless the authenticated session is exhausted."
+            "Default credentials are confirmed. Treat authentication as context, not as IDOR "
+            "evidence: use stateful_session to map the authenticated workflow, then triage and "
+            "mutate the forms and API operations it reveals. Run an "
+            "authorization specialist only after an object or role boundary is actually observed."
         ),
         markers=("default_credentials_valid",),
         tier=1,

--- a/packages/ravage/src/ravage/agent_core/semantic_routes.py
+++ b/packages/ravage/src/ravage/agent_core/semantic_routes.py
@@ -148,6 +148,16 @@ def _action_body(action: Mapping[str, object]) -> str:
         "run_command": action.get("command"),
         "run_python": action.get("code"),
         "validate_poc": json.dumps(action.get("steps") or [], sort_keys=True, default=str),
+        "http_request": json.dumps(
+            {
+                "url": action.get("url") or action.get("path"),
+                "form": action.get("form"),
+                "json": action.get("json"),
+                "body": action.get("body"),
+            },
+            sort_keys=True,
+            default=str,
+        ),
     }
     kind = str(action.get("action") or "")
     return str(bodies.get(kind) or action.get("probe") or "")
@@ -183,6 +193,9 @@ def _first_marker_class(
 
 def _endpoints(action: Mapping[str, object], *, body: str) -> list[str]:
     candidates = _step_endpoints(action)
+    direct = action.get("url") or action.get("path")
+    if isinstance(direct, str) and direct.strip():
+        candidates.append(direct)
     candidates.extend(match.group(0) for match in _URL_RE.finditer(body))
     if not candidates:
         candidates.extend(match.group(1) for match in _QUOTED_PATH_RE.finditer(body))
@@ -217,7 +230,7 @@ def _normalize_endpoint(value: str) -> str:
 
 
 def _method(action: Mapping[str, object], *, combined: str, has_endpoint: bool) -> str:
-    explicit = str(action.get("method") or "").upper()
+    explicit = str(action.get("method") or "").strip().upper()
     if explicit:
         return explicit
     step_method = _first_step_method(action)
@@ -245,7 +258,7 @@ def _first_step_method(action: Mapping[str, object]) -> str:
     steps = action.get("steps")
     if not isinstance(steps, list) or not steps or not isinstance(steps[0], Mapping):
         return ""
-    return str(steps[0].get("method") or "GET").upper()
+    return str(steps[0].get("method") or "GET").strip().upper()
 
 
 def _inputs(action: Mapping[str, object], *, endpoints: list[str]) -> list[str]:
@@ -256,11 +269,16 @@ def _inputs(action: Mapping[str, object], *, endpoints: list[str]) -> list[str]:
 
 
 def _explicit_inputs(action: Mapping[str, object]) -> list[str]:
-    return [
+    names = [
         str(action.get(key) or "").strip()
         for key in ("param", "parameter", "input", "field")
         if str(action.get(key) or "").strip()
     ]
+    for key in ("form", "json", "params"):
+        values = action.get(key)
+        if isinstance(values, Mapping):
+            names.extend(str(name) for name in values)
+    return names
 
 
 def _step_inputs(action: Mapping[str, object]) -> list[str]:

--- a/packages/ravage/src/ravage/agent_core/stateful_http.py
+++ b/packages/ravage/src/ravage/agent_core/stateful_http.py
@@ -1,0 +1,585 @@
+# Request-boundary errors intentionally carry precise fail-closed context.
+# ruff: noqa: BLE001, EM101, TC001, TC003, TRY003, TRY004
+"""Persistent structured HTTP replay for the default web-agent route."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from ravage.agent_core.action_executor import ActionResult
+from ravage.agent_core.autonomous_graph.action_bridge import ActionExecution
+from ravage.agent_core.autonomous_graph.evidence import EvidenceBlackboard
+from ravage.agent_core.autonomous_graph.operational_profile import (
+    GraphOperationalProfileName,
+    graph_operational_profile,
+)
+from ravage.agent_core.autonomous_graph.scoped_http import ScopedGraphHttpExecutor
+from ravage.agent_core.autonomous_graph.traffic_lifecycle import (
+    GraphTrafficLifecycle,
+    GraphTrafficTerminal,
+    graph_traffic_session_id,
+)
+from ravage.agent_core.evidence_lead_lock import (
+    reactivate_for_session_change,
+    release_for_session_reset,
+)
+from ravage.agent_core.surface_graph import SurfaceGraphError
+from ravage.agent_core.surface_graph_ingest import project_surface_graph
+from ravage.traffic.redaction import redact_text as redact_traffic_text
+from ravage.traffic.redaction import sanitize_url
+from ravage.web_core.http_probe import ProbeResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from pentest_schemas import Scope
+
+    from ravage.agent_core.agent_state import AgentState
+    from ravage.auth.runtime import ManagedAttackAuthentication
+    from ravage.traffic.contracts import CapturedHttpExchange
+    from ravage.traffic.policy import TrafficPolicyController
+
+_HTTP_STATE_EPOCH_KEY = "http_state_epoch"
+_HTTP_SESSION_DIRTY_KEY = "http_session_dirty"
+
+
+@dataclass(slots=True)
+class StatefulHttpActionSession:
+    """Own one cookie-preserving, metered HTTP executor for a base-agent run."""
+
+    target_url: str
+    scope: Scope
+    allow_remote_target: bool
+    roe_max_rps: int
+    max_total_requests: int
+    workspace_dir: Path
+    state: AgentState
+    proof_recognition_enabled: bool = False
+    authentication: ManagedAttackAuthentication | None = None
+    traffic_policy: TrafficPolicyController | None = None
+    low_noise: bool = False
+    resume_expected: bool = False
+    _traffic: GraphTrafficLifecycle | None = field(default=None, init=False, repr=False)
+    _executor: ScopedGraphHttpExecutor | None = field(default=None, init=False, repr=False)
+    _blackboard: EvidenceBlackboard | None = field(default=None, init=False, repr=False)
+    _validation_proofs: list[str] = field(default_factory=list, init=False, repr=False)
+    _call_lock: threading.RLock = field(
+        default_factory=threading.RLock,
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        # A resumed process owns a fresh in-memory cookie jar. Give its physical
+        # requests a new executor-owned repeat context instead of treating them
+        # as identical to requests issued by the prior process.
+        lane_artifacts = self._lane_artifacts()
+        if self.resume_expected and any(lane_artifacts) and not all(lane_artifacts):
+            raise RuntimeError(
+                "structured HTTP resume requires request state, traffic history, and evidence"
+            )
+        if (
+            self.resume_expected
+            and self.state.surface.get(_HTTP_SESSION_DIRTY_KEY) is True
+            and not all(lane_artifacts)
+        ):
+            raise RuntimeError("structured HTTP session state exists without its durable lane")
+        if self.resume_expected and all(lane_artifacts):
+            try:
+                self._advance_http_state_epoch()
+                executor = self._open()
+                session_was_dirty = (
+                    self.state.surface.get(_HTTP_SESSION_DIRTY_KEY) is True
+                    or executor.session_dirty
+                )
+                if session_was_dirty:
+                    release_for_session_reset(self.state)
+                    fact = (
+                        "structured HTTP session was reset on resume; re-establish "
+                        "authentication before rediscovering the released evidence route"
+                    )
+                    if fact not in self.state.facts:
+                        self.state.facts.append(fact)
+                        del self.state.facts[:-80]
+                    self.state.surface.pop(_HTTP_SESSION_DIRTY_KEY, None)
+                    executor.clear_session_dirty()
+            except BaseException as exc:
+                if self._traffic is not None:
+                    try:
+                        self.finalize()
+                    except BaseException as cleanup_error:
+                        exc.add_note(
+                            "structured HTTP resumed-session cleanup also failed: "
+                            f"{type(cleanup_error).__name__}"
+                        )
+                    finally:
+                        self._executor = None
+                        self._traffic = None
+                        self._blackboard = None
+                raise
+
+    def __call__(
+        self,
+        *,
+        node_id: str,
+        arguments: dict[str, object],
+        action_id: str,
+    ) -> ActionExecution:
+        # Keep traffic-delta recovery inside the executor's single-action
+        # boundary. This also prevents one caller from claiming another
+        # caller's captured exchanges when an action is interrupted.
+        with self._call_lock:
+            return self._execute_action(
+                node_id=node_id,
+                arguments=arguments,
+                action_id=action_id,
+            )
+
+    def _execute_action(
+        self,
+        *,
+        node_id: str,
+        arguments: dict[str, object],
+        action_id: str,
+    ) -> ActionExecution:
+        executor = self._executor or self._open()
+        traffic = self._traffic
+        blackboard = self._blackboard
+        if traffic is None or blackboard is None:
+            raise RuntimeError("structured HTTP durable lane is unavailable")
+        known_exchange_ids = {
+            exchange.exchange_id
+            for exchange in traffic.store.exchanges()
+            if exchange.source == "agent_http"
+        }
+        session_before = self._session_tokens(executor)
+        # Persist this before dispatch. Any target response can rotate server-side
+        # session state even when no Set-Cookie line is visible, and cookie jars
+        # themselves are intentionally never written to disk.
+        executor.mark_session_dirty()
+        self.state.surface[_HTTP_SESSION_DIRTY_KEY] = True
+        try:
+            try:
+                execution = executor(
+                    node_id=node_id,
+                    arguments=arguments,
+                    action_id=action_id,
+                )
+            except BaseException as exc:
+                try:
+                    self._record_interrupted_action(
+                        producer_node_id=node_id,
+                        arguments=arguments,
+                        action_id=action_id,
+                        known_exchange_ids=known_exchange_ids,
+                    )
+                except BaseException as evidence_error:
+                    exc.add_note(
+                        "structured HTTP interruption evidence could not be persisted: "
+                        f"{type(evidence_error).__name__}"
+                    )
+                raise
+        finally:
+            session_after = self._session_tokens(executor)
+            if session_before.shape != session_after.shape:
+                self._advance_http_state_epoch()
+            if session_before.full != session_after.full:
+                reactivate_for_session_change(self.state)
+        blackboard.record_action_result(
+            producer_node_id=node_id,
+            action={"action": "http_request", **arguments},
+            result=execution.result,
+            observation_id=execution.observation_id,
+        )
+        return execution
+
+    def _record_interrupted_action(
+        self,
+        *,
+        producer_node_id: str,
+        arguments: Mapping[str, object],
+        action_id: str,
+        known_exchange_ids: set[str],
+    ) -> None:
+        """Close the evidence half of any action that captured a physical hop."""
+        traffic = self._traffic
+        blackboard = self._blackboard
+        if traffic is None or blackboard is None:
+            return
+        captured = [
+            exchange
+            for exchange in traffic.store.exchanges()
+            if exchange.source == "agent_http"
+            and exchange.exchange_id not in known_exchange_ids
+        ]
+        observation_ids = tuple(
+            dict.fromkeys(
+                exchange.source_observation_id
+                for exchange in captured
+                if exchange.source_observation_id
+            )
+        )
+        for observation_id in observation_ids:
+            exchanges = [
+                exchange
+                for exchange in captured
+                if exchange.source_observation_id == observation_id
+            ]
+            latest = exchanges[-1]
+            evidence = json.dumps(
+                {
+                    "action_id": action_id,
+                    "node_id": producer_node_id,
+                    "outcome": "http_request_interrupted",
+                    "traffic_exchange_ids": [item.exchange_id for item in exchanges],
+                    "response": {
+                        "status": latest.response_status,
+                        "final_url": latest.response_final_url,
+                        "headers": {
+                            name: value for name, value in latest.response_headers
+                        },
+                        "body": "",
+                        "body_sha256": latest.response_body_sha256,
+                        "body_unavailable": True,
+                        "truncated": latest.response_body_observed,
+                        "error": "structured HTTP action was blocked after a captured hop",
+                    },
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            blackboard.record_action_result(
+                producer_node_id=producer_node_id,
+                action={"action": "http_request", **arguments},
+                result=ActionResult(
+                    ok=False,
+                    observation=evidence,
+                    outcome="http_request_interrupted",
+                    evidence_source_kind="tool_http_request",
+                    evidence_observation=evidence,
+                ),
+                observation_id=observation_id,
+            )
+
+    @property
+    def opened(self) -> bool:
+        return self._traffic is not None
+
+    def finalize(self) -> GraphTrafficTerminal | None:
+        if self._traffic is None:
+            return None
+        primary_error: BaseException | None = None
+        terminal: GraphTrafficTerminal | None = None
+        try:
+            if self._executor is not None:
+                self._executor.close()
+        except BaseException as exc:  # preserve lifecycle cleanup below.
+            primary_error = exc
+        try:
+            terminal = self._traffic.finalize()
+        except BaseException as exc:
+            if primary_error is None:
+                primary_error = exc
+            else:
+                primary_error.add_note(
+                    "structured HTTP traffic finalization also failed: "
+                    f"{type(exc).__name__}"
+                )
+        try:
+            if self.authentication is not None:
+                self.authentication.configure_request_gate(None)
+        except BaseException as exc:
+            if primary_error is None:
+                primary_error = exc
+            else:
+                primary_error.add_note(
+                    "structured HTTP authentication-gate cleanup also failed: "
+                    f"{type(exc).__name__}"
+                )
+        if primary_error is not None:
+            raise primary_error
+        return terminal
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: bytes | None = None,
+        headers: dict[str, str] | None = None,
+        timeout_seconds: int = 10,
+    ) -> ProbeResponse:
+        """Adapt the persistent lane for ``validate_http_poc`` paired replays."""
+        arguments: dict[str, object] = {
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "timeout_seconds": timeout_seconds,
+        }
+        if data is not None:
+            arguments["body"] = data.decode("utf-8", errors="replace")
+        try:
+            execution = self(
+                node_id="base-agent-validator",
+                arguments=arguments,
+                action_id=f"validate-{uuid4()}",
+            )
+        except ValueError as exc:
+            error = str(exc)
+            if self.authentication is not None:
+                error = self.authentication.redact_text(error)
+            return ProbeResponse(
+                method=str(method).upper(),
+                url=sanitize_url(url),
+                status=None,
+                final_url=sanitize_url(url),
+                elapsed_ms=0,
+                error=redact_traffic_text(error, max_chars=300),
+            )
+        if execution.result.flag and execution.result.flag not in self._validation_proofs:
+            self._validation_proofs.append(execution.result.flag)
+        try:
+            envelope = json.loads(execution.result.evidence_observation)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("structured HTTP validation returned invalid evidence") from exc
+        response = envelope.get("response") if isinstance(envelope, dict) else None
+        if not isinstance(response, dict):
+            raise RuntimeError("structured HTTP validation returned no response evidence")
+        status_value = response.get("status")
+        status = (
+            status_value
+            if isinstance(status_value, int) and not isinstance(status_value, bool)
+            else None
+        )
+        response_headers = response.get("headers")
+        body = str(response.get("body") or "")
+        return ProbeResponse(
+            method=str(method).upper(),
+            url=url,
+            status=status,
+            final_url=str(response.get("final_url") or url),
+            elapsed_ms=0,
+            headers=(
+                {str(name): str(value) for name, value in response_headers.items()}
+                if isinstance(response_headers, dict)
+                else {}
+            ),
+            body=body,
+            error=str(response.get("error") or ""),
+            truncated=response.get("truncated") is True,
+        )
+
+    def begin_validation(self) -> None:
+        """Start one outer PoC replay proof-aggregation boundary."""
+        self._validation_proofs.clear()
+
+    def consume_validation_proofs(self) -> tuple[str, ...]:
+        """Return and clear proofs recognized before validator body clipping."""
+        proofs = tuple(self._validation_proofs)
+        self._validation_proofs.clear()
+        return proofs
+
+    def _open(self) -> ScopedGraphHttpExecutor:
+        identity_alias = self.authentication.identity if self.authentication is not None else ""
+        http_state_path = self.workspace_dir / "agent-http-state.json"
+        blackboard_path = self.workspace_dir / "evidence-blackboard.json"
+        lane_artifacts = self._lane_artifacts()
+        if any(lane_artifacts) and not all(lane_artifacts):
+            raise RuntimeError(
+                "structured HTTP resume requires request state, traffic history, and evidence"
+            )
+        lane_resumed = all(lane_artifacts)
+        if lane_resumed and not self.resume_expected:
+            raise RuntimeError("new agent run cannot reuse prior structured HTTP state")
+        try:
+            self._blackboard = EvidenceBlackboard(
+                target_url=self.target_url,
+                state_path=blackboard_path,
+            )
+            traffic = GraphTrafficLifecycle.open(
+                self.workspace_dir,
+                target_url=self.target_url,
+                in_scope=tuple(str(item) for item in self.scope.in_scope),
+                out_of_scope=tuple(str(item) for item in self.scope.out_of_scope),
+                capture_session_id=graph_traffic_session_id(
+                    f"base-agent:{self.target_url}:{identity_alias or 'anonymous'}"
+                ),
+                graph_resume_expected=lane_resumed,
+                identity_alias=identity_alias,
+            )
+            self._traffic = traffic
+            traffic.recorder.set_exchange_sink(self._ingest_exchange)
+            executor = ScopedGraphHttpExecutor(
+                target_url=self.target_url,
+                scope=self.scope,
+                allow_remote_target=self.allow_remote_target,
+                profile=graph_operational_profile(
+                    (
+                        GraphOperationalProfileName.LOW_NOISE
+                        if self.low_noise
+                        else GraphOperationalProfileName.STANDARD
+                    ),
+                    roe_max_rps=self.roe_max_rps,
+                    max_total_requests=self.max_total_requests,
+                ),
+                proof_recognition_enabled=self.proof_recognition_enabled,
+                state_path=http_state_path,
+                traffic_observer=traffic.recorder,
+                require_existing_state=traffic.resumed,
+                minimum_request_count=traffic.existing_agent_http_exchange_count,
+                authentication=self.authentication,
+                traffic_policy=self.traffic_policy,
+                # This lane deliberately carries cookies between actions. The
+                # policy fingerprint is computed before urllib adds Cookie, so a
+                # cached pre-login GET could otherwise mask a post-login response.
+                cache_anonymous_gets=False,
+                persistent_managed_session=True,
+            )
+            self._executor = executor
+            if lane_resumed:
+                self._validate_resumed_evidence(traffic)
+                self._restore_surface_from_traffic(traffic)
+        except BaseException as exc:
+            try:
+                if self._traffic is not None:
+                    self.finalize()
+                elif self.authentication is not None:
+                    self.authentication.configure_request_gate(None)
+            except BaseException as cleanup_error:
+                exc.add_note(
+                    "structured HTTP failed-open cleanup also failed: "
+                    f"{type(cleanup_error).__name__}"
+                )
+            finally:
+                self._executor = None
+                self._traffic = None
+                self._blackboard = None
+            if not lane_resumed:
+                try:
+                    self._rollback_fresh_lane()
+                except OSError as cleanup_error:
+                    exc.add_note(
+                        "structured HTTP fresh-lane rollback failed: "
+                        f"{type(cleanup_error).__name__}"
+                    )
+            raise
+        else:
+            return executor
+
+    def _lane_artifacts(self) -> tuple[bool, bool, bool]:
+        return (
+            (self.workspace_dir / "agent-http-state.json").is_file(),
+            (self.workspace_dir / "traffic").exists(),
+            (self.workspace_dir / "evidence-blackboard.json").is_file(),
+        )
+
+    def _rollback_fresh_lane(self) -> None:
+        """Remove only artifacts created by a failed, previously empty lane."""
+        for name in ("agent-http-state.json", "evidence-blackboard.json"):
+            path = self.workspace_dir / name
+            if path.is_file():
+                path.unlink()
+        traffic_path = self.workspace_dir / "traffic"
+        if traffic_path.exists():
+            shutil.rmtree(traffic_path)
+
+    def _session_tokens(self, executor: ScopedGraphHttpExecutor) -> _SessionTokens:
+        prefix: tuple[object, ...] = (
+            "managed",
+            self.authentication.identity_generation,
+        ) if self.authentication is not None else ("anonymous",)
+        transport = getattr(executor, "transport", None)
+        cookies = getattr(transport, "cookies", None)
+        if cookies is None:
+            return _SessionTokens(shape=prefix, full=prefix)
+        try:
+            entries = tuple(
+                (
+                    (
+                        str(cookie.domain),
+                        str(cookie.path),
+                        str(cookie.name),
+                        bool(cookie.secure),
+                        str(cookie.port or ""),
+                        int(cookie.version),
+                        bool(cookie.discard),
+                    ),
+                    str(cookie.value),
+                    cookie.expires,
+                )
+                for cookie in cookies
+            )
+            shaped = tuple(sorted(shape for shape, _value, _expires in entries))
+            valued = tuple(sorted((*shape, value, expires) for shape, value, expires in entries))
+            return _SessionTokens(shape=(*prefix, *shaped), full=(*prefix, *valued))
+        except (AttributeError, TypeError):
+            # A custom test transport may not expose stdlib Cookie objects.
+            return _SessionTokens(shape=prefix, full=prefix)
+
+    def _advance_http_state_epoch(self) -> None:
+        value = self.state.surface.get(_HTTP_STATE_EPOCH_KEY)
+        current = value if isinstance(value, int) and not isinstance(value, bool) else 0
+        self.state.surface[_HTTP_STATE_EPOCH_KEY] = max(0, current) + 1
+
+    def _ingest_exchange(self, exchange: CapturedHttpExchange) -> None:
+        try:
+            self.state.surface_graph.ingest_exchange(exchange)
+        except SurfaceGraphError:
+            # One structured lane may target multiple explicitly scoped origins,
+            # while the canonical graph is intentionally bound to one origin.
+            return
+        self.state.surface = project_surface_graph(self.state.surface_graph, self.state.surface)
+
+    def _validate_resumed_evidence(self, traffic: GraphTrafficLifecycle) -> None:
+        blackboard = self._blackboard
+        if blackboard is None:
+            raise RuntimeError("structured HTTP evidence blackboard is unavailable")
+        traffic_observations = {
+            exchange.source_observation_id
+            for exchange in traffic.store.exchanges()
+            if exchange.source == "agent_http"
+        }
+        blackboard_observations = {
+            record.observation_id
+            for record in blackboard.state.records.values()
+            if record.kind.value == "raw_observation"
+            and record.source.value == "tool_http_request"
+        }
+        if "" in traffic_observations or not traffic_observations.issubset(
+            blackboard_observations
+        ):
+            raise RuntimeError(
+                "structured HTTP traffic and evidence are inconsistent after interruption"
+            )
+
+    def _restore_surface_from_traffic(self, traffic: GraphTrafficLifecycle) -> None:
+        known_refs = {
+            ref
+            for observation in (self.state.surface_graph.observations or {}).values()
+            for ref in observation.evidence_refs
+        }
+        for exchange in traffic.store.exchanges():
+            if exchange.source != "agent_http" or exchange.exchange_id in known_refs:
+                continue
+            self._ingest_exchange(exchange)
+
+
+@dataclass(frozen=True, slots=True)
+class _SessionTokens:
+    shape: tuple[object, ...]
+    full: tuple[object, ...]
+
+
+def request_arguments(action: Mapping[str, object]) -> dict[str, object]:
+    """Return only executor-owned HTTP dispatch fields from a model action."""
+    allowed = {"method", "url", "path", "headers", "body", "json", "form", "timeout_seconds"}
+    return {key: action[key] for key in allowed if key in action}
+
+
+__all__ = ["StatefulHttpActionSession", "request_arguments"]

--- a/packages/ravage/src/ravage/agent_core/surface_graph.py
+++ b/packages/ravage/src/ravage/agent_core/surface_graph.py
@@ -37,6 +37,8 @@ _MAX_METADATA_CHARS = 128
 _MAX_TIMESTAMP_CHARS = 64
 _MIN_HTTP_STATUS = 100
 _MAX_HTTP_STATUS = 599
+_MIN_SUCCESSFUL_HTTP_STATUS = 200
+_FIRST_UNSUCCESSFUL_HTTP_STATUS = 400
 
 _METHOD_RE = re.compile(r"^[A-Z][A-Z0-9_-]{0,31}$")
 _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.:\[\]-]+")
@@ -116,6 +118,7 @@ _ALLOWED_SOURCE_KINDS = frozenset(
         "graphql",
         "browser",
         "probe",
+        "agent_http_response",
         "external_tool",
         "legacy_import",
     }
@@ -562,19 +565,19 @@ class SurfaceGraphState:
         observed_at: object = "",
     ) -> SurfaceOperation:
         source = _source_kind(source_kind)
-        attack_metadata = source == "probe"
+        route_only_metadata = source in {"probe", "agent_http_response"}
         operation = self.add_operation(
             SurfaceOperation.create(
                 url=url,
                 method=method,
                 selector=selector,
                 # Probe mutations remain access evidence, never discovery
-                # metadata. This also prevents a later trusted observation of
-                # the same method/route from inheriting attacker-made fields.
-                parameters=() if attack_metadata else parameters,
-                content_types=() if attack_metadata else content_types,
-                header_names=() if attack_metadata else header_names,
-                hints=() if attack_metadata else hints,
+                # metadata. A successful agent-authored HTTP request confirms
+                # only the method/route, not its model-authored request fields.
+                parameters=() if route_only_metadata else parameters,
+                content_types=() if route_only_metadata else content_types,
+                header_names=() if route_only_metadata else header_names,
+                hints=() if route_only_metadata else hints,
                 provenance=(source,),
             )
         )
@@ -594,18 +597,34 @@ class SurfaceGraphState:
         return operation
 
     def ingest_exchange(self, exchange: CapturedHttpExchange) -> SurfaceOperation:
-        source = _exchange_source_kind(exchange.source)
-        parameters = _exchange_parameters(exchange)
-        content_types = tuple(
-            value for name, value in exchange.request_headers if name.casefold() == "content-type"
+        successful_agent_http = _successful_agent_http_exchange(exchange)
+        source = (
+            "agent_http_response"
+            if successful_agent_http
+            else _exchange_source_kind(exchange.source)
+        )
+        retain_request_metadata = source not in {"probe", "agent_http_response"}
+        parameters = _exchange_parameters(exchange) if retain_request_metadata else ()
+        content_types = (
+            tuple(
+                value
+                for name, value in exchange.request_headers
+                if name.casefold() == "content-type"
+            )
+            if retain_request_metadata
+            else ()
         )
         return self.add(
             url=exchange.request_url,
             method=exchange.request_method,
             parameters=parameters,
             content_types=content_types,
-            header_names=(name for name, _value in exchange.request_headers),
-            hints=(exchange.request_resource_type,),
+            header_names=(
+                (name for name, _value in exchange.request_headers)
+                if retain_request_metadata
+                else ()
+            ),
+            hints=(exchange.request_resource_type,) if retain_request_metadata else (),
             source_kind=source,
             identity_alias=exchange.identity_alias or "anonymous",
             access_level="response" if exchange.response_status is not None else "request",
@@ -976,6 +995,15 @@ def _exchange_source_kind(source: object) -> str:
     return "probe"
 
 
+def _successful_agent_http_exchange(exchange: CapturedHttpExchange) -> bool:
+    status = exchange.response_status
+    return (
+        exchange.source == "agent_http"
+        and status is not None
+        and _MIN_SUCCESSFUL_HTTP_STATUS <= status < _FIRST_UNSUCCESSFUL_HTTP_STATUS
+    )
+
+
 def _optional_status(value: object) -> int | None:
     if value in (None, ""):
         return None
@@ -1084,7 +1112,7 @@ def _json_mapping_items(
         raise SurfaceGraphError(f"{label} must be an array")
     if any(not isinstance(item, Mapping) for item in value):
         raise SurfaceGraphError(f"{label} must contain only objects")
-    return tuple(value)  # type: ignore[return-value]
+    return tuple(item for item in value if isinstance(item, Mapping))
 
 
 def _json_object_items(value: object, *, label: str) -> tuple[object, ...]:

--- a/packages/ravage/src/ravage/probes/specialists/shared.py
+++ b/packages/ravage/src/ravage/probes/specialists/shared.py
@@ -23,6 +23,14 @@ def _generic_input_targets(state: AgentState, *, limit: int) -> list[dict[str, o
     targets: list[dict[str, object]] = []
     reflected = _reflected_input_names(state)
     for target in _parameter_targets(state, limit=limit):
+        if any(
+            source.casefold().startswith("surface_graph:")
+            for source in _string_items(target.get("sources"))
+        ):
+            # Canonical graph parameters must retain their physical location;
+            # the aggregate legacy projection cannot safely associate one URL
+            # with one of several body/query provenance labels.
+            continue
         input_name = str(target.get("name") or "")
         priority = _int_value(target.get("priority"))
         priority += _input_name_priority(input_name)
@@ -35,8 +43,10 @@ def _generic_input_targets(state: AgentState, *, limit: int) -> list[dict[str, o
                 "input": input_name,
                 "hints": _string_items(target.get("hints")),
                 "priority": priority,
+                "authority": _parameter_target_authority(target),
             }
         )
+    targets.extend(_surface_graph_query_targets(state, reflected=reflected))
     for form in _form_targets(state, limit=limit):
         action = str(form.get("action") or state.surface.get("target_url") or "")
         if not action:
@@ -55,6 +65,7 @@ def _generic_input_targets(state: AgentState, *, limit: int) -> list[dict[str, o
                     "form": form,
                     "hints": _string_items(form.get("categories")),
                     "priority": priority,
+                    "authority": "target_observed",
                 }
             )
     for target in _signal_parameter_targets(state, reflected=reflected, limit=limit):
@@ -62,6 +73,7 @@ def _generic_input_targets(state: AgentState, *, limit: int) -> list[dict[str, o
     for endpoint in _signal_endpoints(state):
         endpoint_query_names = _query_param_names_from_url(endpoint)
         names = endpoint_query_names or _common_param_names(endpoint)
+        authority = "observed_input" if endpoint_query_names else "inferred"
         endpoint_priority = _endpoint_input_priority(endpoint)
         endpoint_priority += _endpoint_query_bonus(endpoint_query_names)
         for name in names:
@@ -72,11 +84,16 @@ def _generic_input_targets(state: AgentState, *, limit: int) -> list[dict[str, o
                     "kind": _endpoint_target_kind(endpoint),
                     "url": endpoint,
                     "input": name,
-                    "hints": ["observed_input_name"],
+                    "hints": [
+                        "observed_input_name"
+                        if endpoint_query_names
+                        else "inferred_input_name"
+                    ],
                     "priority": 24
                     + endpoint_priority
                     + _input_name_priority(name)
                     + _rendered_text_input_bonus(name),
+                    "authority": authority,
                 }
             )
     deduped: dict[tuple[str, str, str], dict[str, object]] = {}
@@ -134,6 +151,7 @@ def _rendered_text_input_bonus(name: str) -> int:
             "bio",
             "text",
             "author",
+            "sentence",
         ),
     ):
         return 16
@@ -153,14 +171,72 @@ def _target_should_replace_previous(
 ) -> bool:
     if previous is None:
         return True
+    authority = _target_authority_rank(target)
+    previous_authority = _target_authority_rank(previous)
+    if authority != previous_authority:
+        return authority < previous_authority
     return _int_value(target.get("priority")) > _int_value(previous.get("priority"))
 
 
-def _target_sort_key(item: dict[str, object]) -> tuple[int, str, str]:
+def _target_sort_key(item: dict[str, object]) -> tuple[int, int, str, str]:
+    authority = _target_authority_rank(item)
     priority = -_int_value(item.get("priority"))
     url = str(item.get("url"))
     input_name = str(item.get("input"))
-    return priority, url, input_name
+    return authority, priority, url, input_name
+
+
+def _target_authority_rank(target: dict[str, object]) -> int:
+    authority = str(target.get("authority") or "")
+    if authority == "target_observed":
+        return 0
+    if authority == "observed_input":
+        return 1
+    return 2
+
+
+def _parameter_target_authority(target: dict[str, object]) -> str:
+    sources = {item.casefold() for item in _string_items(target.get("sources"))}
+    if any(
+        source in {
+            "surface_graph:body",
+            "surface_graph:form",
+            "surface_graph:graphql",
+            "surface_graph:query",
+        }
+        for source in sources
+    ):
+        return "target_observed"
+    return "observed_input"
+
+
+def _surface_graph_query_targets(
+    state: AgentState,
+    *,
+    reflected: set[str],
+) -> list[dict[str, object]]:
+    targets: list[dict[str, object]] = []
+    for operation in (state.surface_graph.operations or {}).values():
+        if not operation.actionable or operation.method.upper() not in {"GET", "HEAD"}:
+            continue
+        for parameter in operation.parameters:
+            if parameter.location != "query":
+                continue
+            input_name = parameter.name
+            priority = _input_name_priority(input_name)
+            priority += _rendered_text_input_bonus(input_name)
+            priority += _reflected_priority_bonus(input_name, reflected)
+            targets.append(
+                {
+                    "kind": "query_param",
+                    "url": operation.structural_url,
+                    "input": input_name,
+                    "hints": list(operation.hints),
+                    "priority": priority,
+                    "authority": "target_observed",
+                }
+            )
+    return targets[:128]
 
 
 def _send_target(session: ProbeSession, target: dict[str, object], value: str) -> ProbeResponse:
@@ -521,9 +597,9 @@ def _cookie_signal_values(state: AgentState) -> list[str]:
 
 
 def _name_looks_expression_context(name: str, url: str) -> bool:
-    text = f"{name} {url}".lower()
-    return _contains_marker(
-        text,
+    lowered_name = name.lower()
+    if _contains_marker(
+        lowered_name,
         (
             "term",
             "amount",
@@ -534,6 +610,25 @@ def _name_looks_expression_context(name: str, url: str) -> bool:
             "years",
             "value",
             "expression",
+            "calc",
+            "amort",
+            "total",
+            "date",
+            "time",
+            "remind",
+            "reminder",
+            "notify",
+            "schedule",
+        ),
+    ):
+        return True
+    lowered_url = url.lower()
+    return _contains_marker(
+        lowered_url,
+        (
+            "amount",
+            "principal",
+            "payment",
             "calc",
             "amort",
             "total",
@@ -646,6 +741,7 @@ def _parameter_target_sort_key(item: dict[str, object]) -> tuple[int, str]:
 
 def _form_targets(state: AgentState, *, limit: int) -> list[dict[str, object]]:
     forms = _list_of_dicts(state.surface.get("forms"))
+    forms.extend(_surface_graph_form_targets(state))
     forms.extend(_signal_form_targets(state))
     deduped: dict[tuple[str, str, str], dict[str, object]] = {}
     for form in forms:
@@ -659,6 +755,39 @@ def _form_targets(state: AgentState, *, limit: int) -> list[dict[str, object]]:
     ordered = list(deduped.values())
     ordered.sort(key=_form_target_sort_key)
     return ordered[:limit]
+
+
+def _surface_graph_form_targets(state: AgentState) -> list[dict[str, object]]:
+    """Rebuild value-free specialist forms from trusted canonical declarations."""
+    forms: list[dict[str, object]] = []
+    for operation in (state.surface_graph.operations or {}).values():
+        if not operation.actionable or "form" not in operation.hints:
+            continue
+        method = operation.method.upper()
+        if method not in {"GET", "POST"}:
+            continue
+        inputs = [
+            {
+                "name": parameter.name,
+                "type": "text",
+                "value": "",
+                "required": parameter.required,
+            }
+            for parameter in operation.parameters
+            if parameter.location in {"form", "query"}
+        ]
+        if not inputs:
+            continue
+        forms.append(
+            {
+                "action": operation.structural_url,
+                "method": method,
+                "inputs": inputs,
+                "categories": list(operation.hints),
+                "source": "surface_graph",
+            }
+        )
+    return forms[:64]
 
 
 def _form_target_sort_key(item: dict[str, object]) -> tuple[int, str]:
@@ -752,6 +881,7 @@ def _signal_parameter_targets(
                     "input": name,
                     "hints": ["observed_parameter_name"],
                     "priority": priority,
+                    "authority": "observed_input",
                 }
             )
     targets.sort(key=_target_sort_key)

--- a/packages/ravage/src/ravage/probes/specialists/ssti.py
+++ b/packages/ravage/src/ravage/probes/specialists/ssti.py
@@ -7,7 +7,6 @@ from typing import Callable, TypeVar
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ravage.agent_core.agent_state import AgentState
-from ravage.runtime.common import clip
 from ravage.probes.specialists.shared import (
     _auth_headers_from_state,
     _baseline_value,
@@ -24,11 +23,14 @@ from ravage.probes.specialists.shared import (
     _slow_response,
     _string_items,
     _surface_endpoints,
+    _target_authority_rank,
     _target_brief,
     _target_current_value,
     _target_headers,
     _target_replay,
+    _target_should_replace_previous,
 )
+from ravage.runtime.common import clip
 from ravage.web_core.http_probe import (
     ProbeResponse,
     ProbeSession,
@@ -2088,6 +2090,7 @@ def _ssti_expression_targets(
                     hints=["expression_context_endpoint"],
                     priority=95 + _input_name_priority(name),
                     auth_headers=auth_headers,
+                    authority="target_observed",
                 )
             )
         for name in _common_param_names(endpoint):
@@ -2100,6 +2103,7 @@ def _ssti_expression_targets(
                     hints=["expression_context_heuristic"],
                     priority=40 + _input_name_priority(name),
                     auth_headers=auth_headers,
+                    authority="inferred",
                 )
             )
     if _description_suggests_reminder_template_flow(state):
@@ -2111,19 +2115,19 @@ def _ssti_expression_targets(
                     hints=["description_reminder_expression"],
                     priority=155,
                     auth_headers=auth_headers,
+                    authority="inferred",
                 )
             )
     deduped: dict[tuple[str, str, str], dict[str, object]] = {}
     for target in expression_targets:
         key = (str(target.get("kind")), str(target.get("url")), str(target.get("input")))
         previous = deduped.get(key)
-        if previous is None or _int_value(target.get("priority")) > _int_value(
-            previous.get("priority")
-        ):
+        if _target_should_replace_previous(target, previous):
             deduped[key] = target
     ordered = list(deduped.values())
     ordered.sort(
         key=lambda item: (
+            _target_authority_rank(item),
             -_expression_target_score(item),
             str(item.get("url")),
             str(item.get("input")),
@@ -2178,6 +2182,7 @@ def _expression_query_target(
     hints: list[str],
     priority: int,
     auth_headers: dict[str, str],
+    authority: str,
 ) -> dict[str, object]:
     return {
         "kind": "query_param",
@@ -2186,6 +2191,7 @@ def _expression_query_target(
         "hints": hints,
         "priority": priority,
         "auth_headers": auth_headers,
+        "authority": authority,
     }
 
 

--- a/packages/ravage/src/ravage/report.py
+++ b/packages/ravage/src/ravage/report.py
@@ -8,7 +8,7 @@ import stat
 from datetime import UTC, datetime
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, Self, cast
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 from ravage.finding_evidence import confirmed_finding_evidence_failures
 from ravage.hosting_layer import HOSTING_LAYER_EVENT_KIND, run_configured_hosting_layer_agent
@@ -17,8 +17,9 @@ from ravage.run_data.brief import load_engagement_brief
 from ravage.run_data.run_manifest import read_manifest
 from ravage.traffic.manifest import (
     TrafficRunError,
+    TrafficRunManifest,
     read_traffic_manifest,
-    resolve_workspace,
+    resolve_workspaces,
 )
 from ravage.traffic.policy import TrafficPolicyError, load_traffic_policy_snapshot
 from ravage.traffic.provenance import TrafficProvenanceError, load_traffic_provenance
@@ -31,7 +32,9 @@ if TYPE_CHECKING:
 
     from pentest_schemas import EngagementBrief, Scope
 
-REPORT_SCHEMA_VERSION = "2026-08-25"
+    from ravage.traffic.provenance import AgentHttpEvidenceLink
+
+REPORT_SCHEMA_VERSION = "2026-09-04"
 PRO_REPORT_MODULE = "ravage_pro.report"
 PRO_REPORT_SUFFIXES = frozenset({".pdf", ".docx"})
 CORE_REPORT_SUFFIXES = frozenset({"", ".md", ".json"})
@@ -48,7 +51,13 @@ _SECRET_PATTERNS = (
 
 _MIN_SECRET_REPLACEMENT_GROUPS = 5
 _GRAPH_MARKER_MAX_BYTES = 262_144
-_PRIVATE_HTTP_STATE_VERSION = 2
+type _ExpectedTrafficBoundary = tuple[
+    str,
+    str | None,
+    str,
+    tuple[str, ...],
+    tuple[str, ...],
+]
 
 _SEVERITY_ORDER = {
     "Critical": 4,
@@ -329,8 +338,17 @@ def build_pentest_report(  # noqa: PLR0913
 
     generated_at = datetime.now(UTC).isoformat()
     target = target_url or _target_from_events(events) or (manifest.target_url if manifest else "")
-    agent_http_evidence = _agent_http_evidence_summary(workspace_dir)
-    traffic_accounting = _traffic_accounting_summary(workspace_dir, events=events)
+    agent_http_evidence = _agent_http_evidence_summary(
+        workspace_dir,
+        target_url=target,
+        scope=brief.scope,
+    )
+    traffic_accounting = _traffic_accounting_summary(
+        workspace_dir,
+        events=events,
+        target_url=target,
+        scope=brief.scope,
+    )
     scan_coverage = _scan_coverage_summary(workspace_dir)
     report = {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -667,12 +685,16 @@ def _traffic_accounting_summary(
     workspace_dir: Path,
     *,
     events: list[dict[str, Any]],
+    target_url: str,
+    scope: Scope,
 ) -> dict[str, object]:
     ledger_path = workspace_dir / "traffic-policy.json"
     if not ledger_path.exists():
         scan_accounting = _scan_traffic_accounting_summary(
             workspace_dir,
             events=events,
+            target_url=target_url,
+            scope=scope,
         )
         if scan_accounting is not None:
             return scan_accounting
@@ -687,6 +709,14 @@ def _traffic_accounting_summary(
             "status": "unavailable",
             "provenance": "traffic_policy_ledger_unreadable",
         }
+    try:
+        expected_origin = _traffic_policy_origin(target_url)
+    except ValueError as exc:
+        message = "report target cannot be matched to traffic accounting"
+        raise TrafficProvenanceError(message) from exc
+    if inspection.target_origin != expected_origin:
+        message = "traffic accounting does not match the report target"
+        raise TrafficProvenanceError(message)
     snapshot = inspection.snapshot
     limit = inspection.config.max_physical_requests
     remaining = (
@@ -719,33 +749,59 @@ def _traffic_accounting_summary(
     }
 
 
-def _scan_traffic_accounting_summary(
+def _scan_traffic_accounting_summary(  # noqa: C901 - each lane fails closed independently.
     workspace_dir: Path,
     *,
     events: list[dict[str, Any]],
+    target_url: str,
+    scope: Scope,
 ) -> dict[str, object] | None:
     if not any(event.get("kind") == "scan_probe" for event in events):
         return None
     try:
-        traffic_workspace = resolve_workspace(workspace_dir)
+        traffic_workspaces = resolve_workspaces(workspace_dir)
     except TrafficRunError as exc:
-        if _canonical_traffic_artifacts_present(workspace_dir):
-            message = "traffic artifacts are present but could not be validated"
-            raise TrafficProvenanceError(message) from exc
-        return None
-    try:
-        traffic_manifest = read_traffic_manifest(traffic_workspace)
-        exchanges = TrafficStore.open(traffic_workspace).exchanges()
-    except (TrafficRunError, TrafficStoreError) as exc:
         message = "traffic artifacts are present but could not be validated"
         raise TrafficProvenanceError(message) from exc
-    if any(
-        exchange.capture_session_id != traffic_manifest.capture_session_id for exchange in exchanges
-    ):
-        message = "traffic capture session does not match its run manifest"
-        raise TrafficProvenanceError(message)
-
-    scan_exchanges = tuple(exchange for exchange in exchanges if exchange.source == "probe_session")
+    if not traffic_workspaces:
+        return None
+    report_boundary = _expected_traffic_manifest_boundary(target_url, scope=scope)
+    scan_exchanges = []
+    scan_manifests = []
+    expected_boundary: tuple[object, ...] | None = None
+    for traffic_workspace in traffic_workspaces:
+        try:
+            traffic_manifest = read_traffic_manifest(traffic_workspace)
+            store = TrafficStore.open(traffic_workspace)
+            exchanges = store.exchanges()
+            replay_receipts = store.replay_receipts()
+        except (TrafficRunError, TrafficStoreError) as exc:
+            message = "traffic artifacts are present but could not be validated"
+            raise TrafficProvenanceError(message) from exc
+        if not _traffic_manifest_matches_expected(traffic_manifest, report_boundary):
+            message = "traffic history does not match the report target or scope"
+            raise TrafficProvenanceError(message)
+        boundary = _traffic_manifest_boundary(traffic_manifest)
+        if expected_boundary is None:
+            expected_boundary = boundary
+        elif boundary != expected_boundary:
+            message = "traffic histories disagree on target or scope"
+            raise TrafficProvenanceError(message)
+        if any(
+            exchange.capture_session_id != traffic_manifest.capture_session_id
+            for exchange in exchanges
+        ) or any(
+            receipt.capture_session_id != traffic_manifest.capture_session_id
+            for receipt in replay_receipts
+        ):
+            message = "traffic capture session does not match its run manifest"
+            raise TrafficProvenanceError(message)
+        lane_scan_exchanges = [
+            exchange for exchange in exchanges if exchange.source == "probe_session"
+        ]
+        if lane_scan_exchanges:
+            scan_exchanges.extend(lane_scan_exchanges)
+            scan_manifests.append(traffic_manifest)
     if not scan_exchanges:
         return None
     physical_requests = sum(exchange.request_sent for exchange in scan_exchanges)
@@ -761,32 +817,88 @@ def _scan_traffic_accounting_summary(
         "remaining_physical_requests": None,
         "recorded_exchange_count": len(scan_exchanges),
         "blocked_count": sum(not exchange.request_sent for exchange in scan_exchanges),
-        "capture_completed": bool(traffic_manifest.completed_at),
+        "capture_completed": all(manifest.completed_at for manifest in scan_manifests),
     }
 
 
 def _agent_http_evidence_summary(
     workspace_dir: Path,
+    *,
+    target_url: str,
+    scope: Scope,
 ) -> dict[str, object]:
     try:
-        traffic_workspace = resolve_workspace(workspace_dir)
+        traffic_workspaces = resolve_workspaces(workspace_dir)
     except TrafficRunError as exc:
-        if _canonical_traffic_artifacts_present(workspace_dir) or _graph_traffic_expected(
-            workspace_dir
-        ):
-            message = "traffic artifacts are present but could not be validated"
-            raise TrafficProvenanceError(message) from exc
+        message = "traffic artifacts are present but could not be validated"
+        raise TrafficProvenanceError(message) from exc
+    if not traffic_workspaces:
         return _empty_agent_http_evidence_summary()
 
+    report_boundary = _expected_traffic_manifest_boundary(target_url, scope=scope)
+    links: list[dict[str, object]] = []
+    evidence_refs: set[tuple[str, str]] = set()
+    material_evidence_refs: set[tuple[str, str]] = set()
+    expected_boundary: tuple[object, ...] | None = None
+    for traffic_workspace in traffic_workspaces:
+        lane, boundary, agent_links = _validated_agent_http_lane(traffic_workspace)
+        if not _traffic_boundary_matches_expected(boundary, report_boundary):
+            message = "traffic history does not match the report target or scope"
+            raise TrafficProvenanceError(message)
+        if expected_boundary is None:
+            expected_boundary = boundary
+        elif boundary != expected_boundary:
+            message = "traffic histories disagree on target or scope"
+            raise TrafficProvenanceError(message)
+        for link in agent_links:
+            evidence_refs.update((lane, evidence_id) for evidence_id in link.evidence_refs)
+            material_evidence_refs.update(
+                (lane, evidence_id) for evidence_id in link.material_evidence_refs
+            )
+            links.append(
+                {
+                    "lane": lane,
+                    "request_id": f"{lane}:{link.request_id}",
+                    "local_request_id": link.request_id,
+                    "status": link.status,
+                    "observation_id": link.observation_id,
+                    "evidence_ids": list(link.evidence_refs),
+                    "material_evidence_ids": list(link.material_evidence_refs),
+                }
+            )
+
+    if not links:
+        return _empty_agent_http_evidence_summary()
+    return {
+        "status": "available",
+        "request_count": len(links),
+        "linked_request_count": sum(link["status"] == "linked" for link in links),
+        "observation_only_request_count": sum(
+            link["status"] == "observation_only" for link in links
+        ),
+        "evidence_count": len(evidence_refs),
+        "material_evidence_count": len(material_evidence_refs),
+        "links": links,
+    }
+
+
+def _validated_agent_http_lane(
+    traffic_workspace: Path,
+) -> tuple[str, tuple[object, ...], tuple[AgentHttpEvidenceLink, ...]]:
     try:
         traffic_manifest = read_traffic_manifest(traffic_workspace)
         store = TrafficStore.open(traffic_workspace)
         exchanges = store.exchanges()
+        replay_receipts = store.replay_receipts()
     except (TrafficRunError, TrafficStoreError) as exc:
         message = "traffic artifacts are present but could not be validated"
         raise TrafficProvenanceError(message) from exc
     if any(
-        exchange.capture_session_id != traffic_manifest.capture_session_id for exchange in exchanges
+        exchange.capture_session_id != traffic_manifest.capture_session_id
+        for exchange in exchanges
+    ) or any(
+        receipt.capture_session_id != traffic_manifest.capture_session_id
+        for receipt in replay_receipts
     ):
         message = "traffic capture session does not match its run manifest"
         raise TrafficProvenanceError(message)
@@ -800,49 +912,20 @@ def _agent_http_evidence_summary(
         for exchange, link in zip(exchanges, provenance.links, strict=True)
         if exchange.source == "agent_http"
     )
-    invalid_statuses = {
-        link.status
+    if any(
+        link.status not in {"linked", "observation_only", "missing_observation"}
         for link in agent_links
-        if link.status not in {"linked", "observation_only", "missing_observation"}
-    }
-    if invalid_statuses:
+    ):
         message = "agent HTTP provenance has an invalid link status"
         raise TrafficProvenanceError(message)
     if any(link.status == "missing_observation" for link in agent_links):
         message = "agent HTTP traffic is missing its evidence observation identifier"
         raise TrafficProvenanceError(message)
-    if not agent_links:
-        return _empty_agent_http_evidence_summary()
-
-    evidence_ids = tuple(
-        dict.fromkeys(evidence_id for link in agent_links for evidence_id in link.evidence_refs)
+    return (
+        _traffic_lane_name(traffic_workspace),
+        _traffic_manifest_boundary(traffic_manifest),
+        agent_links,
     )
-    material_evidence_ids = tuple(
-        dict.fromkeys(
-            evidence_id for link in agent_links for evidence_id in link.material_evidence_refs
-        )
-    )
-    links = [
-        {
-            "request_id": link.request_id,
-            "status": link.status,
-            "observation_id": link.observation_id,
-            "evidence_ids": list(link.evidence_refs),
-            "material_evidence_ids": list(link.material_evidence_refs),
-        }
-        for link in agent_links
-    ]
-    return {
-        "status": "available",
-        "request_count": len(agent_links),
-        "linked_request_count": sum(link.status == "linked" for link in agent_links),
-        "observation_only_request_count": sum(
-            link.status == "observation_only" for link in agent_links
-        ),
-        "evidence_count": len(evidence_ids),
-        "material_evidence_count": len(material_evidence_ids),
-        "links": links,
-    }
 
 
 def _empty_agent_http_evidence_summary() -> dict[str, object]:
@@ -857,53 +940,93 @@ def _empty_agent_http_evidence_summary() -> dict[str, object]:
     }
 
 
-def _canonical_traffic_artifacts_present(workspace_dir: Path) -> bool:
-    for candidate in _traffic_workspace_candidates(workspace_dir):
-        try:
-            (candidate / "traffic").lstat()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            message = "could not safely inspect traffic artifacts"
-            raise TrafficProvenanceError(message) from exc
-        else:
-            return True
-    return False
+def _traffic_lane_name(workspace_dir: Path) -> str:
+    if workspace_dir.name == "agent-graph" and workspace_dir.parent.name == "autonomous-route":
+        return "autonomous_graph"
+    return "base"
 
 
-def _graph_traffic_expected(workspace_dir: Path) -> bool:
-    """Detect new-version graph artifacts that require a traffic store."""
-    for candidate in _traffic_workspace_candidates(workspace_dir):
-        try:
-            (candidate / "graph-http-state.json").lstat()
-        except FileNotFoundError:
-            pass
-        except OSError as exc:
-            message = "could not safely inspect graph HTTP state"
-            raise TrafficProvenanceError(message) from exc
-        else:
-            # Local graph HTTP persistence and automatic traffic capture shipped
-            # together, so any such state file requires the paired store.
-            return True
-
-        remote_state = _read_bounded_json_object(candidate / "remote-http-state.json")
-        if remote_state.get("version") == _PRIVATE_HTTP_STATE_VERSION and remote_state.get(
-            "target_identity"
-        ):
-            return True
-        for receipt_name in ("graph-route-receipt.json", "remote-graph-receipt.json"):
-            receipt = _read_bounded_json_object(candidate / receipt_name)
-            if "traffic" in receipt:
-                return True
-    return False
-
-
-def _traffic_workspace_candidates(workspace_dir: Path) -> tuple[Path, ...]:
+def _traffic_manifest_boundary(manifest: TrafficRunManifest) -> tuple[object, ...]:
     return (
-        workspace_dir,
-        workspace_dir / "workspace",
-        workspace_dir / "autonomous-route" / "agent-graph",
-        workspace_dir / "workspace" / "autonomous-route" / "agent-graph",
+        manifest.target_url,
+        manifest.target_identity,
+        manifest.origin,
+        manifest.in_scope,
+        manifest.out_of_scope,
+    )
+
+
+def _expected_traffic_manifest_boundary(
+    target_url: str,
+    *,
+    scope: Scope,
+) -> _ExpectedTrafficBoundary:
+    try:
+        expected = TrafficRunManifest.create(
+            target_url=target_url,
+            capture_session_id="report-attribution",
+            in_scope=tuple(str(item) for item in scope.in_scope),
+            out_of_scope=tuple(str(item) for item in scope.out_of_scope),
+        )
+    except TrafficRunError as exc:
+        message = "report target or scope cannot be matched to traffic evidence"
+        raise TrafficProvenanceError(message) from exc
+    raw_target = target_url.strip()
+    decoded_target = unquote(raw_target).casefold()
+    persisted_target = sanitize_url(raw_target)
+    expected_identity = (
+        None
+        if (
+            raw_target in (REDACTED_URL, persisted_target) or "[redacted" in decoded_target
+        )
+        else expected.target_identity
+    )
+    return (
+        expected.target_url,
+        expected_identity,
+        expected.origin,
+        expected.in_scope,
+        expected.out_of_scope,
+    )
+
+
+def _traffic_policy_origin(target_url: str) -> str:
+    parsed = urlsplit(target_url.strip())
+    scheme = parsed.scheme.casefold()
+    invalid_target = "invalid traffic accounting target"
+    if scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError(invalid_target)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(invalid_target)
+    # Mirror traffic.policy._target_origin exactly. Unicode host casefolding is
+    # not equivalent to the writer's lowercase normalization (for example ß).
+    host = parsed.hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
+    port = parsed.port
+    default_port = 443 if scheme == "https" else 80
+    netloc = host if port in {None, default_port} else f"{host}:{port}"
+    return urlunsplit((scheme, netloc, "", "", ""))
+
+
+def _traffic_manifest_matches_expected(
+    manifest: TrafficRunManifest,
+    expected: _ExpectedTrafficBoundary,
+) -> bool:
+    return _traffic_boundary_matches_expected(_traffic_manifest_boundary(manifest), expected)
+
+
+def _traffic_boundary_matches_expected(
+    actual: tuple[object, ...],
+    expected: _ExpectedTrafficBoundary,
+) -> bool:
+    expected_target, expected_identity, expected_origin, expected_in, expected_out = expected
+    return (
+        actual[0] == expected_target
+        and (expected_identity is None or actual[1] == expected_identity)
+        and actual[2] == expected_origin
+        and actual[3] == expected_in
+        and actual[4] == expected_out
     )
 
 
@@ -966,8 +1089,11 @@ def _agent_http_evidence_markdown(summary: dict[str, Any]) -> list[str]:
         return lines
     lines.extend(
         [
-            "| Request ID | Status | Observation ID | Evidence IDs | Material evidence IDs |",
-            "| --- | --- | --- | --- | --- |",
+            (
+                "| Lane | Request ID | Status | Observation ID | Evidence IDs | "
+                "Material evidence IDs |"
+            ),
+            "| --- | --- | --- | --- | --- | --- |",
         ]
     )
     for item in links:
@@ -977,6 +1103,7 @@ def _agent_http_evidence_markdown(summary: dict[str, Any]) -> list[str]:
             + " | ".join(
                 _table_cell(value)
                 for value in (
+                    link.get("lane", ""),
                     link.get("request_id", ""),
                     link.get("status", ""),
                     link.get("observation_id", ""),

--- a/packages/ravage/src/ravage/traffic/cli.py
+++ b/packages/ravage/src/ravage/traffic/cli.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,8 +21,10 @@ from ravage.web_core.scope_policy import is_local_url
 
 from .manifest import (
     TrafficRunError,
+    TrafficRunManifest,
     read_traffic_manifest,
     resolve_workspace,
+    resolve_workspaces,
 )
 from .provenance import load_traffic_provenance
 from .redaction import redact_text, sanitize_url
@@ -39,8 +42,19 @@ _SLOT_RE = re.compile(
 _MAX_DISPLAY_URL_CHARS = 100
 
 if TYPE_CHECKING:
-    from .contracts import CapturedHttpExchange
-    from .provenance import AgentHttpEvidenceLink
+    from .contracts import CapturedHttpExchange, ReplayReceipt
+    from .provenance import AgentHttpEvidenceLink, TrafficProvenanceIndex
+
+
+@dataclass(frozen=True, slots=True)
+class _TrafficLane:
+    name: str
+    workspace: Path
+    manifest: TrafficRunManifest
+    store: TrafficStore
+    exchanges: tuple[CapturedHttpExchange, ...]
+    replays: tuple[ReplayReceipt, ...]
+    provenance: TrafficProvenanceIndex
 
 
 def handle_traffic_command(args: Sequence[str]) -> None:
@@ -241,79 +255,95 @@ def _capture(parsed: argparse.Namespace) -> None:  # noqa: C901
 
 
 def _list(parsed: argparse.Namespace) -> None:
-    workspace, store = _open_store(parsed.run_dir)
-    manifest = read_traffic_manifest(workspace)
-    all_exchanges = store.exchanges()
-    provenance = load_traffic_provenance(
-        workspace,
-        exchanges=all_exchanges,
-        target_identity=manifest.target_identity,
-    )
-    links_by_id = {link.request_id: link for link in provenance.links}
-    exchanges = [
-        exchange
-        for exchange in all_exchanges
-        if parsed.all or exchange.request_resource_type not in _ASSET_RESOURCE_TYPES
-    ]
-    payload = {
+    lanes = _open_lanes(parsed.run_dir)
+    qualified = len(lanes) > 1
+    visible: list[tuple[_TrafficLane, CapturedHttpExchange, AgentHttpEvidenceLink]] = []
+    hidden_assets = 0
+    for lane in lanes:
+        links_by_id = {link.request_id: link for link in lane.provenance.links}
+        for exchange in lane.exchanges:
+            if not parsed.all and exchange.request_resource_type in _ASSET_RESOURCE_TYPES:
+                hidden_assets += 1
+                continue
+            visible.append((lane, exchange, links_by_id[exchange.exchange_id]))
+    payload: dict[str, object] = {
         "run_dir": str(parsed.run_dir),
-        "workspace_dir": str(workspace),
+        "workspace_dir": str(lanes[0].workspace),
         "requests": [
             _exchange_summary(
                 exchange,
-                agent_evidence=links_by_id[exchange.exchange_id].summary_json(),
+                request_id=_qualified_id(lane.name, exchange.exchange_id)
+                if qualified
+                else exchange.exchange_id,
+                lane=lane.name if qualified else "",
+                agent_evidence=evidence_link.summary_json(),
             )
-            for exchange in exchanges
+            for lane, exchange, evidence_link in visible
         ],
-        "contracts": len(store.contracts()),
-        "hidden_assets": len(all_exchanges) - len(exchanges),
+        "contracts": sum(len(lane.store.contracts()) for lane in lanes),
+        "hidden_assets": hidden_assets,
     }
+    if qualified:
+        payload["workspaces"] = [
+            {"lane": lane.name, "workspace_dir": str(lane.workspace)} for lane in lanes
+        ]
     if parsed.json:
         _line(json.dumps(payload, indent=2, sort_keys=True))
         return
-    _line(banner("TRAFFIC HISTORY", f"{len(exchanges)} requests"))
-    if not exchanges:
+    _line(banner("TRAFFIC HISTORY", f"{len(visible)} requests"))
+    if not visible:
         _line(f"{badge('empty', 'muted')} no application requests were captured")
-    for exchange in exchanges:
+    for lane, exchange, evidence_link in visible:
         status = exchange.response_status if exchange.response_status is not None else "—"
         sent = "" if exchange.request_sent else " blocked"
+        request_id = (
+            _qualified_id(lane.name, exchange.exchange_id) if qualified else exchange.exchange_id
+        )
+        request_id_width = 27 if qualified else 9
         _line(
-            f"{exchange.exchange_id:<9} {exchange.request_method:<7} {status!s:<7} "
+            f"{request_id:<{request_id_width}} {exchange.request_method:<7} {status!s:<7} "
             f"{_display_url(exchange.request_url)}{sent}"
-            f"{_evidence_list_suffix(links_by_id[exchange.exchange_id])}"
+            f"{_evidence_list_suffix(evidence_link)}"
         )
     if payload["hidden_assets"]:
         _line(
             f"{badge('filtered', 'muted')} {payload['hidden_assets']} static assets hidden; "
             "add --all"
         )
-    if exchanges:
-        _line(
-            f"{badge('next', 'info')} ravage traffic show {parsed.run_dir} "
-            f"{exchanges[0].exchange_id}"
+    if visible:
+        lane, exchange, _evidence_link = visible[0]
+        request_id = (
+            _qualified_id(lane.name, exchange.exchange_id) if qualified else exchange.exchange_id
         )
+        _line(f"{badge('next', 'info')} ravage traffic show {parsed.run_dir} {request_id}")
 
 
 def _show(parsed: argparse.Namespace) -> None:
-    workspace, store = _open_store(parsed.run_dir)
-    manifest = read_traffic_manifest(workspace)
-    exchange = _require_exchange(store, parsed.request_id)
-    provenance = load_traffic_provenance(
-        workspace,
-        exchanges=store.exchanges(),
-        target_identity=manifest.target_identity,
+    lanes = _open_lanes(parsed.run_dir)
+    lane, exchange = _select_exchange(lanes, parsed.request_id)
+    qualified = len(lanes) > 1
+    request_id = (
+        _qualified_id(lane.name, exchange.exchange_id) if qualified else exchange.exchange_id
     )
-    evidence_link = provenance.for_exchange_id(exchange.exchange_id)
-    contract = store.contract(exchange.semantic_fingerprint)
-    payload = {
+    evidence_link = lane.provenance.for_exchange_id(exchange.exchange_id)
+    contract = lane.store.contract(exchange.semantic_fingerprint)
+    payload: dict[str, object] = {
         "exchange": exchange.to_json(),
         "contract": contract.to_json() if contract is not None else None,
         "agent_evidence": evidence_link.to_json(),
     }
+    if qualified:
+        payload.update(
+            {
+                "lane": lane.name,
+                "qualified_id": request_id,
+                "workspace_dir": str(lane.workspace),
+            }
+        )
     if parsed.json:
         _line(json.dumps(payload, indent=2, sort_keys=True))
         return
-    _line(banner("REQUEST CONTRACT", exchange.exchange_id))
+    _line(banner("REQUEST CONTRACT", request_id))
     _line(f"method     {exchange.request_method}")
     _line(f"url        {exchange.request_url}")
     _line(f"source     {exchange.source} · {exchange.request_resource_type or 'http'}")
@@ -331,18 +361,26 @@ def _show(parsed: argparse.Namespace) -> None:
     _line(f"observed   {observations} time{'s' if observations != 1 else ''}")
     _show_evidence_link(evidence_link)
     _line(f"{badge('next', 'info')} fill the values below, then run:")
-    for line in _replay_command_skeleton(parsed.run_dir, exchange, manifest.origin):
+    for line in _replay_command_skeleton(
+        parsed.run_dir,
+        exchange,
+        lane.manifest.origin,
+        request_id=request_id,
+    ):
         _line(f"  {line}")
 
 
 def _replay(parsed: argparse.Namespace) -> None:
-    workspace, store = _open_store(parsed.run_dir, writable=True)
-    manifest = read_traffic_manifest(workspace)
-    exchange = _require_exchange(store, parsed.request_id)
+    lanes = _open_lanes(parsed.run_dir, writable=True)
+    lane, exchange = _select_exchange(lanes, parsed.request_id)
+    qualified = len(lanes) > 1
+    request_id = (
+        _qualified_id(lane.name, exchange.exchange_id) if qualified else exchange.exchange_id
+    )
     bindings = _bindings(parsed.values, parsed.env_values)
     result = replay_exchange(
-        store=store,
-        manifest=manifest,
+        store=lane.store,
+        manifest=lane.manifest,
         exchange=exchange,
         allow_remote_target=parsed.authorized_remote_target,
         allow_state_change=parsed.allow_state_change,
@@ -351,6 +389,16 @@ def _replay(parsed: argparse.Namespace) -> None:
     )
     receipt = result.receipt
     payload = receipt.to_json()
+    replay_id = _qualified_id(lane.name, receipt.replay_id) if qualified else receipt.replay_id
+    if qualified:
+        payload.update(
+            {
+                "lane": lane.name,
+                "qualified_id": replay_id,
+                "source_request_ref": request_id,
+                "workspace_dir": str(lane.workspace),
+            }
+        )
     if parsed.json:
         _line(json.dumps(payload, indent=2, sort_keys=True))
         if not result.sent:
@@ -358,37 +406,49 @@ def _replay(parsed: argparse.Namespace) -> None:
         if receipt.response_status is None:
             raise SystemExit(1)
     elif result.sent and receipt.response_status is not None:
-        _line(banner("REQUEST REPLAY", receipt.replay_id))
+        _line(banner("REQUEST REPLAY", replay_id))
         _line(
             f"{badge('sent', 'ok')} {receipt.request_method} "
             f"{receipt.response_status if receipt.response_status is not None else 'no response'} "
             f"{_display_url(receipt.request_url)}"
         )
         _line(
-            f"{badge('next', 'info')} ravage traffic diff {parsed.run_dir} "
-            f"{exchange.exchange_id} {receipt.replay_id}"
+            f"{badge('next', 'info')} ravage traffic diff {parsed.run_dir} {request_id} {replay_id}"
         )
     elif not result.sent:
         _line(f"{badge('blocked', 'warn')} {result.error}")
-        _line(f"{badge('receipt', 'info')} {receipt.replay_id} · no request sent")
+        _line(f"{badge('receipt', 'info')} {replay_id} · no request sent")
         raise SystemExit(2)
     else:
-        _line(banner("REQUEST REPLAY", receipt.replay_id))
+        _line(banner("REQUEST REPLAY", replay_id))
         _line(
             f"{badge('attempted', 'warn')} {receipt.request_method} · no response · "
             f"{_display_url(receipt.request_url)}"
         )
         _line(f"{badge('error', 'warn')} {receipt.response_error or 'transport failed'}")
-        _line(f"{badge('receipt', 'info')} {receipt.replay_id} · request attempted")
+        _line(f"{badge('receipt', 'info')} {replay_id} · request attempted")
         raise SystemExit(1)
 
 
 def _diff(parsed: argparse.Namespace) -> None:
-    _workspace, store = _open_store(parsed.run_dir)
+    lanes = _open_lanes(parsed.run_dir)
+    left_lane, left_id = _select_record(lanes, parsed.left_id)
+    right_lane, right_id = _select_record(lanes, parsed.right_id)
+    if left_lane.workspace != right_lane.workspace:
+        raise ValueError("traffic diff requires both records to be in the same lane/store")
     try:
-        payload = diff_records(store, parsed.left_id, parsed.right_id)
+        payload = diff_records(left_lane.store, left_id, right_id)
     except KeyError as exc:
         raise KeyError(f"unknown traffic record ID: {exc.args[0]}") from None
+    if len(lanes) > 1:
+        payload.update(
+            {
+                "lane": left_lane.name,
+                "left_ref": _qualified_id(left_lane.name, left_id),
+                "right_ref": _qualified_id(right_lane.name, right_id),
+                "workspace_dir": str(left_lane.workspace),
+            }
+        )
     if parsed.json:
         _line(json.dumps(payload, indent=2, sort_keys=True))
         return
@@ -404,22 +464,166 @@ def _diff(parsed: argparse.Namespace) -> None:
             _line(f"{name:<22} {change.get('left')} → {change.get('right')}{suffix}")
 
 
+def _open_lanes(run_dir: Path, *, writable: bool = False) -> tuple[_TrafficLane, ...]:
+    supplied = Path(run_dir)
+    try:
+        os.lstat(supplied / "traffic")
+    except FileNotFoundError:
+        workspaces = resolve_workspaces(supplied)
+    except OSError as exc:
+        raise TrafficRunError("could not inspect explicit traffic workspace") from exc
+    else:
+        # Preserve exact selection when the operator names a workspace. Run
+        # roots have no direct traffic directory and intentionally aggregate.
+        workspaces = (resolve_workspace(supplied),)
+    if not workspaces:
+        raise TrafficRunError(f"no traffic history found in run directory {run_dir}")
+    lanes: list[_TrafficLane] = []
+    for workspace in workspaces:
+        manifest = read_traffic_manifest(workspace)
+        store = TrafficStore.open(workspace, writable=writable)
+        exchanges = store.exchanges()
+        replays = store.replay_receipts()
+        if any(
+            exchange.capture_session_id != manifest.capture_session_id
+            for exchange in exchanges
+        ) or any(
+            receipt.capture_session_id != manifest.capture_session_id for receipt in replays
+        ):
+            raise TrafficStoreError("traffic store contains records from another capture session")
+        provenance = load_traffic_provenance(
+            workspace,
+            exchanges=exchanges,
+            target_identity=manifest.target_identity,
+        )
+        lanes.append(
+            _TrafficLane(
+                name=_lane_name(workspace),
+                workspace=workspace,
+                manifest=manifest,
+                store=store,
+                exchanges=exchanges,
+                replays=replays,
+                provenance=provenance,
+            )
+        )
+    if lanes:
+        expected_boundary = _lane_manifest_boundary(lanes[0].manifest)
+        if any(
+            _lane_manifest_boundary(lane.manifest) != expected_boundary
+            for lane in lanes[1:]
+        ):
+            raise TrafficRunError("traffic histories disagree on target or scope")
+    return tuple(lanes)
+
+
 def _open_store(run_dir: Path, *, writable: bool = False) -> tuple[Path, TrafficStore]:
+    """Open one explicit traffic store for compatibility with internal callers."""
     workspace = resolve_workspace(run_dir)
     manifest = read_traffic_manifest(workspace)
     store = TrafficStore.open(workspace, writable=writable)
+    exchanges = store.exchanges()
+    replays = store.replay_receipts()
     if any(
-        exchange.capture_session_id != manifest.capture_session_id for exchange in store.exchanges()
+        exchange.capture_session_id != manifest.capture_session_id for exchange in exchanges
+    ) or any(
+        receipt.capture_session_id != manifest.capture_session_id for receipt in replays
     ):
         raise TrafficStoreError("traffic store contains records from another capture session")
+    load_traffic_provenance(
+        workspace,
+        exchanges=exchanges,
+        target_identity=manifest.target_identity,
+    )
     return workspace, store
 
 
-def _require_exchange(store: TrafficStore, request_id: str) -> CapturedHttpExchange:
-    exchange = store.exchange(request_id)
-    if exchange is None:
-        raise KeyError(f"unknown request ID: {request_id}")
-    return exchange
+def _select_exchange(
+    lanes: Sequence[_TrafficLane],
+    request_ref: str,
+) -> tuple[_TrafficLane, CapturedHttpExchange]:
+    selected_lane, request_id = _parse_qualified_ref(lanes, request_ref)
+    candidates = (
+        (lane, exchange)
+        for lane in lanes
+        if selected_lane is None or lane.name == selected_lane
+        if (
+            exchange := next(
+                (item for item in lane.exchanges if item.exchange_id == request_id),
+                None,
+            )
+        )
+        is not None
+    )
+    matches = tuple(candidates)
+    if not matches:
+        raise KeyError(f"unknown request ID: {request_ref}")
+    if len(matches) > 1:
+        choices = ", ".join(_qualified_id(lane.name, request_id) for lane, _ in matches)
+        raise TrafficRunError(f"request ID {request_id} is ambiguous; use one of: {choices}")
+    return matches[0]
+
+
+def _select_record(
+    lanes: Sequence[_TrafficLane],
+    record_ref: str,
+) -> tuple[_TrafficLane, str]:
+    selected_lane, record_id = _parse_qualified_ref(lanes, record_ref)
+    matches = tuple(
+        lane
+        for lane in lanes
+        if selected_lane is None or lane.name == selected_lane
+        if _lane_has_record(lane, record_id)
+    )
+    if not matches:
+        raise KeyError(f"unknown traffic record ID: {record_ref}")
+    if len(matches) > 1:
+        choices = ", ".join(_qualified_id(lane.name, record_id) for lane in matches)
+        raise TrafficRunError(f"traffic record ID {record_id} is ambiguous; use one of: {choices}")
+    return matches[0], record_id
+
+
+def _parse_qualified_ref(
+    lanes: Sequence[_TrafficLane],
+    record_ref: str,
+) -> tuple[str | None, str]:
+    lane_name, separator, record_id = record_ref.partition(":")
+    if not separator:
+        return None, record_ref
+    known = {lane.name for lane in lanes}
+    if lane_name not in known:
+        raise ValueError(f"unknown traffic lane: {lane_name}")
+    if not record_id:
+        raise ValueError("qualified traffic ID is missing its record ID")
+    return lane_name, record_id
+
+
+def _lane_has_record(lane: _TrafficLane, record_id: str) -> bool:
+    if record_id.startswith("rq_"):
+        return any(exchange.exchange_id == record_id for exchange in lane.exchanges)
+    if record_id.startswith("rp_"):
+        return any(receipt.replay_id == record_id for receipt in lane.replays)
+    return False
+
+
+def _lane_name(workspace: Path) -> str:
+    if workspace.name == "agent-graph" and workspace.parent.name == "autonomous-route":
+        return "autonomous_graph"
+    return "base"
+
+
+def _lane_manifest_boundary(manifest: TrafficRunManifest) -> tuple[object, ...]:
+    return (
+        manifest.target_url,
+        manifest.target_identity,
+        manifest.origin,
+        manifest.in_scope,
+        manifest.out_of_scope,
+    )
+
+
+def _qualified_id(lane: str, record_id: str) -> str:
+    return f"{lane}:{record_id}"
 
 
 def _bindings(values: Sequence[str], env_values: Sequence[str]) -> dict[str, str]:
@@ -453,10 +657,12 @@ def _assignment(value: str, *, label: str) -> tuple[str, str]:
 def _exchange_summary(
     exchange: CapturedHttpExchange,
     *,
+    request_id: str,
+    lane: str,
     agent_evidence: Mapping[str, object],
 ) -> dict[str, object]:
-    return {
-        "id": exchange.exchange_id,
+    payload: dict[str, object] = {
+        "id": request_id,
         "method": exchange.request_method,
         "url": exchange.request_url,
         "resource_type": exchange.request_resource_type,
@@ -467,6 +673,9 @@ def _exchange_summary(
         "unresolved_slots": list(exchange.unresolved_slots),
         "agent_evidence": dict(agent_evidence),
     }
+    if lane:
+        payload["lane"] = lane
+    return payload
 
 
 def _evidence_list_suffix(link: AgentHttpEvidenceLink) -> str:
@@ -505,6 +714,8 @@ def _replay_command_skeleton(
     run_dir: Path,
     exchange: CapturedHttpExchange,
     origin: str,
+    *,
+    request_id: str | None = None,
 ) -> tuple[str, ...]:
     if exchange.replayability == "not_replayable":
         return ("This blocked request is not replayable.",)
@@ -526,7 +737,7 @@ def _replay_command_skeleton(
         "traffic",
         "replay",
         str(run_dir),
-        exchange.exchange_id,
+        request_id or exchange.exchange_id,
         *bindings,
     ]
     if not is_local_url(origin):

--- a/packages/ravage/src/ravage/traffic/manifest.py
+++ b/packages/ravage/src/ravage/traffic/manifest.py
@@ -21,6 +21,7 @@ TRAFFIC_RUN_SCHEMA = "ravage.traffic-run.v1"
 TRAFFIC_RUN_MANIFEST = "run.json"
 _MAX_MANIFEST_BYTES = 262_144
 _TARGET_IDENTITY_RE = re.compile(r"^target:[0-9a-f]{64}$")
+_PRIVATE_HTTP_STATE_VERSION = 2
 
 
 class TrafficRunError(RuntimeError):
@@ -231,35 +232,11 @@ def read_traffic_manifest(workspace_dir: Path) -> TrafficRunManifest:
 def resolve_workspace(run_dir: Path) -> Path:
     """Resolve an explicit run directory without guessing a latest run."""
     supplied = Path(run_dir)
-    found: list[Path] = []
-    for candidate in (
-        supplied,
-        supplied / "workspace",
-        supplied / "autonomous-route" / "agent-graph",
-        supplied / "workspace" / "autonomous-route" / "agent-graph",
-    ):
-        resolved = _contained_workspace(supplied, candidate)
-        if resolved is not None and resolved not in found:
-            found.append(resolved)
+    explicit = _canonical_workspace(supplied, supplied)
+    if explicit is not None:
+        return explicit
 
-    # A normal scan can store a workspace below its run directory. Never follow
-    # an arbitrary external pointer from an untrusted run bundle; an operator
-    # can pass an external workspace explicitly instead.
-    run_manifest = supplied / "run.json"
-    payload = _read_bounded_json(run_manifest)
-    if isinstance(payload, dict) and payload.get("workspace_dir"):
-        declared = Path(str(payload["workspace_dir"]))
-        declared_candidates = (
-            (declared,) if declared.is_absolute() else (supplied / declared, Path.cwd() / declared)
-        )
-        for declared_candidate in declared_candidates:
-            for possible in (
-                declared_candidate,
-                declared_candidate / "autonomous-route" / "agent-graph",
-            ):
-                resolved = _contained_workspace(supplied, possible)
-                if resolved is not None and resolved not in found:
-                    found.append(resolved)
+    found = resolve_workspaces(supplied)
     if len(found) == 1:
         return found[0]
     if len(found) > 1:
@@ -270,21 +247,168 @@ def resolve_workspace(run_dir: Path) -> Path:
     raise TrafficRunError(f"no traffic history found in run directory {supplied}")
 
 
+def resolve_workspaces(run_dir: Path) -> tuple[Path, ...]:
+    """
+    Return every valid canonical traffic workspace below an explicit run path.
+
+    Discovery is deliberately non-recursive. A run can contain one base lane and
+    one autonomous-graph lane, and their order is always base before graph. An
+    existing canonical ``traffic`` directory is treated as an asserted artifact:
+    if its manifest is missing or invalid, discovery fails closed instead of
+    silently selecting another lane.
+    """
+    supplied = Path(run_dir)
+    candidates: list[Path] = [
+        supplied,
+        supplied / "workspace",
+        supplied / "autonomous-route" / "agent-graph",
+        supplied / "workspace" / "autonomous-route" / "agent-graph",
+    ]
+    # Preserve custom/legacy run layouts declared by the ordinary run manifest,
+    # while subjecting them to the same containment and canonical-child rules.
+    for declared in _declared_workspace_candidates(supplied):
+        candidates.extend((declared, declared / "autonomous-route" / "agent-graph"))
+    _require_expected_traffic_roots(supplied, candidates)
+    found: list[tuple[str, Path, TrafficRunManifest]] = []
+    for candidate in candidates:
+        resolved = _canonical_workspace(supplied, candidate)
+        if resolved is None or any(resolved == item[1] for item in found):
+            continue
+        manifest = read_traffic_manifest(resolved)
+        lane = _workspace_lane(resolved)
+        if any(lane == item[0] for item in found):
+            raise TrafficRunError(f"multiple canonical {lane} traffic histories found")
+        found.append((lane, resolved, manifest))
+
+    found.sort(key=lambda item: 0 if item[0] == "base" else 1)
+    if found:
+        expected = _manifest_boundary(found[0][2])
+        if any(_manifest_boundary(item[2]) != expected for item in found[1:]):
+            raise TrafficRunError("traffic histories disagree on target or scope")
+    return tuple(item[1] for item in found)
+
+
 def _require_posix_traffic_artifacts() -> None:
     if os.name != "posix":
         raise TrafficRunError("traffic artifacts require a POSIX filesystem; on Windows, use WSL")
 
 
-def _contained_workspace(root: Path, candidate: Path) -> Path | None:
-    """Return a real workspace path only when it stays below the supplied root."""
+def _canonical_workspace(root: Path, candidate: Path) -> Path | None:
+    """Return a manifested canonical workspace contained below the supplied root."""
+    resolved_candidate = _contained_candidate(root, candidate)
+    if resolved_candidate is None:
+        return None
+    traffic_root = resolved_candidate / "traffic"
+    try:
+        os.lstat(traffic_root)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise TrafficRunError("could not inspect canonical traffic workspace") from exc
+    # The caller reads and validates the manifest. Returning a workspace as soon
+    # as its canonical traffic root exists ensures malformed roots are not
+    # skipped in favour of another valid lane.
+    read_traffic_manifest(resolved_candidate)
+    return resolved_candidate
+
+
+def _workspace_lane(workspace: Path) -> str:
+    if workspace.name == "agent-graph" and workspace.parent.name == "autonomous-route":
+        return "autonomous_graph"
+    return "base"
+
+
+def _manifest_boundary(manifest: TrafficRunManifest) -> tuple[object, ...]:
+    return (
+        manifest.target_url,
+        manifest.target_identity,
+        manifest.origin,
+        manifest.in_scope,
+        manifest.out_of_scope,
+    )
+
+
+def _require_expected_traffic_roots(root: Path, candidates: list[Path]) -> None:
+    """Reject durable HTTP state whose adjacent canonical traffic lane is missing."""
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = _contained_candidate(root, candidate)
+        if resolved is None or resolved in seen:
+            continue
+        seen.add(resolved)
+        if not _traffic_expected_at(resolved):
+            continue
+        try:
+            os.lstat(resolved / "traffic")
+        except FileNotFoundError as exc:
+            raise TrafficRunError(
+                "durable HTTP state exists without its canonical traffic history"
+            ) from exc
+        except OSError as exc:
+            raise TrafficRunError("could not inspect canonical traffic workspace") from exc
+
+
+def _contained_candidate(root: Path, candidate: Path) -> Path | None:
     try:
         resolved_root = root.resolve(strict=True)
-        resolved_candidate = candidate.resolve(strict=True)
-        resolved_candidate.relative_to(resolved_root)
-    except (OSError, ValueError):
+    except FileNotFoundError:
         return None
-    manifest = resolved_candidate / "traffic" / TRAFFIC_RUN_MANIFEST
-    return resolved_candidate if manifest.is_file() else None
+    except (OSError, RuntimeError) as exc:
+        raise TrafficRunError("could not resolve traffic run directory") from exc
+    try:
+        resolved_candidate = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        return None
+    except (OSError, RuntimeError) as exc:
+        raise TrafficRunError("could not resolve canonical traffic workspace") from exc
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved_candidate
+
+
+def _traffic_expected_at(workspace: Path) -> bool:
+    if any(
+        _artifact_path_present(workspace / name)
+        for name in ("agent-http-state.json", "graph-http-state.json")
+    ):
+        return True
+    remote_state = _read_bounded_json(workspace / "remote-http-state.json")
+    if (
+        isinstance(remote_state, dict)
+        and remote_state.get("version") == _PRIVATE_HTTP_STATE_VERSION
+        and remote_state.get("target_identity")
+    ):
+        return True
+    for receipt_name in ("graph-route-receipt.json", "remote-graph-receipt.json"):
+        receipt = _read_bounded_json(workspace / receipt_name)
+        if isinstance(receipt, dict) and "traffic" in receipt:
+            return True
+    return False
+
+
+def _artifact_path_present(path: Path) -> bool:
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise TrafficRunError("could not inspect durable HTTP state") from exc
+    return True
+
+
+def _declared_workspace_candidates(run_dir: Path) -> tuple[Path, ...]:
+    payload = _read_bounded_json(run_dir / "run.json")
+    if not isinstance(payload, dict) or not payload.get("workspace_dir"):
+        return ()
+    declared = Path(str(payload["workspace_dir"]))
+    if declared.is_absolute():
+        return (declared,)
+    # Older manifests have used both run-relative and process-relative paths.
+    # `_canonical_workspace` later rejects either interpretation if it escapes
+    # the explicitly supplied run directory.
+    return (run_dir / declared, Path.cwd() / declared)
 
 
 def _read_bounded_json(path: Path) -> object | None:
@@ -378,5 +502,6 @@ __all__ = [
     "TrafficRunManifest",
     "read_traffic_manifest",
     "resolve_workspace",
+    "resolve_workspaces",
     "write_traffic_manifest",
 ]

--- a/packages/ravage/src/ravage/web_core/poc_validator.py
+++ b/packages/ravage/src/ravage/web_core/poc_validator.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
+from ravage.traffic.redaction import redact_headers, redact_text, sanitize_url
 from ravage.web_core.http_probe import ProbeResponse, ProbeSession
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from ravage.traffic.policy import TrafficPolicyController
+
+
+_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"})
+_BODYLESS_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_MAX_STEPS = 12
+_MAX_ARTIFACT_ERROR_CHARS = 2_048
+_EMBEDDED_URL_RE = re.compile(
+    r"(?i)(?:https?://[^\s'\"<>]+|(?<![A-Za-z0-9:/])/[^\s'\"<>]*[?#][^\s'\"<>]+)"
+)
 
 
 @dataclass(frozen=True)
@@ -70,6 +80,13 @@ def validate_http_poc(
         target_url
     ):
         raise ValueError("validate_http_poc session belongs to a different target")
+    step_errors = _step_validation_errors(steps)
+    if step_errors:
+        return ValidationResult(
+            ok=False,
+            summary="validate_poc contains invalid steps",
+            errors=[_artifact_text(error) for error in step_errors],
+        )
     if session is None and request is None:
         session = ProbeSession(
             target_url,
@@ -86,10 +103,7 @@ def validate_http_poc(
     errors: list[str] = []
     required_checks = 0
     passed_checks = 0
-    for index, raw_step in enumerate(steps[:12], start=1):
-        if not isinstance(raw_step, dict):
-            errors.append(f"step {index} is not an object")
-            continue
+    for index, raw_step in enumerate(steps, start=1):
         response = _execute_step(
             session,
             raw_step,
@@ -98,7 +112,10 @@ def validate_http_poc(
             timeout_seconds=timeout_seconds,
         )
         step_result = _evaluate_step(index=index, step=raw_step, response=response)
-        safe_step_result = _redacted_mapping(step_result, redact=redact)
+        safe_step_result = _redacted_mapping(
+            _sanitize_step_result(step_result),
+            redact=redact,
+        )
         _notify_step(
             on_step,
             index=index,
@@ -159,13 +176,14 @@ def _notify_step(
         _redacted_mapping(
             {
                 "index": index,
-                "method": str(step.get("method") or "GET"),
-                "url": str(step.get("url") or ""),
+                "method": str(step.get("method") or "GET").upper(),
+                "url": _artifact_url(_step_location(step)),
                 "form": form if isinstance(form, dict) else None,
                 "status": response.status,
                 "ok": ok if isinstance(ok, bool) else None,
-                "headers": dict(response.headers) if isinstance(response.headers, dict) else {},
+                "headers": _artifact_response_headers(response.headers),
                 "body": response.body,
+                "error": _artifact_text(response.error),
             },
             redact=redact,
         )
@@ -181,13 +199,13 @@ def _execute_step(
     timeout_seconds: int,
 ) -> ProbeResponse:
     method = str(step.get("method") or "GET").upper()
-    url = str(step.get("url") or target_url)
+    url = _step_location(step, fallback=target_url)
     headers = _string_dict(step.get("headers"))
-    form = _string_dict(step.get("form"))
-    if form:
+    data: bytes | None
+    if step.get("form") is not None:
+        form = _string_dict(step.get("form"))
         data = urlencode(form).encode("utf-8")
         headers = {"Content-Type": "application/x-www-form-urlencoded", **headers}
-        method = "POST"
     else:
         body = step.get("body")
         data = _request_body_bytes(body)
@@ -222,9 +240,10 @@ def _redacted_text(
     *,
     redact: Callable[[object], object] | None,
 ) -> str:
+    artifact_safe = _artifact_text(value)
     if redact is None:
-        return value
-    safe = redact(value)
+        return artifact_safe
+    safe = redact(artifact_safe)
     if not isinstance(safe, str):
         raise TypeError("validate_http_poc redactor must preserve text values")
     return safe
@@ -297,8 +316,8 @@ def _evaluate_step(
         "index": index,
         "request": {
             "method": str(step.get("method") or "GET").upper(),
-            "url": str(step.get("url") or ""),
-            "has_body": step.get("body") is not None or bool(step.get("form")),
+            "url": _step_location(step),
+            "has_body": step.get("body") is not None or step.get("form") is not None,
         },
         "response": response.summary(body_chars=300),
         "checks": checks,
@@ -306,6 +325,59 @@ def _evaluate_step(
         "passed_checks": _passed_check_count(checks),
         "errors": errors,
     }
+
+
+def _sanitize_step_result(result: dict[str, object]) -> dict[str, object]:
+    sanitized = dict(result)
+    request = result.get("request")
+    if isinstance(request, dict):
+        safe_request = dict(request)
+        safe_request["url"] = _artifact_url(request.get("url"))
+        sanitized["request"] = safe_request
+    response = result.get("response")
+    if isinstance(response, dict):
+        safe_response = dict(response)
+        safe_response["url"] = _artifact_url(response.get("url"))
+        safe_response["final_url"] = _artifact_url(response.get("final_url"))
+        safe_response["headers"] = _artifact_response_headers(response.get("headers"))
+        safe_response["error"] = _artifact_text(response.get("error"))
+        sanitized["response"] = safe_response
+    checks = result.get("checks")
+    if isinstance(checks, list):
+        safe_checks: list[object] = []
+        for check in checks:
+            if not isinstance(check, dict):
+                safe_checks.append(check)
+                continue
+            safe_check = dict(check)
+            expected = check.get("expected")
+            if isinstance(expected, str):
+                safe_check["expected"] = _artifact_text(expected)
+            safe_checks.append(safe_check)
+        sanitized["checks"] = safe_checks
+    raw_errors = result.get("errors")
+    if isinstance(raw_errors, list):
+        sanitized["errors"] = [_artifact_text(error) for error in raw_errors]
+    return sanitized
+
+
+def _artifact_url(value: object) -> str:
+    text = str(value or "").strip()
+    return sanitize_url(text) if text else ""
+
+
+def _artifact_response_headers(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return dict(redact_headers(value, response=True))
+
+
+def _artifact_text(value: object) -> str:
+    text = _EMBEDDED_URL_RE.sub(
+        lambda match: sanitize_url(match.group(0)),
+        str(value or ""),
+    )
+    return redact_text(text, max_chars=_MAX_ARTIFACT_ERROR_CHARS)
 
 
 def _passed_check_count(checks: list[dict[str, object]]) -> int:
@@ -323,6 +395,55 @@ def _string_dict(value: object) -> dict[str, str]:
     for key, item in value.items():
         result[str(key)] = str(item)
     return result
+
+
+def _step_validation_errors(steps: list[object]) -> list[str]:
+    if len(steps) > _MAX_STEPS:
+        return [f"validate_poc accepts at most {_MAX_STEPS} steps"]
+    errors: list[str] = []
+    for index, step in enumerate(steps, start=1):
+        error = _step_validation_error(step)
+        if error:
+            errors.append(f"step {index} {error}")
+    return errors
+
+
+def _step_validation_error(value: object) -> str:  # noqa: C901, PLR0911
+    if not isinstance(value, dict):
+        return "must be an object"
+    for location_field in ("url", "path"):
+        location = value.get(location_field)
+        if location is not None and not isinstance(location, str):
+            return f"{location_field} must be a string"
+    if not _step_location(value):
+        return "requires url or path"
+
+    method = str(value.get("method") or "GET").strip().upper()
+    if method not in _HTTP_METHODS:
+        return f"method is not allowed: {method}"
+    if value.get("headers") is not None and not isinstance(value.get("headers"), dict):
+        return "headers must be an object"
+    if value.get("json") is not None:
+        return "does not support json; encode JSON in body and set Content-Type"
+
+    body_fields = [name for name in ("body", "form") if value.get(name) is not None]
+    if len(body_fields) > 1:
+        return "accepts only one of body or form"
+    if method in _BODYLESS_HTTP_METHODS and body_fields:
+        return f"{method} request cannot include a body"
+    if value.get("form") is not None and not isinstance(value.get("form"), dict):
+        return "form must be an object"
+    if value.get("body") is not None and not isinstance(value.get("body"), str):
+        return "body must be a string"
+    return ""
+
+
+def _step_location(step: dict[str, Any], *, fallback: str = "") -> str:
+    for field_name in ("url", "path"):
+        value = step.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return value
+    return fallback
 
 
 def _int_or_none(value: object) -> int | None:

--- a/packages/ravage/tests/test_action_executor_replay_paths.py
+++ b/packages/ravage/tests/test_action_executor_replay_paths.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from ravage.agent_core import action_executor
+from ravage.web_core.poc_validator import ValidationResult
+
+
+def test_path_based_paired_replay_preserves_location_and_changed_query_input() -> None:
+    target_url = "https://target.example/"
+    control = {
+        "method": "GET",
+        "path": "/search?q=control",
+        "evidence_role": "control",
+    }
+    exploit = {
+        "method": "GET",
+        "path": "/search?q=%27%20OR%201%3D1--",
+        "evidence_role": "exploit",
+    }
+
+    assert action_executor._replay_material(control) != action_executor._replay_material(  # noqa: SLF001
+        exploit
+    )
+    assert "' OR 1=1--" in action_executor._decoded_replay_request_text(exploit)  # noqa: SLF001
+    assert action_executor._replay_input_shape(  # noqa: SLF001
+        control,
+        target_url=target_url,
+    ) == ("query:q",)
+    assert action_executor._changed_replay_parameters(  # noqa: SLF001
+        {"steps": [control, exploit]},
+        target_url=target_url,
+    ) == [{"name": "q", "location": "query"}]
+
+
+def test_url_and_path_aliases_have_the_same_replay_material() -> None:
+    path_step = {"method": "GET", "path": "/search?q=control"}
+    url_step = {"method": "GET", "url": "/search?q=control"}
+
+    assert action_executor._replay_material(path_step) == action_executor._replay_material(  # noqa: SLF001
+        url_step
+    )
+
+
+def test_replay_shape_preserves_repeated_query_parameter_multiplicity() -> None:
+    target_url = "https://target.example/"
+    repeated = {"method": "GET", "path": "/search?q=one&q=two"}
+    single = {"method": "GET", "path": "/search?q=one"}
+
+    assert action_executor._replay_input_shape(  # noqa: SLF001
+        repeated,
+        target_url=target_url,
+    ) == ("query:q", "query:q")
+    assert action_executor._replay_input_shape(  # noqa: SLF001
+        repeated,
+        target_url=target_url,
+    ) != action_executor._replay_input_shape(  # noqa: SLF001
+        single,
+        target_url=target_url,
+    )
+
+
+def test_typed_raw_bodies_use_their_physical_named_parameter_shape() -> None:
+    target_url = "https://target.example/"
+    raw_form = {
+        "method": "POST",
+        "path": "/search",
+        "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+        "body": "q=one&q=two&submit=Search",
+    }
+    raw_json = {
+        "method": "POST",
+        "path": "/api/search",
+        "headers": {"Content-Type": "application/problem+json"},
+        "body": '{"q":"one","submit":"Search"}',
+    }
+
+    assert action_executor._replay_input_shape(  # noqa: SLF001
+        raw_form,
+        target_url=target_url,
+    ) == (
+        "body:q",
+        "body:q",
+        "body:submit",
+        "header:content-type",
+    )
+    assert action_executor._replay_parameter_values(  # noqa: SLF001
+        raw_form,
+        target_url=target_url,
+    )[("body", "q")] == ("one", "two")
+    assert action_executor._replay_input_shape(  # noqa: SLF001
+        raw_json,
+        target_url=target_url,
+    ) == ("body:q", "body:submit", "header:content-type")
+    assert action_executor._endpoint_params(  # noqa: SLF001
+        "https://target.example/search",
+        raw_step=raw_form,
+    ) == [
+        {"name": "q", "location": "body"},
+        {"name": "q", "location": "body"},
+        {"name": "submit", "location": "body"},
+    ]
+
+
+def test_paired_replay_rejects_one_sided_empty_input_shape() -> None:
+    action = {
+        "action": "validate_poc",
+        "steps": [
+            {
+                "method": "POST",
+                "path": "/submit",
+                "evidence_role": "control",
+            },
+            {
+                "method": "POST",
+                "path": "/submit",
+                "headers": {"Content-Type": "application/json"},
+                "body": "not-json",
+                "evidence_role": "exploit",
+            },
+        ],
+    }
+    validation = ValidationResult(
+        ok=True,
+        summary="paired response",
+        steps=[
+            {
+                "index": 1,
+                "request": {"method": "POST", "url": "/submit"},
+                "response": {"status": 200},
+                "checks": [{"kind": "status", "passed": True}],
+            },
+            {
+                "index": 2,
+                "request": {"method": "POST", "url": "/submit"},
+                "response": {"status": 500},
+                "checks": [{"kind": "status", "passed": True}],
+            },
+        ],
+    )
+
+    _step, failures = action_executor._paired_replay_evidence(  # noqa: SLF001
+        action,
+        validation=validation,
+        target_url="https://target.example/",
+    )
+
+    assert "control and exploit replays must vary the same input shape" in failures
+
+
+def test_replay_policy_does_not_url_decode_json_or_logical_form_values() -> None:
+    encoded_template = {
+        "method": "POST",
+        "path": "/render",
+        "headers": {"Content-Type": "application/json"},
+        "body": '{"q":"%7B%7B7*7%7D%7D"}',
+    }
+    encoded_sql = {
+        **encoded_template,
+        "body": '{"q":"%55NION%20SELECT"}',
+    }
+    logical_form = {
+        "method": "POST",
+        "path": "/render",
+        "form": {"q": "%7B%7B7*7%7D%7D"},
+    }
+
+    template_text = action_executor._decoded_replay_request_text(encoded_template)  # noqa: SLF001
+    sql_text = action_executor._decoded_replay_request_text(encoded_sql)  # noqa: SLF001
+    form_text = action_executor._decoded_replay_request_text(logical_form)  # noqa: SLF001
+    assert "{{7*7}}" not in template_text
+    assert "%7B%7B7*7%7D%7D" in template_text
+    assert "union_select" not in action_executor._sql_injection_input_markers(  # noqa: SLF001
+        sql_text
+    )
+    assert "{{7*7}}" not in form_text

--- a/packages/ravage/tests/test_action_parser.py
+++ b/packages/ravage/tests/test_action_parser.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+import pytest
 from ravage.agent_core.action_parser import parse_action
 
 
@@ -71,3 +74,110 @@ def test_validate_poc_rejects_incomplete_finding_metadata() -> None:
 
     assert action["action"] == "invalid"
     assert action["error"] == "validate_poc finding requires hypothesis"
+
+
+def test_validate_poc_accepts_url_or_path_steps_with_supported_body_shapes() -> None:
+    action = parse_action(
+        json.dumps(
+            {
+                "action": "validate_poc",
+                "steps": [
+                    {"method": "GET", "path": "/health", "expect_status": 200},
+                    {
+                        "method": "POST",
+                        "url": "/login",
+                        "form": {"username": "guest"},
+                    },
+                    {
+                        "method": "PATCH",
+                        "path": "/profile",
+                        "headers": {"Content-Type": "application/json"},
+                        "body": '{"name":"guest"}',
+                    },
+                ],
+            }
+        )
+    )
+
+    assert action["action"] == "validate_poc"
+
+
+def test_http_methods_are_canonicalized_after_validation() -> None:
+    direct = parse_action(
+        '{"action":"http_request","method":" get ","path":"/health"}'
+    )
+    replay = parse_action(
+        '{"action":"validate_poc","steps":'
+        '[{"method":" patch ","path":"/profile","body":"{}"}]}'
+    )
+
+    assert direct["method"] == "GET"
+    assert replay["steps"] == [
+        {"method": "PATCH", "path": "/profile", "body": "{}"}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("steps", "error"),
+    [
+        ([], "requires a non-empty steps list"),
+        (["GET /"], "step 1 must be an object"),
+        ([{"method": "GET"}], "step 1 requires url or path"),
+        ([{"method": "GET", "path": 7}], "step 1 path must be a string"),
+        (
+            [{"method": "DELETE", "path": "/item"}],
+            "step 1 method is not allowed",
+        ),
+        (
+            [{"method": "GET", "path": "/item", "body": "payload"}],
+            "step 1 GET request cannot include a body",
+        ),
+        (
+            [{"method": "HEAD", "path": "/item", "form": {"key": "value"}}],
+            "step 1 HEAD request cannot include a body",
+        ),
+        (
+            [{"method": "OPTIONS", "path": "/item", "body": "payload"}],
+            "step 1 OPTIONS request cannot include a body",
+        ),
+        (
+            [{"method": "POST", "path": "/item", "json": {"key": "value"}}],
+            "step 1 does not support json",
+        ),
+        (
+            [{"method": "POST", "path": "/item", "headers": ["X-Test: value"]}],
+            "step 1 headers must be an object",
+        ),
+        (
+            [{"method": "POST", "path": "/item", "form": ["key=value"]}],
+            "step 1 form must be an object",
+        ),
+        (
+            [{"method": "POST", "path": "/item", "body": {"key": "value"}}],
+            "step 1 body must be a string",
+        ),
+        (
+            [
+                {
+                    "method": "POST",
+                    "path": "/item",
+                    "body": "raw",
+                    "form": {"key": "value"},
+                }
+            ],
+            "step 1 accepts only one of body or form",
+        ),
+        (
+            [{"method": "GET", "path": f"/{index}"} for index in range(13)],
+            "accepts at most 12 steps",
+        ),
+    ],
+)
+def test_validate_poc_rejects_invalid_step_shapes(
+    steps: list[object],
+    error: str,
+) -> None:
+    action = parse_action(json.dumps({"action": "validate_poc", "steps": steps}))
+
+    assert action["action"] == "invalid"
+    assert error in str(action["error"])

--- a/packages/ravage/tests/test_authenticated_attack_runtime.py
+++ b/packages/ravage/tests/test_authenticated_attack_runtime.py
@@ -1415,7 +1415,7 @@ def test_authenticated_run_error_report_never_persists_secret_details(
     assert b"correct-horse" not in audit_bytes
 
 
-def test_authenticated_poc_filters_tainted_proof_candidate_independently(
+def test_authenticated_poc_does_not_trust_validator_summary_proof_candidates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1458,9 +1458,9 @@ def test_authenticated_poc_filters_tainted_proof_candidate_independently(
         audit.close()
         owner.close()
 
-    assert result.flag == real_proof
-    assert state.flags == [real_proof]
-    assert state.last_observation["recognized_proofs"] == [real_proof]
+    assert result.flag == ""
+    assert state.flags == []
+    assert state.last_observation["recognized_proofs"] == []
     persisted = workspace.events_path.read_text(encoding="utf-8")
     assert "FLAG{alice}" not in persisted
     assert real_proof in persisted
@@ -1804,7 +1804,7 @@ def test_authenticated_prompt_exposes_only_managed_http_lanes(
     assert user["managed_http_identity"] == {
         "control_actions": ["final"],
         "identity_alias": "service",
-        "managed_http_actions": ["run_probe", "validate_poc"],
+        "managed_http_actions": ["http_request", "run_probe", "validate_poc"],
         "mode": "identity:service",
         "request_lane": "managed_http",
     }

--- a/packages/ravage/tests/test_autonomous_graph_production.py
+++ b/packages/ravage/tests/test_autonomous_graph_production.py
@@ -1351,7 +1351,7 @@ def test_surface_graph_traffic_binding_batches_projection_and_preserves_provenan
     binding.finalize()
     assert len(projections) == 2
     [operation] = (state.surface_graph.operations or {}).values()
-    assert operation.provenance == ("openapi", "probe")
+    assert operation.provenance == ("agent_http_response", "openapi")
 
 
 def test_surface_graph_binding_imports_already_captured_browser_exchange(

--- a/packages/ravage/tests/test_autonomous_graph_scoped_http.py
+++ b/packages/ravage/tests/test_autonomous_graph_scoped_http.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import replace
 from email.message import Message
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 import pytest
 from pentest_schemas import Scope
@@ -189,6 +190,7 @@ def _executor(
     require_existing_state: bool = False,
     minimum_request_count: int = 0,
     traffic_policy: TrafficPolicyController | None = None,
+    proof_recognition_enabled: bool = False,
 ) -> ScopedGraphHttpExecutor:
     selected_clock = clock or FakeClock()
     return ScopedGraphHttpExecutor(
@@ -204,6 +206,7 @@ def _executor(
         resolver=resolver or (lambda _host, _port: (TARGET_ADDRESS,)),
         clock=selected_clock,
         sleeper=selected_clock.sleep,
+        proof_recognition_enabled=proof_recognition_enabled,
         state_path=state_path,
         traffic_observer=traffic_observer,
         require_existing_state=require_existing_state,
@@ -367,6 +370,7 @@ def test_remote_http_uses_stable_identity_and_auditable_receipt() -> None:
     assert request.headers["User-Agent"] == "ravage-authorized-assessment/1.0"
     assert payload["profile"]["name"] == "low-noise"
     assert payload["requests"][0]["sequence"] == 1
+    assert payload["requests"][0]["request_body_sha256"] == "unavailable"
     assert payload["response"]["body"] == "remote body"
     assert execution.result.evidence_source_kind == "tool_http_request"
     assert execution.observation_id.startswith("http:")
@@ -418,6 +422,158 @@ def test_managed_authentication_owns_request_and_redacts_all_observations(
     [exchange] = store.exchanges()
     assert exchange.identity_alias == authentication.identity
     assert authentication.secret not in (store.root / "exchanges.jsonl").read_text(encoding="utf-8")
+
+
+def test_persistent_managed_authentication_reuses_and_retires_one_session() -> None:
+    authentication = FakeManagedAuthentication()
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=4,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        authentication=authentication,
+        persistent_managed_session=True,
+    )
+    assert authentication.request_gate is None
+
+    executor(
+        node_id="node-auth-1",
+        arguments={"method": "GET", "path": "/app/first"},
+        action_id="action-auth-1",
+    )
+    assert authentication.request_gate is None
+    assert executor.request_count == 1
+    authentication.request("GET", TARGET_URL)
+    assert executor.request_count == 1
+    executor(
+        node_id="node-auth-2",
+        arguments={"method": "GET", "path": "/app/second"},
+        action_id="action-auth-2",
+    )
+
+    assert authentication.request_gate is None
+    assert executor.request_count == 2
+    assert len(authentication.calls) == 3
+    assert authentication.retired_sessions == []
+    executor.close()
+    assert len(authentication.retired_sessions) == 1
+    executor.close()
+    assert len(authentication.retired_sessions) == 1
+
+
+def test_response_urls_locations_and_errors_are_secret_safe() -> None:
+    secret = "plain-query-secret"  # noqa: S105 - redaction fixture.
+    response_url = f"{TARGET_URL}?token={secret}#private-fragment"
+    transport = QueuedTransport(
+        [
+            ScopedHttpTransportResponse(
+                status=200,
+                url=response_url,
+                headers={
+                    "Content-Type": "text/plain",
+                    "Location": f"/next?password={secret}#private-fragment",
+                },
+                body=b"ok",
+                elapsed_ms=3,
+                error=f"upstream failed with password={secret}",
+            )
+        ]
+    )
+
+    execution = _executor(transport)(
+        node_id="node-safe-artifact",
+        arguments={"method": "GET", "path": "/app/safe"},
+        action_id="action-safe-artifact",
+    )
+
+    evidence = execution.result.evidence_observation
+    visible = execution.result.observation
+    assert secret not in evidence
+    assert secret not in visible
+    assert "private-fragment" not in evidence
+    payload = json.loads(evidence)
+    assert "token" in payload["response"]["final_url"]
+    assert "password" in payload["response"]["headers"]["Location"]
+
+
+def test_request_rejects_case_insensitive_duplicate_headers_before_dispatch() -> None:
+    transport = QueuedTransport([_response()])
+
+    with pytest.raises(ScopedHttpError, match="duplicated"):
+        _executor(transport)(
+            node_id="node-duplicate-header",
+            arguments={
+                "method": "GET",
+                "path": "/app/safe",
+                "headers": {"X-Trace": "first", "x-trace": "second"},
+            },
+            action_id="action-duplicate-header",
+        )
+
+    assert transport.calls == []
+
+
+def test_request_rejects_non_token_header_name_before_dispatch() -> None:
+    transport = QueuedTransport([_response()])
+
+    with pytest.raises(ScopedHttpError, match="header name is invalid"):
+        _executor(transport)(
+            node_id="node-invalid-header",
+            arguments={
+                "method": "GET",
+                "path": "/app/safe",
+                "headers": {"flag{caller_authored_header_name_7c2e91}": "1"},
+            },
+            action_id="action-invalid-header",
+        )
+
+    assert transport.calls == []
+
+
+def test_executor_filters_proof_authored_in_encoded_header_name() -> None:
+    proof = "flag{caller_authored_header_name_7c2e91}"
+    encoded_header_name = quote(proof, safe="")
+    transport = QueuedTransport([_response(body=proof.encode())])
+
+    execution = _executor(
+        transport,
+        proof_recognition_enabled=True,
+    )(
+        node_id="node-encoded-header-proof",
+        arguments={
+            "method": "GET",
+            "path": "/app/echo-headers",
+            "headers": {encoded_header_name: "1"},
+        },
+        action_id="action-encoded-header-proof",
+    )
+
+    assert encoded_header_name in transport.calls[0].headers
+    assert execution.result.flag == ""
+
+
+def test_executor_filters_triple_percent_encoded_authored_proof() -> None:
+    proof = "flag{caller_authored_triple_encoded_7c2e91}"
+    encoded = proof
+    for _index in range(3):
+        encoded = quote(encoded, safe="")
+    transport = QueuedTransport([_response(body=proof.encode())])
+
+    execution = _executor(
+        transport,
+        proof_recognition_enabled=True,
+    )(
+        node_id="node-triple-encoded-proof",
+        arguments={"method": "GET", "path": f"/app/echo?value={encoded}"},
+        action_id="action-triple-encoded-proof",
+    )
+
+    assert execution.result.flag == ""
 
 
 def test_managed_traffic_uses_exact_wire_bytes_without_persisting_content(tmp_path) -> None:
@@ -678,6 +834,258 @@ def test_managed_auth_lifecycle_requests_share_persisted_target_ceiling(
             arguments={"path": "/app/private"},
             action_id="action-auth-resume",
         )
+
+
+def test_managed_internal_interrupt_does_not_fabricate_outer_route_traffic(
+    tmp_path: Path,
+) -> None:
+    class HealthOnlyInterruptingAuthentication(FakeManagedAuthentication):
+        def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            data: bytes | None = None,
+            headers: dict[str, str] | None = None,
+            timeout_seconds: float | None = None,
+        ) -> ProbeResponse:
+            del method, url, data, headers, timeout_seconds
+            self.account_physical_request("GET", f"{TARGET_URL}/health")
+            raise KeyboardInterrupt
+
+    store = TrafficStore.create(tmp_path / "workspace")
+    recorder = ProbeTrafficRecorder(
+        store,
+        capture_session_id="managed-interrupt-test",
+        source="agent_http",
+        strict=True,
+    )
+    state_path = tmp_path / "managed-http-state.json"
+    authentication = HealthOnlyInterruptingAuthentication()
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=3,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        state_path=state_path,
+        traffic_observer=recorder,
+        authentication=authentication,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        executor(
+            node_id="node-auth-interrupt",
+            arguments={"path": "/app/never-sent"},
+            action_id="action-auth-interrupt",
+        )
+
+    assert executor.request_count == 1
+    assert json.loads(state_path.read_text(encoding="utf-8"))["request_count"] == 1
+    assert not store.exchanges()
+    assert len(authentication.retired_sessions) == 1
+    assert authentication.request_gate is None
+
+
+def test_managed_begin_failure_is_not_masked_by_gate_cleanup_failure() -> None:
+    class FailingAuthentication(FakeManagedAuthentication):
+        def session_for_model_action(
+            self,
+            *,
+            timeout_seconds: int = 10,
+        ) -> FakeManagedSession:
+            del timeout_seconds
+            raise RuntimeError("session-start-primary")
+
+        def configure_request_gate(
+            self,
+            gate: Callable[[str, str], object] | None,
+        ) -> None:
+            if gate is None:
+                raise OSError("gate-cleanup-secondary")
+            super().configure_request_gate(gate)
+
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=3,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        authentication=FailingAuthentication(),
+    )
+
+    with pytest.raises(
+        ScopedHttpError,
+        match="managed authentication action session failed",
+    ) as error:
+        executor(
+            node_id="node-auth-begin-failure",
+            arguments={"path": "/app/private"},
+            action_id="action-auth-begin-failure",
+        )
+
+    assert any(
+        "managed authentication gate cleanup also failed: OSError" in note
+        for note in getattr(error.value, "__notes__", ())
+    )
+
+
+def test_managed_action_failure_survives_end_and_gate_cleanup_failures() -> None:
+    class FailingAuthentication(FakeManagedAuthentication):
+        def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            data: bytes | None = None,
+            headers: dict[str, str] | None = None,
+            timeout_seconds: float | None = None,
+        ) -> ProbeResponse:
+            del data, headers, timeout_seconds
+            self.account_physical_request(method, url)
+            raise KeyboardInterrupt
+
+        def retire_probe_session(self, session: FakeManagedSession) -> None:
+            self.retired_sessions.append(session)
+            raise RuntimeError("action-cleanup-secondary")
+
+        def configure_request_gate(
+            self,
+            gate: Callable[[str, str], object] | None,
+        ) -> None:
+            if gate is None:
+                raise OSError("gate-cleanup-tertiary")
+            super().configure_request_gate(gate)
+
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=3,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        authentication=FailingAuthentication(),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as error:
+        executor(
+            node_id="node-auth-action-failure",
+            arguments={"path": "/app/private"},
+            action_id="action-auth-action-failure",
+        )
+
+    notes = getattr(error.value, "__notes__", ())
+    assert any(
+        "managed authentication action cleanup also failed: ScopedHttpError" in note
+        for note in notes
+    )
+    assert any(
+        "managed authentication gate cleanup also failed: OSError" in note
+        for note in notes
+    )
+
+
+def test_managed_end_action_failure_is_not_masked_by_gate_cleanup_failure() -> None:
+    class FailingAuthentication(FakeManagedAuthentication):
+        def retire_probe_session(self, session: FakeManagedSession) -> None:
+            self.retired_sessions.append(session)
+            raise RuntimeError("action-cleanup-primary")
+
+        def configure_request_gate(
+            self,
+            gate: Callable[[str, str], object] | None,
+        ) -> None:
+            if gate is None:
+                raise OSError("gate-cleanup-secondary")
+            super().configure_request_gate(gate)
+
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=3,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        authentication=FailingAuthentication(),
+    )
+
+    with pytest.raises(
+        ScopedHttpError,
+        match="managed authentication action cleanup failed",
+    ) as error:
+        executor(
+            node_id="node-auth-end-failure",
+            arguments={"path": "/app/private"},
+            action_id="action-auth-end-failure",
+        )
+
+    assert any(
+        "managed authentication gate cleanup also failed: OSError" in note
+        for note in getattr(error.value, "__notes__", ())
+    )
+
+
+def test_managed_close_failure_is_not_masked_by_gate_cleanup_failure() -> None:
+    class FailingAuthentication(FakeManagedAuthentication):
+        fail_gate_cleanup = False
+
+        def retire_probe_session(self, session: FakeManagedSession) -> None:
+            self.retired_sessions.append(session)
+            raise RuntimeError("close-primary")
+
+        def configure_request_gate(
+            self,
+            gate: Callable[[str, str], object] | None,
+        ) -> None:
+            if gate is None and self.fail_gate_cleanup:
+                raise OSError("gate-cleanup-secondary")
+            super().configure_request_gate(gate)
+
+    authentication = FailingAuthentication()
+    executor = ScopedGraphHttpExecutor(
+        target_url=TARGET_URL,
+        scope=Scope(in_scope=[TARGET_URL], out_of_scope=[]),
+        allow_remote_target=True,
+        profile=graph_operational_profile(
+            GraphOperationalProfileName.LOW_NOISE,
+            roe_max_rps=5,
+            max_total_requests=3,
+        ),
+        resolver=lambda _host, _port: (TARGET_ADDRESS,),
+        authentication=authentication,
+        persistent_managed_session=True,
+    )
+    executor(
+        node_id="node-auth-close",
+        arguments={"path": "/app/private"},
+        action_id="action-auth-close",
+    )
+    authentication.fail_gate_cleanup = True
+
+    with pytest.raises(
+        ScopedHttpError,
+        match="managed authentication action cleanup failed",
+    ) as error:
+        executor.close()
+
+    assert any(
+        "managed authentication gate cleanup also failed: OSError" in note
+        for note in getattr(error.value, "__notes__", ())
+    )
 
 
 def test_managed_begin_dispatch_block_does_not_increment_graph_count(

--- a/packages/ravage/tests/test_cli_plumbing.py
+++ b/packages/ravage/tests/test_cli_plumbing.py
@@ -1557,7 +1557,7 @@ def test_attack_result_distinguishes_confirmed_findings_from_candidate_signals(
     workspace.mkdir()
     traffic_policy = TrafficPolicyController.open(
         workspace / "traffic-policy.json",
-        target_url="http://127.0.0.1:8765",
+        target_url="https://example.test",
         config=TrafficPolicyConfig(),
     )
     traffic_policy.record_unmetered_action()

--- a/packages/ravage/tests/test_cockpit_live.py
+++ b/packages/ravage/tests/test_cockpit_live.py
@@ -150,8 +150,84 @@ def test_http_step_payload_masks_and_normalizes() -> None:
         ok=True,
     )
     assert payload["method"] == "POST"
-    assert payload["path"] == "/login?x=1"
+    assert payload["path"] == "/login?x=%5BREDACTED%5D"
     assert payload["fields"]["password"] != "p"
+
+
+def test_http_step_payload_sanitizes_urls_and_response_headers() -> None:
+    payload = http_step_payload(
+        action_id="safe-artifact",
+        index=1,
+        method="get",
+        url=(
+            "https://alice:request-password@target.example/callback"
+            "?view=request-query&token=request-token#request-fragment"
+        ),
+        form=None,
+        status=302,
+        ok=True,
+        response_headers={
+            "Content-Type": "text/plain; charset=utf-8",
+            "Location": (
+                "https://target.example/next"
+                "?view=location-query&code=location-code#location-fragment"
+            ),
+            "Set-Cookie": "session=response-cookie",
+            "X-Debug": "response-header-secret",
+        },
+        body="non-secret response evidence",
+    )
+
+    serialized = json.dumps(payload, sort_keys=True)
+    for secret in (
+        "alice",
+        "request-password",
+        "request-query",
+        "request-token",
+        "request-fragment",
+        "location-query",
+        "location-code",
+        "location-fragment",
+        "response-cookie",
+        "response-header-secret",
+    ):
+        assert secret not in serialized
+    assert payload["url"] == (
+        "https://target.example/callback"
+        "?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
+    )
+    assert payload["path"] == "/callback?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
+    headers = payload["response_headers"]
+    assert isinstance(headers, dict)
+    assert headers["location"] == (
+        "https://target.example/next?view=%5BREDACTED%5D&code=%5BREDACTED%5D"
+    )
+    assert headers["set-cookie"] == "[REDACTED]"
+    assert headers["x-debug"] == "[REDACTED]"
+
+
+def test_describe_invalid_action_sanitizes_url_bearing_error() -> None:
+    described = describe_action(
+        {
+            "action": "invalid",
+            "error": (
+                "failed https://alice:error-password@target.example/callback"
+                "?view=error-query#error-fragment; "
+                "Authorization: Bearer error-authorization"
+            ),
+        }
+    )
+
+    serialized = json.dumps(described, sort_keys=True)
+    for secret in (
+        "alice",
+        "error-password",
+        "error-query",
+        "error-fragment",
+        "error-authorization",
+    ):
+        assert secret not in serialized
+    assert "https://target.example/callback?view=%5BREDACTED%5D" in serialized
 
 
 # ---- dashboard state ----------------------------------------------------

--- a/packages/ravage/tests/test_evidence_lead_lock.py
+++ b/packages/ravage/tests/test_evidence_lead_lock.py
@@ -1,0 +1,1159 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+from ravage.agent_core import evidence_lead_lock
+from ravage.agent_core.agent_state import AgentState
+from ravage.agent_core.evidence_lead_lock import (
+    EvidenceLead,
+    action_matches_lead,
+    awaiting_session_lead,
+    directive,
+    lead_replay_generation,
+    pending_lead,
+    reactivate_for_session_change,
+    record_aligned_outcome,
+    release_for_session_reset,
+    remember_from_probe_result,
+    unresolved_lead,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _ssti_probe_text(*, endpoint: str = "/generate") -> str:
+    return json.dumps(
+        {
+            "probe": "ssti_fingerprint",
+            "ok": True,
+            "findings": [
+                {
+                    "type": "ssti_fingerprint_signal",
+                    "signal": {"kind": "evaluated_expression", "observed": "49"},
+                    "replay": {
+                        "method": "POST",
+                        "url": f"https://target.example{endpoint}",
+                        "payload_field": "sentence",
+                        "encoding": "application/x-www-form-urlencoded",
+                        "form": {
+                            "sentence": "<%= 7 * 7 %>",
+                            "submit": "Render",
+                        },
+                    },
+                    "baseline_replay": {
+                        "method": "POST",
+                        "url": f"https://target.example{endpoint}",
+                        "payload_field": "sentence",
+                        "encoding": "application/x-www-form-urlencoded",
+                        "form": {"sentence": "lead-lock-secret", "submit": "Render"},
+                    },
+                    "response": {
+                        "method": "POST",
+                        "url": f"https://target.example{endpoint}",
+                        "status": 200,
+                        "body_len": 120,
+                        "body_sha_hint": "abc123",
+                    },
+                    "delta": {"body_changed": True},
+                }
+            ],
+            "requests": [],
+            "errors": [],
+        }
+    )
+
+
+def _open_ssti(state: AgentState | None = None) -> tuple[AgentState, EvidenceLead]:
+    target = state or AgentState()
+    lead = remember_from_probe_result(
+        target,
+        _ssti_probe_text(),
+        {"action": "run_probe", "probe": "ssti_fingerprint"},
+        "observation-1",
+    )
+    assert lead is not None
+    return target, lead
+
+
+def _aligned_action() -> dict[str, object]:
+    return {
+        "action": "http_request",
+        "vuln_class": "ssti",
+        "method": "POST",
+        "url": "https://target.example/generate",
+        "form": {"sentence": "<%= 8 * 8 %>", "submit": "Render"},
+    }
+
+
+def _confirmed_validate_payload() -> str:
+    return json.dumps(
+        {
+            "finding_id": "finding-1",
+            "vuln_class": "sql_injection",
+            "assessment_source": "executor_policy",
+            "endpoint": {
+                "method": "GET",
+                "url": "https://target.example/search",
+                "params": [{"name": "q", "location": "query"}],
+            },
+            "input": {
+                "method": "GET",
+                "parameters": [{"name": "q", "location": "query"}],
+                "affected_parameters": [{"name": "q", "location": "query"}],
+            },
+            "status": "confirmed",
+            "validator_vote": "confirm",
+            "evidence_checks": {"passed": 2, "required": 2},
+            "evidence_kind": "http_poc_replay",
+            "outcome_stage": "verified_vulnerability",
+            "source_kind": "tool_validate_poc",
+            "source_observation_id": "observation-poc",
+            "provenance": {
+                "source_kind": "tool_validate_poc",
+                "source_observation_id": "observation-poc",
+                "assessment_source": "executor_policy",
+                "model_claims_used": False,
+            },
+        }
+    )
+
+
+def test_material_native_probe_opens_secret_free_exact_route_lock() -> None:
+    state, lead = _open_ssti()
+
+    assert lead.family == "template_injection"
+    assert lead.method == "POST"
+    assert lead.origin == "https://target.example"
+    assert lead.endpoint == "/generate"
+    assert lead.inputs == ("sentence",)
+    assert lead.input_locations == (("body", "sentence"),)
+    assert lead.request_inputs == (("body", "sentence"), ("body", "submit"))
+    assert lead.body_encoding == "form"
+    assert lead.source_kind == "tool_run_probe"
+    assert lead.stage == "verified_vulnerability"
+    assert pending_lead(state) == lead
+    assert "lead-lock-secret" not in json.dumps(state.surface)
+    assert "POST /generate" in directive(state)
+    assert "sentence" in directive(state)
+
+
+@pytest.mark.parametrize("kind", ["http_request", "run_command", "run_python"])
+def test_untyped_tool_output_cannot_open_lock(kind: str) -> None:
+    state = AgentState()
+
+    opened = remember_from_probe_result(
+        state,
+        _ssti_probe_text(),
+        {"action": kind, "probe": "ssti_fingerprint"},
+        "observation-raw",
+    )
+
+    assert opened is None
+    assert pending_lead(state) is None
+
+
+def test_auth_state_only_finding_cannot_open_lock() -> None:
+    text = json.dumps(
+        {
+            "probe": "default_credentials",
+            "ok": True,
+            "findings": [
+                {
+                    "type": "default_credentials_valid",
+                    "url": "https://target.example/account",
+                }
+            ],
+        }
+    )
+
+    opened = remember_from_probe_result(
+        AgentState(),
+        text,
+        {"action": "run_probe", "probe": "default_credentials"},
+        "observation-auth",
+    )
+
+    assert opened is None
+
+
+def test_incomplete_native_candidate_cannot_open_lock() -> None:
+    payload = json.loads(_ssti_probe_text())
+    payload["findings"][0]["signal"] = {"kind": "template_error"}
+
+    opened = remember_from_probe_result(
+        AgentState(),
+        json.dumps(payload),
+        {"action": "run_probe", "probe": "ssti_fingerprint"},
+        "observation-candidate",
+    )
+
+    assert opened is None
+
+
+def test_confirmed_validate_poc_payload_opens_lock() -> None:
+    state = AgentState()
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "GET",
+                "url": "/search?q=%27",
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "GET",
+                "url": "/search?q=control",
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    lead = remember_from_probe_result(
+        state,
+        _confirmed_validate_payload(),
+        action,
+        "observation-poc",
+    )
+
+    assert lead is not None
+    assert lead.family == "sql_injection"
+    assert lead.method == "GET"
+    assert lead.endpoint == "/search"
+    assert lead.inputs == ("q",)
+    assert lead.source_kind == "tool_validate_poc"
+
+
+def test_confirmed_raw_json_poc_opens_a_replayable_named_body_lock() -> None:
+    state = AgentState()
+    payload = json.loads(_confirmed_validate_payload())
+    payload["endpoint"] = {
+        "method": "POST",
+        "url": "https://target.example/api/search",
+        "params": [{"name": "query", "location": "body"}],
+    }
+    payload["input"] = {
+        "method": "POST",
+        "parameters": [{"name": "query", "location": "body"}],
+        "affected_parameters": [{"name": "query", "location": "body"}],
+    }
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "POST",
+                "path": "/api/search",
+                "headers": {"Content-Type": "application/json"},
+                "body": '{"query":"exploit","submit":true}',
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "POST",
+                "path": "/api/search",
+                "headers": {"Content-Type": "application/json"},
+                "body": '{"query":"control","submit":true}',
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    lead = remember_from_probe_result(
+        state,
+        json.dumps(payload),
+        action,
+        "observation-poc",
+    )
+
+    assert lead is not None
+    assert lead.body_encoding == "json"
+    assert lead.request_inputs == (("body", "query"), ("body", "submit"))
+    assert (
+        action_matches_lead(
+            action,
+            lead,
+            primary_origin="https://target.example",
+        )
+        is True
+    )
+    assert action_matches_lead(
+        {
+            "action": "http_request",
+            "vuln_class": "sql_injection",
+            "method": "POST",
+            "path": "/api/search",
+            "json": ["query", "unmodelled-list"],
+        },
+        lead,
+    ) is False
+
+
+@pytest.mark.parametrize(
+    ("content_type", "body"),
+    [
+        ("application/json", "not-json"),
+        ("application/json", "7"),
+        ("application/json", '["array"]'),
+        ("application/x-www-form-urlencoded", "%"),
+        ("application/x-www-form-urlencoded", "=missing-name"),
+    ],
+)
+def test_unmodelled_typed_body_cannot_hide_drift_in_query_lock(
+    content_type: str,
+    body: str,
+) -> None:
+    payload = json.loads(_confirmed_validate_payload())
+    payload["endpoint"]["method"] = "POST"
+    payload["input"]["method"] = "POST"
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "POST",
+                "path": "/search?q=exploit",
+                "headers": {"Content-Type": content_type},
+                "body": body,
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "POST",
+                "path": "/search?q=control",
+                "headers": {"Content-Type": content_type},
+                "body": body,
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            json.dumps(payload),
+            action,
+            "observation-poc",
+        )
+        is None
+    )
+
+
+def test_confirmed_poc_lock_preserves_duplicate_query_slots() -> None:
+    state = AgentState()
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "GET",
+                "path": "/search?q=exploit&q=second",
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "GET",
+                "path": "/search?q=control&q=second",
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    lead = remember_from_probe_result(
+        state,
+        _confirmed_validate_payload(),
+        action,
+        "observation-poc",
+    )
+
+    assert lead is not None
+    assert lead.request_inputs == (("query", "q"), ("query", "q"))
+    assert (
+        action_matches_lead(
+            action,
+            lead,
+            primary_origin="https://target.example",
+        )
+        is True
+    )
+    drifted = {
+        **action,
+        "steps": [
+            {**step, "path": "/search?q=only-one"}
+            for step in action["steps"]
+            if isinstance(step, dict)
+        ],
+    }
+    assert action_matches_lead(drifted, lead) is False
+
+
+def test_opaque_raw_body_does_not_open_exact_lock() -> None:
+    payload = json.loads(_confirmed_validate_payload())
+    payload["endpoint"] = {
+        "method": "POST",
+        "url": "https://target.example/search",
+        "params": [{"name": "raw_body", "location": "body"}],
+    }
+    payload["input"] = {
+        "method": "POST",
+        "parameters": [{"name": "raw_body", "location": "body"}],
+        "affected_parameters": [{"name": "raw_body", "location": "body"}],
+    }
+    raw_action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "POST",
+                "path": "/search",
+                "body": "opaque exploit bytes",
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "POST",
+                "path": "/search",
+                "body": "opaque control bytes",
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            json.dumps(payload),
+            raw_action,
+            "observation-poc",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/items/{id}",
+        "/items/{int}",
+        "/items/{uuid}",
+        "/items/{segment}",
+        "/items/:id",
+        "/items/:redacted",
+        "/items/%7Bid%7D",
+        "/items/%3Aid",
+        "/items/<int:id>",
+    ],
+)
+def test_structural_endpoint_does_not_open_or_match_exact_lock(endpoint: str) -> None:
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            _ssti_probe_text(endpoint=endpoint),
+            {"action": "run_probe", "probe": "ssti_fingerprint"},
+            "observation-template",
+        )
+        is None
+    )
+
+    _state, concrete = _open_ssti()
+    structural = replace(concrete, endpoint=endpoint, fingerprint="")
+    structural = replace(
+        structural,
+        fingerprint=evidence_lead_lock._lead_fingerprint(structural),  # noqa: SLF001
+    )
+    candidate = {**_aligned_action(), "url": f"https://target.example{endpoint}"}
+    assert action_matches_lead(candidate, structural) is False
+
+
+def test_persisted_structural_endpoint_fails_closed_on_load() -> None:
+    state, concrete = _open_ssti()
+    structural = replace(concrete, endpoint="/items/{id}", fingerprint="")
+    structural = replace(
+        structural,
+        fingerprint=evidence_lead_lock._lead_fingerprint(structural),  # noqa: SLF001
+    )
+    state.surface["evidence_lead_lock"] = structural.to_json()
+
+    assert pending_lead(state) is None
+
+
+def test_validate_poc_requires_matching_executor_provenance() -> None:
+    payload = json.loads(_confirmed_validate_payload())
+    payload["provenance"]["model_claims_used"] = True
+
+    opened = remember_from_probe_result(
+        AgentState(),
+        json.dumps(payload),
+        {"action": "validate_poc", "steps": []},
+        "observation-poc",
+    )
+
+    assert opened is None
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"vuln_class": "sql_injection"},
+        {"method": "GET"},
+        {"url": "https://target.example/preview"},
+        {"form": {"name": "<%= 8 * 8 %>"}},
+    ],
+)
+def test_action_match_requires_exact_family_method_endpoint_and_input(
+    change: dict[str, object],
+) -> None:
+    _state, lead = _open_ssti()
+    aligned = _aligned_action()
+    aligned.update(change)
+
+    assert action_matches_lead(aligned, lead) is False
+
+
+def test_exact_http_route_matches_and_state_round_trips() -> None:
+    state, lead = _open_ssti()
+    restored = AgentState.from_json(state.to_json())
+
+    assert pending_lead(restored) == lead
+    assert action_matches_lead(_aligned_action(), lead) is True
+    # Declarative metadata does not constrain what a native specialist will
+    # physically request, so a run_probe action cannot satisfy an exact replay.
+    assert action_matches_lead(
+        {
+            "action": "run_probe",
+            "probe": "ssti_fingerprint",
+            "method": "POST",
+            "url": "https://target.example/generate",
+            "field": "sentence",
+        },
+        lead,
+    ) is False
+
+
+def _aligned_validate_action() -> dict[str, object]:
+    return {
+        "action": "validate_poc",
+        "vuln_class": "ssti",
+        "steps": [
+            {
+                "method": "POST",
+                "url": "https://target.example/generate",
+                "evidence_role": "exploit",
+                "form": {"sentence": "<%= 8 * 8 %>", "submit": "Render"},
+            },
+            {
+                "method": "POST",
+                "url": "https://target.example/generate",
+                "evidence_role": "control",
+                "form": {"sentence": "control", "submit": "Render"},
+            },
+        ],
+    }
+
+
+def test_validate_poc_exact_observed_request_shape_matches() -> None:
+    _state, lead = _open_ssti()
+
+    assert action_matches_lead(_aligned_validate_action(), lead) is True
+
+
+@pytest.mark.parametrize(
+    ("changed_key", "changed_value"),
+    [("method", "GET"), ("url", "https://target.example/preview")],
+)
+def test_validate_poc_rejects_when_any_step_changes_transport(
+    changed_key: str,
+    changed_value: str,
+) -> None:
+    _state, lead = _open_ssti()
+    action = _aligned_validate_action()
+    steps = action["steps"]
+    assert isinstance(steps, list)
+    control = steps[1]
+    assert isinstance(control, dict)
+    control[changed_key] = changed_value
+
+    assert action_matches_lead(action, lead) is False
+
+
+def test_validate_poc_rejects_affected_input_moved_from_body_to_query() -> None:
+    _state, lead = _open_ssti()
+    action = _aligned_validate_action()
+    steps = action["steps"]
+    assert isinstance(steps, list)
+    for index, step in enumerate(steps):
+        assert isinstance(step, dict)
+        value = "%3C%25%3D8%2A8%25%3E" if index == 0 else "control"
+        step["url"] = f"https://target.example/generate?sentence={value}"
+        step["form"] = {"submit": "Render"}
+
+    assert action_matches_lead(action, lead) is False
+
+
+@pytest.mark.parametrize(
+    "form",
+    [
+        {"sentence": "<%= 8 * 8 %>"},
+        {"sentence": "<%= 8 * 8 %>", "commit": "Render"},
+        {"sentence": "<%= 8 * 8 %>", "submit": "Render", "unexpected": "1"},
+    ],
+)
+def test_validate_poc_requires_exact_companion_input_names(
+    form: dict[str, str],
+) -> None:
+    _state, lead = _open_ssti()
+    action = _aligned_validate_action()
+    steps = action["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        assert isinstance(step, dict)
+        step["form"] = dict(form)
+
+    assert action_matches_lead(action, lead) is False
+
+
+def test_validate_poc_rejects_json_when_observed_body_was_form_encoded() -> None:
+    _state, lead = _open_ssti()
+    action = _aligned_validate_action()
+    steps = action["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        assert isinstance(step, dict)
+        form = step.pop("form")
+        step["json"] = form
+
+    assert action_matches_lead(action, lead) is False
+
+
+def test_http_request_rejects_observed_body_shape_drift() -> None:
+    _state, lead = _open_ssti()
+    drifted = [
+        {
+            "action": "http_request",
+            "vuln_class": "ssti",
+            "method": "POST",
+            "url": "https://target.example/generate?sentence=payload",
+            "form": {"submit": "Render"},
+        },
+        {
+            "action": "http_request",
+            "vuln_class": "ssti",
+            "method": "POST",
+            "url": "https://target.example/generate",
+            "form": {"sentence": "payload"},
+        },
+        {
+            "action": "http_request",
+            "vuln_class": "ssti",
+            "method": "POST",
+            "url": "https://target.example/generate",
+            "form": {"sentence": "payload", "submit": "Render", "unexpected": "1"},
+        },
+        {
+            "action": "http_request",
+            "vuln_class": "ssti",
+            "method": "POST",
+            "url": "https://target.example/generate",
+            "json": {"sentence": "payload", "submit": "Render"},
+        },
+    ]
+
+    assert all(not action_matches_lead(action, lead) for action in drifted)
+
+
+def test_http_request_rejects_origin_and_effective_encoding_drift() -> None:
+    _state, lead = _open_ssti()
+    other_origin = {
+        **_aligned_action(),
+        "url": "https://other-authorized.example/generate",
+    }
+    mislabeled_form = {
+        **_aligned_action(),
+        "headers": {"Content-Type": "application/json"},
+    }
+
+    assert action_matches_lead(other_origin, lead) is False
+    assert action_matches_lead(mislabeled_form, lead) is False
+
+
+def test_relative_http_request_requires_matching_primary_origin() -> None:
+    _state, lead = _open_ssti()
+    relative = {
+        **_aligned_action(),
+        "url": "/generate",
+    }
+
+    assert action_matches_lead(relative, lead) is False
+    assert (
+        action_matches_lead(
+            relative,
+            lead,
+            primary_origin="https://target.example/app",
+        )
+        is True
+    )
+    assert (
+        action_matches_lead(
+            relative,
+            lead,
+            primary_origin="https://main.example/app",
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        {"X-Debug-Mode": "1"},
+        {"Authorization": "Bearer attacker-authored"},
+        {"Cookie": "tenant=b; sid=attacker-authored"},
+    ],
+)
+def test_http_request_rejects_unmodelled_authored_headers(
+    header: dict[str, str],
+) -> None:
+    _state, lead = _open_ssti()
+    explicit_content_type = {
+        **_aligned_action(),
+        "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+    }
+    added_header = {
+        **explicit_content_type,
+        "headers": {
+            "Content-Type": "application/x-www-form-urlencoded",
+            **header,
+        },
+    }
+
+    assert action_matches_lead(explicit_content_type, lead) is True
+    assert action_matches_lead(added_header, lead) is False
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        {"X-Tenant": "tenant-a"},
+        {"Cookie": "tenant=a; sid=source-cookie"},
+    ],
+)
+def test_native_header_dependent_request_does_not_open_exact_lock(
+    header: dict[str, str],
+) -> None:
+    payload = json.loads(_ssti_probe_text())
+    finding = payload["findings"][0]
+    assert isinstance(finding, dict)
+    for key in ("replay", "baseline_replay"):
+        replay = finding[key]
+        assert isinstance(replay, dict)
+        replay["headers"] = dict(header)
+
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            json.dumps(payload),
+            {"action": "run_probe", "probe": "ssti_fingerprint"},
+            "observation-header-dependent",
+        )
+        is None
+    )
+
+
+def test_header_only_mutation_cannot_open_a_named_input_lock() -> None:
+    payload = json.loads(_confirmed_validate_payload())
+    payload["input"] = {
+        "method": "GET",
+        "parameters": [{"name": "x-tenant", "location": "header"}],
+        "affected_parameters": [{"name": "x-tenant", "location": "header"}],
+    }
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "GET",
+                "path": "/search",
+                "headers": {"X-Tenant": "exploit"},
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "GET",
+                "path": "/search",
+                "headers": {"X-Tenant": "control"},
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            json.dumps(payload),
+            action,
+            "observation-poc",
+        )
+        is None
+    )
+
+
+def test_unchanged_companion_header_prevents_false_query_lock() -> None:
+    action = {
+        "action": "validate_poc",
+        "finding": {"vuln_class": "sql_injection"},
+        "steps": [
+            {
+                "method": "GET",
+                "path": "/search?q=exploit",
+                "headers": {"X-Tenant": "tenant-a"},
+                "evidence_role": "exploit",
+            },
+            {
+                "method": "GET",
+                "path": "/search?q=control",
+                "headers": {"X-Tenant": "tenant-a"},
+                "evidence_role": "control",
+            },
+        ],
+    }
+
+    assert (
+        remember_from_probe_result(
+            AgentState(),
+            _confirmed_validate_payload(),
+            action,
+            "observation-poc",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("action_factory", [_aligned_action, _aligned_validate_action])
+def test_locked_replay_rejects_case_insensitive_duplicate_headers(
+    action_factory: Callable[[], dict[str, object]],
+) -> None:
+    _state, lead = _open_ssti()
+    action = action_factory()
+    if action["action"] == "validate_poc":
+        requests = action["steps"]
+        assert isinstance(requests, list)
+    else:
+        requests = [action]
+    for request in requests:
+        assert isinstance(request, dict)
+        request["headers"] = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "content-type": "application/json",
+        }
+
+    assert action_matches_lead(action, lead) is False
+
+
+def test_only_complete_aligned_no_progress_attempts_exhaust_lock() -> None:
+    state, original = _open_ssti()
+    aligned = _aligned_action()
+
+    for ignored in (
+        {"ok": False, "outcome": "blocked"},
+        {"ok": False, "outcome": "observed", "timed_out": True},
+        {"ok": False, "outcome": "same_as_before"},
+    ):
+        assert record_aligned_outcome(state, aligned, ignored) == original
+
+    assert record_aligned_outcome(
+        state,
+        {**aligned, "url": "https://target.example/unrelated"},
+        {"ok": True, "outcome": "observed"},
+    ) == original
+
+    after_first = record_aligned_outcome(
+        state,
+        aligned,
+        {"ok": True, "outcome": "observed"},
+    )
+    assert after_first is not None
+    assert after_first.aligned_no_progress == 1
+    assert "1 complete aligned no-progress attempt(s) remain" in directive(state)
+
+    assert record_aligned_outcome(
+        state,
+        aligned,
+        {"ok": True, "outcome": "observed"},
+    ) is None
+    assert pending_lead(state) is None
+    assert state.surface["evidence_lead_lock"]["status"] == "exhausted"
+
+
+@pytest.mark.parametrize("status", [401, 403, 407])
+def test_authentication_required_status_pauses_exact_lead(status: int) -> None:
+    state, original = _open_ssti()
+    state.last_observation = {"http_response": {"status": status}}
+
+    remaining = record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {"ok": True, "outcome": "http_response_observed"},
+    )
+
+    assert remaining is None
+    assert pending_lead(state) is None
+    assert awaiting_session_lead(state) is not None
+    assert unresolved_lead(state) is not None
+    stored = state.surface["evidence_lead_lock"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "awaiting_session"
+    assert stored["response_status"] == status
+    assert "Establish authentication" in directive(state)
+
+    state.last_observation = {"http_response": {"status": 200}}
+    reactivated = record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {"ok": True, "outcome": "http_response_observed"},
+    )
+    assert reactivated is not None
+    assert reactivated.fingerprint == original.fingerprint
+    assert reactivated.aligned_no_progress == 1
+    assert awaiting_session_lead(state) is None
+    assert unresolved_lead(state) == reactivated
+    assert lead_replay_generation(state) == 1
+
+
+def test_only_waiting_lead_reactivation_advances_replay_generation() -> None:
+    state, original = _open_ssti()
+
+    assert lead_replay_generation(state) == 0
+    assert reactivate_for_session_change(state) is None
+    assert lead_replay_generation(state) == 0
+
+    record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {
+            "ok": True,
+            "outcome": "http_response_observed",
+            "_evidence_observation": json.dumps({"response": {"status": 401}}),
+        },
+    )
+    active = reactivate_for_session_change(state)
+
+    assert active is not None
+    assert active.fingerprint == original.fingerprint
+    assert active.status == "active"
+    assert active.aligned_no_progress == 0
+    assert lead_replay_generation(state) == 1
+    assert reactivate_for_session_change(state) is None
+    assert lead_replay_generation(state) == 1
+
+
+def test_blocked_replay_cannot_reactivate_auth_paused_lead() -> None:
+    state, _original = _open_ssti()
+    action = _aligned_action()
+    record_aligned_outcome(
+        state,
+        action,
+        {
+            "ok": True,
+            "outcome": "http_response_observed",
+            "_evidence_observation": json.dumps({"response": {"status": 401}}),
+        },
+    )
+
+    assert record_aligned_outcome(
+        state,
+        action,
+        {"ok": False, "outcome": "blocked"},
+    ) is None
+    stored = state.surface["evidence_lead_lock"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "awaiting_session"
+    assert lead_replay_generation(state) == 0
+
+
+def test_current_http_auth_response_with_rotated_cookie_still_pauses_lead() -> None:
+    auth_status = 401
+    state, _original = _open_ssti()
+    state.last_observation = {"http_response": {"status": 200}}
+    evidence = json.dumps(
+        {
+            "response": {
+                "status": auth_status,
+                "headers": {"Set-Cookie": "session=rotated; HttpOnly"},
+            }
+        }
+    )
+
+    remaining = record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {
+            "ok": True,
+            "outcome": "http_response_observed",
+            "_evidence_observation": evidence,
+        },
+    )
+
+    assert remaining is None
+    stored = state.surface["evidence_lead_lock"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "awaiting_session"
+    assert stored["response_status"] == auth_status
+
+
+def test_pre_dispatch_block_does_not_reuse_stale_auth_response() -> None:
+    state, original = _open_ssti()
+    state.last_observation = {"http_response": {"status": 401}}
+
+    remaining = record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {"ok": False, "outcome": "blocked"},
+    )
+
+    assert remaining == original
+    assert state.surface["evidence_lead_lock"]["status"] == "active"
+
+
+@pytest.mark.parametrize("status", [429, 500, 503])
+def test_complete_server_response_counts_as_no_progress(status: int) -> None:
+    state, _original = _open_ssti()
+    state.last_observation = {"http_response": {"status": status}}
+
+    remaining = record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {"ok": True, "outcome": "http_response_observed"},
+    )
+
+    assert remaining is not None
+    assert remaining.aligned_no_progress == 1
+
+
+def test_session_reset_releases_unreplayable_lead() -> None:
+    state, original = _open_ssti()
+
+    released = release_for_session_reset(state)
+
+    assert released is not None
+    assert released.fingerprint == original.fingerprint
+    assert pending_lead(state) is None
+    stored = state.surface["evidence_lead_lock"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "exhausted"
+    assert stored["release_reason"] == "http_session_reset"
+
+
+def test_completed_rejected_validate_poc_counts_as_no_progress() -> None:
+    state, _original = _open_ssti()
+    action = _aligned_validate_action()
+    evidence = json.dumps(
+        {
+            "steps": [
+                {"response": {"status": 200}},
+                {"response": {"status": 200}},
+            ]
+        }
+    )
+    rejected = {
+        "ok": False,
+        "outcome": "blocked",
+        "_evidence_observation": evidence,
+    }
+
+    first = record_aligned_outcome(state, action, rejected)
+    assert first is not None
+    assert first.aligned_no_progress == 1
+    assert record_aligned_outcome(state, action, rejected) is None
+    assert state.surface["evidence_lead_lock"]["status"] == "exhausted"
+
+
+@pytest.mark.parametrize("status", [401, 403, 407])
+def test_completed_validate_auth_responses_pause_without_consuming_attempt(
+    status: int,
+) -> None:
+    state, _original = _open_ssti()
+    outcome = {
+        "ok": False,
+        "outcome": "blocked",
+        "_evidence_observation": json.dumps(
+            {
+                "steps": [
+                    {"response": {"status": status}},
+                    {"response": {"status": status}},
+                ]
+            }
+        ),
+    }
+
+    assert record_aligned_outcome(state, _aligned_validate_action(), outcome) is None
+    stored = state.surface["evidence_lead_lock"]
+    assert isinstance(stored, dict)
+    assert stored["status"] == "awaiting_session"
+    assert stored["response_status"] == status
+    assert stored["aligned_no_progress"] == 0
+
+
+def test_mixed_validate_responses_count_as_completed_attempt_instead_of_auth_pause() -> None:
+    state, _original = _open_ssti()
+    outcome = {
+        "ok": False,
+        "outcome": "blocked",
+        "_evidence_observation": json.dumps(
+            {
+                "steps": [
+                    {"response": {"status": 200}},
+                    {"response": {"status": 403}},
+                ]
+            }
+        ),
+    }
+
+    remaining = record_aligned_outcome(state, _aligned_validate_action(), outcome)
+
+    assert remaining is not None
+    assert remaining.status == "active"
+    assert remaining.aligned_no_progress == 1
+
+
+def test_incomplete_validate_poc_does_not_consume_attempt() -> None:
+    state, original = _open_ssti()
+    outcome = {
+        "ok": False,
+        "outcome": "blocked",
+        "_evidence_observation": json.dumps(
+            {
+                "steps": [
+                    {"response": {"status": 200}},
+                    {"response": {"status": None, "error": "request blocked"}},
+                ]
+            }
+        ),
+    }
+
+    assert record_aligned_outcome(state, _aligned_validate_action(), outcome) == original
+
+
+@pytest.mark.parametrize("outcome", ["flag_candidate", "lead_rejected"])
+def test_proof_or_rejected_aligned_outcome_closes_lock(outcome: str) -> None:
+    state, _lead = _open_ssti()
+
+    assert record_aligned_outcome(
+        state,
+        _aligned_action(),
+        {"ok": True, "outcome": outcome},
+    ) is None
+    assert pending_lead(state) is None
+    assert state.surface["evidence_lead_lock"]["status"] in {"resolved", "rejected"}
+
+
+def test_new_lead_does_not_preempt_unresolved_route() -> None:
+    state, first = _open_ssti()
+
+    returned = remember_from_probe_result(
+        state,
+        _ssti_probe_text(endpoint="/other"),
+        {"action": "run_probe", "probe": "ssti_fingerprint"},
+        "observation-2",
+    )
+
+    assert returned == first
+    assert pending_lead(state) == first

--- a/packages/ravage/tests/test_evidence_lead_lock_wiring.py
+++ b/packages/ravage/tests/test_evidence_lead_lock_wiring.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+import ravage.agent_core.ai_agent as ai_agent_module
+from ravage.agent_core.action_executor import ActionResult, execute_action
+from ravage.agent_core.agent_state import AgentState
+from ravage.agent_core.ai_agent import (
+    _execute_recovery_action,
+    _model_action,
+    _repeat_context,
+    _update_state_from_action,
+)
+from ravage.agent_core.autonomous_graph.action_bridge import ActionExecution
+from ravage.agent_core.evidence_lead_lock import (
+    awaiting_session_lead,
+    pending_lead,
+    reactivate_for_session_change,
+    record_aligned_outcome,
+    remember_from_probe_result,
+    unresolved_lead,
+)
+from ravage.agent_core.recovery_runtime import RecoveryCampaign
+from ravage.agent_core.semantic_routes import semantic_action_fingerprint
+from ravage.agent_core.surface_graph import SurfaceGraphState
+from ravage.run_data.audit import AuditStore
+from ravage.run_data.workspace import AgentWorkspace
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _ssti_probe_text(*, origin: str = "https://target.example") -> str:
+    return json.dumps(
+        {
+            "probe": "ssti_fingerprint",
+            "ok": True,
+            "findings": [
+                {
+                    "type": "ssti_fingerprint_signal",
+                    "signal": {"kind": "evaluated_expression", "observed": "49"},
+                    "replay": {
+                        "method": "POST",
+                        "url": f"{origin}/generate",
+                        "payload_field": "sentence",
+                        "encoding": "application/x-www-form-urlencoded",
+                        "form": {"sentence": "<%= 7 * 7 %>", "submit": "Render"},
+                    },
+                    "baseline_replay": {
+                        "method": "POST",
+                        "url": f"{origin}/generate",
+                        "payload_field": "sentence",
+                        "encoding": "application/x-www-form-urlencoded",
+                        "form": {"sentence": "control", "submit": "Render"},
+                    },
+                    "response": {
+                        "method": "POST",
+                        "url": f"{origin}/generate",
+                        "status": 200,
+                        "body_len": 120,
+                        "body_sha_hint": "abc123",
+                    },
+                    "delta": {"body_changed": True},
+                }
+            ],
+            "requests": [],
+            "errors": [],
+        }
+    )
+
+
+def _state_with_lead() -> AgentState:
+    state = AgentState()
+    opened = remember_from_probe_result(
+        state,
+        _ssti_probe_text(),
+        {"action": "run_probe", "probe": "ssti_fingerprint"},
+        "observation-lead",
+    )
+    assert opened is not None
+    return state
+
+
+def _state_with_primary_and_lead(
+    *,
+    primary_origin: str,
+    lead_origin: str,
+) -> AgentState:
+    state = AgentState(
+        surface_graph=SurfaceGraphState.for_target(primary_origin),
+    )
+    opened = remember_from_probe_result(
+        state,
+        _ssti_probe_text(origin=lead_origin),
+        {"action": "run_probe", "probe": "ssti_fingerprint"},
+        "observation-lead",
+    )
+    assert opened is not None
+    return state
+
+
+def _aligned_http_action() -> dict[str, object]:
+    return {
+        "action": "http_request",
+        "vuln_class": "ssti",
+        "method": "POST",
+        "url": "https://target.example/generate",
+        "form": {"sentence": "<%= 8 * 8 %>", "submit": "Render"},
+    }
+
+
+def _http_action_outcome(status: int) -> ActionResult:
+    evidence = json.dumps(
+        {
+            "response": {
+                "status": status,
+                "final_url": "https://target.example/generate",
+                "headers": {},
+                "body": "no proof",
+                "body_sha256": "unavailable",
+                "truncated": False,
+                "error": "",
+            }
+        },
+        sort_keys=True,
+    )
+    return ActionResult(
+        ok=True,
+        observation=evidence,
+        outcome="http_response_observed",
+        evidence_source_kind="tool_http_request",
+        evidence_observation=evidence,
+    )
+
+
+@pytest.mark.parametrize(
+    "proposed",
+    [
+        {
+            "action": "http_request",
+            "vuln_class": "sql_injection",
+            "method": "GET",
+            "url": "https://target.example/search?q=%27",
+        },
+        {"action": "final", "summary": "pivot away from the observed route"},
+    ],
+)
+def test_model_action_blocks_unrelated_family_and_final(
+    proposed: dict[str, object],
+) -> None:
+    state = _state_with_lead()
+
+    selected = _model_action(json.dumps(proposed), state=state, turn=2, max_turns=10)
+
+    assert selected["action"] == "invalid"
+    assert "Evidence lead lock active" in str(selected["error"])
+    assert selected["raw"] == f"blocked action kind: {proposed['action']}"
+
+
+def test_model_action_allows_exact_http_replay_and_capture_flag() -> None:
+    state = _state_with_lead()
+    aligned = _aligned_http_action()
+
+    selected = _model_action(json.dumps(aligned), state=state, turn=2, max_turns=10)
+    capture = _model_action(
+        json.dumps(
+            {
+                "action": "capture_flag",
+                "flag": "FLAG{executor_will_verify_this}",
+                "evidence": "exact proof appeared in trusted target evidence",
+            }
+        ),
+        state=state,
+        turn=3,
+        max_turns=10,
+    )
+
+    assert selected == aligned
+    assert capture["action"] == "capture_flag"
+    assert capture["flag"] == "FLAG{executor_will_verify_this}"
+
+
+def test_model_action_rejects_relative_replay_for_auxiliary_origin_lead() -> None:
+    state = _state_with_primary_and_lead(
+        primary_origin="https://main.example/app",
+        lead_origin="https://aux.example",
+    )
+    relative = {
+        **_aligned_http_action(),
+        "url": "/generate",
+    }
+    absolute_auxiliary = {
+        **relative,
+        "url": "https://aux.example/generate",
+    }
+
+    blocked = _model_action(json.dumps(relative), state=state, turn=2, max_turns=10)
+    allowed = _model_action(
+        json.dumps(absolute_auxiliary),
+        state=state,
+        turn=3,
+        max_turns=10,
+    )
+
+    assert blocked["action"] == "invalid"
+    assert blocked["raw"] == "blocked action kind: http_request"
+    assert allowed == absolute_auxiliary
+
+
+def test_model_action_allows_relative_replay_when_lead_uses_primary_origin() -> None:
+    state = _state_with_primary_and_lead(
+        primary_origin="https://target.example/app",
+        lead_origin="https://target.example",
+    )
+    relative = {
+        **_aligned_http_action(),
+        "url": "/generate",
+    }
+
+    selected = _model_action(json.dumps(relative), state=state, turn=2, max_turns=10)
+
+    assert selected == relative
+
+
+def test_model_action_rejects_metadata_only_native_probe_replay() -> None:
+    state = _state_with_lead()
+    proposed = {
+        "action": "run_probe",
+        "probe": "ssti_fingerprint",
+        "vuln_class": "ssti",
+        "method": "POST",
+        "url": "https://target.example/generate",
+        "field": "sentence",
+    }
+
+    selected = _model_action(json.dumps(proposed), state=state, turn=2, max_turns=10)
+
+    assert selected["action"] == "invalid"
+    assert selected["raw"] == "blocked action kind: run_probe"
+
+
+def test_repeat_context_includes_active_lead_fingerprint() -> None:
+    state = _state_with_lead()
+    lead = pending_lead(state)
+    assert lead is not None
+
+    assert _repeat_context(state) == lead.fingerprint
+
+    state.signals["canonical_hosts"] = ["target.internal"]
+    assert _repeat_context(state) == f"host:target.internal|{lead.fingerprint}"
+
+
+def test_reactivated_lead_gets_a_fresh_exact_replay_budget(tmp_path: Path) -> None:
+    state = _state_with_lead()
+    action = _aligned_http_action()
+    initial_context = _repeat_context(state, action=action)
+
+    assert state.ledger.remember(action, context=initial_context) == 1
+    first = record_aligned_outcome(
+        state,
+        action,
+        {"ok": True, "outcome": "http_response_observed"},
+    )
+    assert first is not None
+    assert first.aligned_no_progress == 1
+    assert state.ledger.remember(action, context=initial_context) == 2
+    assert record_aligned_outcome(
+        state,
+        action,
+        {
+            "ok": True,
+            "outcome": "http_response_observed",
+            "_evidence_observation": json.dumps({"response": {"status": 401}}),
+        },
+    ) is None
+    assert state.surface["evidence_lead_lock"]["status"] == "awaiting_session"
+
+    reactivated = reactivate_for_session_change(state)
+    assert reactivated is not None
+    replay_context = _repeat_context(state, action=action)
+    assert replay_context != initial_context
+    replay_count = state.ledger.remember(action, context=replay_context)
+    assert replay_count == 1
+
+    calls: list[dict[str, object]] = []
+    evidence = json.dumps(
+        {
+            "response": {
+                "status": 200,
+                "final_url": "https://target.example/generate",
+                "headers": {},
+                "body": "clean response",
+                "body_sha256": "unavailable",
+                "truncated": False,
+                "error": "",
+            }
+        },
+        sort_keys=True,
+    )
+
+    def http_executor(**kwargs: object) -> ActionExecution:
+        calls.append(dict(kwargs))
+        return ActionExecution(
+            result=ActionResult(
+                ok=True,
+                observation=evidence,
+                outcome="http_response_observed",
+                evidence_source_kind="tool_http_request",
+                evidence_observation=evidence,
+            ),
+            observation_id="post-auth-replay",
+        )
+
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    audit = AuditStore(tmp_path / "audit.db")
+    try:
+        result = execute_action(
+            action,
+            target_url="https://target.example/",
+            runtime=object(),  # type: ignore[arg-type]
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=replay_count,
+            max_observation_chars=2_000,
+            max_transcript_chars=8_000,
+            action_id="post-auth-replay",
+            http_executor=http_executor,
+        )
+    finally:
+        audit.close()
+
+    assert result.ok is True
+    assert len(calls) == 1
+    unchanged_context = _repeat_context(state, action=action)
+    assert reactivate_for_session_change(state) is None
+    assert _repeat_context(state, action=action) == unchanged_context
+
+
+def test_awaiting_session_allows_login_http_and_blocks_probe_or_final() -> None:
+    state = _state_with_lead()
+    action = _aligned_http_action()
+    unauthorized = {
+        "ok": True,
+        "outcome": "http_response_observed",
+        "_evidence_observation": json.dumps({"response": {"status": 401}}),
+    }
+    assert record_aligned_outcome(state, action, unauthorized) is None
+    assert pending_lead(state) is None
+    assert awaiting_session_lead(state) is not None
+    assert unresolved_lead(state) is not None
+
+    login = {
+        "action": "http_request",
+        "method": "POST",
+        "url": "https://target.example/login",
+        "form": {"username": "analyst", "password": "test-password"},
+    }
+    assert _model_action(json.dumps(login), state=state, turn=2, max_turns=10) == login
+
+    blocked_probe = _model_action(
+        json.dumps({"action": "run_probe", "probe": "ssti_fingerprint"}),
+        state=state,
+        turn=3,
+        max_turns=10,
+    )
+    blocked_final = _model_action(
+        json.dumps({"action": "final", "summary": "give up"}),
+        state=state,
+        turn=4,
+        max_turns=10,
+    )
+    assert blocked_probe["action"] == "invalid"
+    assert blocked_final["action"] == "invalid"
+    assert "Establish authentication" in str(blocked_final["error"])
+
+
+def test_auth_paused_lead_replay_outranks_exhausted_recovery_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _state_with_lead()
+    action = _aligned_http_action()
+    recovery = RecoveryCampaign.create(target_url="https://target.example/", max_model_requests=40)
+    unauthorized = _http_action_outcome(403)
+
+    for _attempt in range(2):
+        recovery.begin_model_request()
+        recovery.record_action_result(action=action, outcome=unauthorized)
+        record_aligned_outcome(
+            state,
+            action,
+            {
+                **unauthorized.to_json(),
+                "_evidence_observation": unauthorized.evidence_observation,
+            },
+        )
+
+    assert awaiting_session_lead(state) is not None
+    route_fingerprint = semantic_action_fingerprint(action)
+    assert recovery.scheduler.route_is_available(route_fingerprint) is False
+    calls: list[dict[str, object]] = []
+
+    def fake_execute_action(
+        selected: dict[str, object],
+        **kwargs: object,
+    ) -> ActionResult:
+        calls.append({"action": selected, **kwargs})
+        return unauthorized
+
+    monkeypatch.setattr(ai_agent_module, "execute_action", fake_execute_action)
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    audit = AuditStore(tmp_path / "audit.db")
+    try:
+        result, branch_handoff = _execute_recovery_action(
+            recovery=recovery,
+            action=action,
+            target_url="https://target.example/",
+            runtime=object(),  # type: ignore[arg-type]
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            proof_recognition_enabled=False,
+            action_id="auth-paused-replay",
+            authentication=None,
+            traffic_policy=object(),  # type: ignore[arg-type]
+            http_executor=object(),  # type: ignore[arg-type]
+        )
+    finally:
+        audit.close()
+
+    assert result is unauthorized
+    assert branch_handoff is False
+    assert len(calls) == 1
+
+
+def test_reactivated_lead_attempt_outranks_exhausted_recovery_route(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _state_with_lead()
+    action = _aligned_http_action()
+    recovery = RecoveryCampaign.create(target_url="https://target.example/", max_model_requests=40)
+
+    unauthorized = _http_action_outcome(401)
+    recovery.begin_model_request()
+    recovery.record_action_result(action=action, outcome=unauthorized)
+    record_aligned_outcome(
+        state,
+        action,
+        {
+            **unauthorized.to_json(),
+            "_evidence_observation": unauthorized.evidence_observation,
+        },
+    )
+    assert state.surface["evidence_lead_lock"]["status"] == "awaiting_session"
+    assert reactivate_for_session_change(state) is not None
+
+    first_replay = _http_action_outcome(200)
+    recovery.begin_model_request()
+    recovery.record_action_result(action=action, outcome=first_replay)
+    record_aligned_outcome(
+        state,
+        action,
+        {
+            **first_replay.to_json(),
+            "_evidence_observation": first_replay.evidence_observation,
+        },
+    )
+    lead = pending_lead(state)
+    assert lead is not None
+    assert lead.aligned_no_progress == 1
+    route_fingerprint = semantic_action_fingerprint(action)
+    assert recovery.scheduler.route_is_available(route_fingerprint) is False
+
+    calls: list[dict[str, object]] = []
+    second_replay = _http_action_outcome(200)
+
+    def fake_execute_action(
+        selected: dict[str, object],
+        **kwargs: object,
+    ) -> ActionResult:
+        calls.append({"action": selected, **kwargs})
+        return second_replay
+
+    monkeypatch.setattr(ai_agent_module, "execute_action", fake_execute_action)
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    audit = AuditStore(tmp_path / "audit.db")
+    try:
+        result, branch_handoff = _execute_recovery_action(
+            recovery=recovery,
+            action=action,
+            target_url="https://target.example/",
+            runtime=object(),  # type: ignore[arg-type]
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            proof_recognition_enabled=False,
+            action_id="post-auth-attempt-2",
+            authentication=None,
+            traffic_policy=object(),  # type: ignore[arg-type]
+            http_executor=object(),  # type: ignore[arg-type]
+        )
+    finally:
+        audit.close()
+
+    assert result is second_replay
+    assert branch_handoff is False
+    assert len(calls) == 1
+    record_aligned_outcome(
+        state,
+        action,
+        {
+            **result.to_json(),
+            "_evidence_observation": result.evidence_observation,
+        },
+    )
+    assert pending_lead(state) is None
+    assert state.surface["evidence_lead_lock"]["status"] == "exhausted"
+
+
+def test_action_update_accounting_only_exhausts_complete_aligned_attempts() -> None:
+    state = _state_with_lead()
+    action = _aligned_http_action()
+    ignored_outcomes = (
+        {"ok": False, "outcome": "blocked", "timed_out": False},
+        {"ok": False, "outcome": "observed", "timed_out": True},
+        {"ok": False, "outcome": "same_as_before", "timed_out": False},
+    )
+
+    for outcome in ignored_outcomes:
+        record_aligned_outcome(state, action, outcome)
+        _update_state_from_action(state, action=action, outcome=outcome)
+
+    unchanged = pending_lead(state)
+    assert unchanged is not None
+    assert unchanged.aligned_no_progress == 0
+
+    first = {"ok": True, "outcome": "observed", "timed_out": False}
+    record_aligned_outcome(state, action, first)
+    _update_state_from_action(state, action=action, outcome=first)
+    after_first = pending_lead(state)
+    assert after_first is not None
+    assert after_first.aligned_no_progress == 1
+
+    second = {"ok": True, "outcome": "observed", "timed_out": False}
+    record_aligned_outcome(state, action, second)
+    _update_state_from_action(state, action=action, outcome=second)
+
+    assert pending_lead(state) is None
+    assert state.surface["evidence_lead_lock"]["status"] == "exhausted"
+    assert len(state.actions) == 5
+
+
+@dataclass(frozen=True)
+class _CompletedProbe:
+    text: str
+    ok: bool = True
+    timed_out: bool = False
+
+
+def test_execute_trusted_probe_opens_lead_without_spending_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ravage.agent_core.action_executor._run_probe_action",
+        lambda *_args, **_kwargs: _CompletedProbe(_ssti_probe_text()),
+    )
+    state = AgentState(surface={"flag_objective": True})
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    audit = AuditStore(tmp_path / "audit.db")
+    try:
+        result = execute_action(
+            {"action": "run_probe", "probe": "ssti_fingerprint"},
+            target_url="https://target.example/",
+            runtime=object(),  # type: ignore[arg-type]
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=2_000,
+            max_transcript_chars=8_000,
+            action_id="trusted-ssti-probe",
+        )
+    finally:
+        audit.close()
+
+    lead = pending_lead(state)
+    assert result.ok is True
+    assert lead is not None
+    assert lead.family == "template_injection"
+    assert lead.method == "POST"
+    assert lead.endpoint == "/generate"
+    assert lead.inputs == ("sentence",)
+    assert lead.aligned_no_progress == 0
+    assert lead.source_observation_id == state.last_observation["observation_id"]

--- a/packages/ravage/tests/test_harness_trace.py
+++ b/packages/ravage/tests/test_harness_trace.py
@@ -40,6 +40,90 @@ def test_harness_trace_redacts_secret_shaped_action_values() -> None:
     assert "flag{REDACTED}" in str(payload)
 
 
+def test_harness_trace_sanitizes_nested_validate_transport_artifacts() -> None:
+    action: dict[str, object] = {
+        "action": "validate_poc",
+        "steps": [
+            {
+                "method": "GET",
+                "url": (
+                    "https://alice:request-password@target.example/callback"
+                    "?view=request-query&token=request-token#request-fragment"
+                ),
+                "headers": {
+                    "Accept": "application/json",
+                    "Authorization": "Bearer request-authorization",
+                    "Referer": "https://source.example/?view=referer-query#referer-fragment",
+                    "X-Debug": "request-header-secret",
+                },
+            }
+        ],
+    }
+    original = json.dumps(action, sort_keys=True)
+
+    payload = sanitize_action(action)
+
+    assert json.dumps(action, sort_keys=True) == original
+    serialized = json.dumps(payload, sort_keys=True)
+    for secret in (
+        "alice",
+        "request-password",
+        "request-query",
+        "request-token",
+        "request-fragment",
+        "request-authorization",
+        "referer-query",
+        "referer-fragment",
+        "request-header-secret",
+    ):
+        assert secret not in serialized
+    steps = payload["steps"]
+    assert isinstance(steps, list)
+    step = steps[0]
+    assert isinstance(step, dict)
+    assert step["url"] == (
+        "https://target.example/callback"
+        "?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
+    )
+    headers = step["headers"]
+    assert isinstance(headers, dict)
+    assert headers == {
+        "accept": "application/json",
+        "authorization": "[REDACTED]",
+        "referer": "[REDACTED]",
+        "x-debug": "[REDACTED]",
+    }
+
+
+def test_harness_exact_fingerprint_cannot_verify_url_or_header_secrets() -> None:
+    def record(secret: str) -> dict[str, object]:
+        action = {
+            "action": "http_request",
+            "method": "GET",
+            "url": f"https://target.example/callback?code={secret}#{secret}",
+            "headers": {"Authorization": f"Bearer {secret}"},
+        }
+        snapshot = state_trace_snapshot(AgentState(turn=1))
+        return attempt_record_payload(
+            turn=1,
+            action_id="action-1",
+            proposed_action=action,
+            selected_action=action,
+            selection_reason="model_proposal",
+            repeat_context="",
+            pre_state=snapshot,
+            post_state=snapshot,
+            outcome={"ok": True, "outcome": "observed", "repeat_count": 1},
+        )
+
+    first = record("first-low-entropy-secret")
+    second = record("second-low-entropy-secret")
+
+    assert first["exact_selected_fingerprint"] == second["exact_selected_fingerprint"]
+    assert "first-low-entropy-secret" not in json.dumps(first, sort_keys=True)
+    assert "second-low-entropy-secret" not in json.dumps(second, sort_keys=True)
+
+
 def test_harness_state_delta_tracks_counts_without_signal_values() -> None:
     state = AgentState(turn=1)
     state.signals["cookies"] = ["session=abc"]

--- a/packages/ravage/tests/test_integration_gap_fixes.py
+++ b/packages/ravage/tests/test_integration_gap_fixes.py
@@ -12,6 +12,7 @@ from ravage.agent_core.ai_agent import (
     _would_hit_repeat_guard,
 )
 from ravage.agent_core.primitive_state import promote_primitives
+from ravage.agent_core.surface_graph import SurfaceGraphState
 
 
 def test_command_timeout_floors_at_ten_seconds() -> None:
@@ -85,6 +86,121 @@ def test_action_fingerprint_hashes_material_beyond_the_old_prefix_limit() -> Non
     assert shared_prefix not in action_fingerprint(first)
 
 
+def test_validate_poc_fingerprint_preserves_form_method_and_path() -> None:
+    put = {
+        "action": "validate_poc",
+        "steps": [{"method": "PUT", "path": "/profile", "form": {"name": "alice"}}],
+    }
+    patch = {
+        "action": "validate_poc",
+        "steps": [{"method": "PATCH", "path": "/profile", "form": {"name": "alice"}}],
+    }
+    other_path = {
+        "action": "validate_poc",
+        "steps": [{"method": "PUT", "path": "/other", "form": {"name": "alice"}}],
+    }
+
+    assert action_fingerprint(put) != action_fingerprint(patch)
+    assert action_fingerprint(put) != action_fingerprint(other_path)
+
+
+@pytest.mark.parametrize("kind", ["http_request", "validate_poc"])
+def test_http_fingerprint_ignores_method_whitespace_and_url_fragment(kind: str) -> None:
+    def action(method: str, fragment: str) -> dict[str, object]:
+        request = {
+            "method": method,
+            "url": f"/search?q=same#{fragment}",
+        }
+        if kind == "http_request":
+            return {"action": kind, **request}
+        return {"action": kind, "steps": [request]}
+
+    assert action_fingerprint(action(" get ", "client-only-one")) == action_fingerprint(
+        action("GET", "client-only-two")
+    )
+
+
+@pytest.mark.parametrize("kind", ["http_request", "validate_poc"])
+def test_http_fingerprint_collapses_same_origin_absolute_and_relative_urls(
+    kind: str,
+) -> None:
+    def action(url: str) -> dict[str, object]:
+        request = {"method": "GET", "url": url}
+        if kind == "http_request":
+            return {"action": kind, **request}
+        return {"action": kind, "steps": [request]}
+
+    context = "origin:https://target.example"
+    assert action_fingerprint(
+        action("/same#client-fragment"),
+        context=context,
+    ) == action_fingerprint(
+        action("https://TARGET.example:443/same#other-fragment"),
+        context=context,
+    )
+
+
+def test_legacy_http_fingerprints_are_not_repersisted() -> None:
+    ledger = ActionLedger(
+        fingerprints={
+            "http_request:{'password': 'guessable'}": 1,
+            "validate_poc:{'steps': [{'token': 'guessable'}]}": 1,
+            "run_probe:surface_map": 1,
+        }
+    )
+
+    assert ledger.to_json() == {"run_probe:surface_map": 1}
+
+
+@pytest.mark.parametrize(
+    ("body_field", "content_type"),
+    [
+        ("form", "application/x-www-form-urlencoded"),
+        ("json", "application/json"),
+    ],
+)
+def test_http_fingerprint_canonicalizes_implicit_body_content_type(
+    body_field: str,
+    content_type: str,
+) -> None:
+    body = {"name": "same"}
+    implicit = {"action": "http_request", "method": "POST", body_field: body, "path": "/"}
+    explicit = {
+        **implicit,
+        "headers": {" Content-Type ": content_type.upper()},
+    }
+
+    assert action_fingerprint(implicit) == action_fingerprint(explicit)
+
+
+@pytest.mark.parametrize("kind", ["http_request", "validate_poc"])
+def test_http_payload_fingerprints_are_not_serialized(kind: str) -> None:
+    action = (
+        {
+            "action": "http_request",
+            "method": "POST",
+            "path": "/login",
+            "form": {"password": "low-entropy-secret"},
+        }
+        if kind == "http_request"
+        else {
+            "action": "validate_poc",
+            "steps": [
+                {
+                    "method": "POST",
+                    "path": "/login",
+                    "form": {"password": "low-entropy-secret"},
+                }
+            ],
+        }
+    )
+    ledger = ActionLedger()
+
+    assert ledger.remember(action) == 1
+    assert ledger.count(action) == 1
+    assert ledger.to_json() == {}
+
+
 def test_repeat_guard_honors_a_legacy_fingerprint_after_state_round_trip() -> None:
     action = {"action": "run_probe", "probe": "cms_exposure"}
     original = AgentState()
@@ -101,6 +217,20 @@ def test_repeat_context_reflects_canonical_host() -> None:
     assert _repeat_context(state) == ""
     state.signals["canonical_hosts"] = ["localhost"]
     assert _repeat_context(state) == "host:localhost"
+
+
+def test_http_session_epoch_only_refreshes_structured_http_repeat_context() -> None:
+    state = AgentState()
+    state.surface_graph = SurfaceGraphState.for_target("https://target.example/")
+    state.surface["http_state_epoch"] = 3
+    http_action = {"action": "http_request", "method": "GET", "path": "/"}
+    poc_action = {"action": "validate_poc", "steps": [{"method": "GET", "path": "/"}]}
+    probe_action = {"action": "run_probe", "probe": "surface_map"}
+
+    expected = "origin:https://target.example|http-state:3"
+    assert _repeat_context(state, action=http_action) == expected
+    assert _repeat_context(state, action=poc_action) == expected
+    assert _repeat_context(state, action=probe_action) == ""
 
 
 def test_probe_repeat_is_unblocked_after_canonical_host_discovered() -> None:
@@ -331,7 +461,7 @@ def test_shadow_router_does_not_replace_password_change_idor_with_default_creden
     assert action["strategy"] == "stateful-session"
 
 
-def test_description_evidence_does_not_override_live_primitive_closer() -> None:
+def test_default_credentials_are_auth_context_not_an_idor_lock() -> None:
     state = AgentState(
         turn=2,
         primitives={"default_credentials_confirmed": 1},
@@ -346,8 +476,8 @@ def test_description_evidence_does_not_override_live_primitive_closer() -> None:
     )
 
     assert action["action"] == "run_probe"
-    assert action["probe"] == "idor_boundary"
-    assert action["strategy"] == "close_authenticated_boundary"
+    assert action["probe"] == "ssti_fingerprint"
+    assert action["strategy"] == "visible_reminder_template_flow"
 
 
 def test_exhausted_tier_one_primitive_closer_does_not_suppress_fallback_route() -> None:

--- a/packages/ravage/tests/test_poc_validator_contract.py
+++ b/packages/ravage/tests/test_poc_validator_contract.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from ravage.web_core.http_probe import ProbeResponse
+from ravage.web_core.poc_validator import validate_http_poc
+
+
+def test_validate_http_poc_dispatches_and_reports_path_steps() -> None:
+    calls: list[dict[str, object]] = []
+    events: list[dict[str, object]] = []
+
+    def request(
+        method: str,
+        url: str,
+        *,
+        data: bytes | None,
+        headers: dict[str, str],
+        timeout_seconds: int,
+    ) -> ProbeResponse:
+        calls.append(
+            {
+                "method": method,
+                "url": url,
+                "data": data,
+                "headers": headers,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return ProbeResponse(
+            method=method,
+            url=url,
+            status=200,
+            final_url=f"http://127.0.0.1{url}",
+            elapsed_ms=1,
+            body="path proof",
+        )
+
+    result = validate_http_poc(
+        target_url="http://127.0.0.1/",
+        steps=[
+            {
+                "method": "GET",
+                "path": "/path-proof",
+                "expect_status": 200,
+                "expect_contains": "path proof",
+            }
+        ],
+        timeout_seconds=7,
+        request=request,
+        on_step=events.append,
+    )
+
+    assert result.ok
+    assert calls == [
+        {
+            "method": "GET",
+            "url": "/path-proof",
+            "data": None,
+            "headers": {},
+            "timeout_seconds": 7,
+        }
+    ]
+    assert result.steps[0]["request"] == {
+        "method": "GET",
+        "url": "/path-proof",
+        "has_body": False,
+    }
+    assert events[0]["url"] == "/path-proof"
+
+
+def test_validate_http_poc_preserves_declared_method_for_form_replay() -> None:
+    calls: list[tuple[str, str, bytes | None, dict[str, str]]] = []
+
+    def request(
+        method: str,
+        url: str,
+        *,
+        data: bytes | None,
+        headers: dict[str, str],
+        timeout_seconds: int,
+    ) -> ProbeResponse:
+        del timeout_seconds
+        calls.append((method, url, data, headers))
+        return ProbeResponse(
+            method=method,
+            url=url,
+            status=204,
+            final_url=f"http://127.0.0.1{url}",
+            elapsed_ms=1,
+        )
+
+    result = validate_http_poc(
+        target_url="http://127.0.0.1/",
+        steps=[
+            {
+                "method": "PATCH",
+                "path": "/profile",
+                "form": {"name": "guest"},
+                "expect_status": 204,
+            }
+        ],
+        request=request,
+    )
+
+    assert result.ok
+    assert calls == [
+        (
+            "PATCH",
+            "/profile",
+            b"name=guest",
+            {"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    ]
+
+
+def test_validate_http_poc_sanitizes_artifacts_without_changing_dispatch() -> None:
+    request_url = (
+        "/callback?view=request-query&token=request-token#request-fragment"
+    )
+    request_headers = {
+        "Authorization": "Bearer request-authorization",
+        "X-Debug": "request-header-secret",
+    }
+    calls: list[dict[str, object]] = []
+    events: list[dict[str, object]] = []
+
+    def request(
+        method: str,
+        url: str,
+        *,
+        data: bytes | None,
+        headers: dict[str, str],
+        timeout_seconds: int,
+    ) -> ProbeResponse:
+        calls.append(
+            {
+                "method": method,
+                "url": url,
+                "data": data,
+                "headers": headers,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return ProbeResponse(
+            method=method,
+            url=url,
+            status=502,
+            final_url=(
+                "https://target.example/final"
+                "?view=final-query&code=final-code#final-fragment"
+            ),
+            elapsed_ms=1,
+            headers={
+                "Content-Type": "text/plain; charset=utf-8",
+                "Location": (
+                    "https://target.example/next"
+                    "?view=location-query&session=location-session#location-fragment"
+                ),
+                "Set-Cookie": "session=response-cookie",
+                "X-Debug": "response-header-secret",
+            },
+            body="ordinary response evidence",
+            error=(
+                "request to https://alice:error-password@target.example/fail"
+                "?view=error-query#error-fragment failed; "
+                "Authorization: Bearer error-authorization"
+            ),
+        )
+
+    result = validate_http_poc(
+        target_url="https://target.example/",
+        steps=[
+            {
+                "method": "GET",
+                "url": request_url,
+                "headers": request_headers,
+                "expect_contains": "flag{authored_expectation_secret_73c9}",
+            }
+        ],
+        timeout_seconds=7,
+        request=request,
+        on_step=events.append,
+    )
+
+    assert calls == [
+        {
+            "method": "GET",
+            "url": request_url,
+            "data": None,
+            "headers": request_headers,
+            "timeout_seconds": 7,
+        }
+    ]
+    serialized = json.dumps(
+        {"result": json.loads(result.to_text()), "events": events},
+        sort_keys=True,
+    )
+    for secret in (
+        "request-query",
+        "request-token",
+        "request-fragment",
+        "final-query",
+        "final-code",
+        "final-fragment",
+        "location-query",
+        "location-session",
+        "location-fragment",
+        "response-cookie",
+        "response-header-secret",
+        "alice",
+        "error-password",
+        "error-query",
+        "error-fragment",
+        "error-authorization",
+        "authored_expectation_secret_73c9",
+    ):
+        assert secret not in serialized
+    step = result.steps[0]
+    request_artifact = step["request"]
+    assert isinstance(request_artifact, dict)
+    assert request_artifact["url"] == (
+        "/callback?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
+    )
+    response_artifact = step["response"]
+    assert isinstance(response_artifact, dict)
+    assert response_artifact["final_url"] == (
+        "https://target.example/final?view=%5BREDACTED%5D&code=%5BREDACTED%5D"
+    )
+    response_headers = response_artifact["headers"]
+    assert isinstance(response_headers, dict)
+    assert response_headers["location"] == (
+        "https://target.example/next?view=%5BREDACTED%5D&session=%5BREDACTED%5D"
+    )
+    assert response_headers["set-cookie"] == "[REDACTED]"
+    assert response_headers["x-debug"] == "[REDACTED]"
+    assert events[0]["url"] == request_artifact["url"]
+    assert events[0]["headers"] == response_headers
+
+
+@pytest.mark.parametrize(
+    ("step", "error"),
+    [
+        ({"method": "GET", "path": "/item", "body": "payload"}, "cannot include a body"),
+        ({"method": "POST", "path": "/item", "json": {"key": "value"}}, "support json"),
+        ({"method": "POST", "path": "/item", "headers": []}, "headers must be an object"),
+        ({"method": "POST", "path": "/item", "form": []}, "form must be an object"),
+        ({"method": "POST", "path": "/item", "body": 7}, "body must be a string"),
+    ],
+)
+def test_validate_http_poc_rejects_invalid_steps_before_dispatch(
+    step: dict[str, object],
+    error: str,
+) -> None:
+    call_count = 0
+
+    def request(*_args: object, **_kwargs: object) -> ProbeResponse:
+        nonlocal call_count
+        call_count += 1
+        return ProbeResponse("GET", "", 500, "", 0)
+
+    result = validate_http_poc(
+        target_url="http://127.0.0.1/",
+        steps=[step],
+        request=request,
+    )
+
+    assert not result.ok
+    assert call_count == 0
+    assert any(error in item for item in result.errors)

--- a/packages/ravage/tests/test_probe_actions.py
+++ b/packages/ravage/tests/test_probe_actions.py
@@ -12,6 +12,7 @@ from ravage.agent_core.action_executor import ActionResult, _clip_probe_text, ex
 from ravage.agent_core.action_parser import parse_action
 from ravage.agent_core.agent_state import AgentState
 from ravage.agent_core.agent_strategy import observation_digest
+from ravage.agent_core.evidence_lead_lock import pending_lead
 from ravage.agent_core.surface_graph import SurfaceGraphState
 from ravage.agent_core.surface_graph_ingest import (
     SURFACE_OBSERVATION_BATCH_SCHEMA,
@@ -356,6 +357,7 @@ def test_validate_poc_promotes_executor_owned_non_flag_finding(
     workspace = AgentWorkspace.open(tmp_path / "workspace")
     engagement_id = uuid4()
     state = AgentState()
+    state.surface["flag_objective"] = True
     audit = AuditStore(tmp_path / "audit.db")
     action = {
         "action": "validate_poc",
@@ -438,7 +440,17 @@ def test_validate_poc_promotes_executor_owned_non_flag_finding(
     assert payload["source_observation_id"]
     assert payload["action_id"] == "poc-finding-action"
     assert payload["finding_record_path"] == str(workspace.events_path)
-    assert "%27" in payload["proof"]["http_request_final"]
+    lead = pending_lead(state)
+    assert lead is not None
+    assert lead.family == "sql_injection"
+    assert lead.method == "GET"
+    assert lead.endpoint == "/search"
+    assert lead.inputs == ("q",)
+    assert lead.source_kind == "tool_validate_poc"
+    assert lead.source_observation_id == payload["source_observation_id"]
+    assert '"url": "/search?q=%5BREDACTED%5D"' in payload["proof"][
+        "http_request_final"
+    ]
     assert [step["evidence_role"] for step in payload["exploit_steps"]] == [
         "exploit",
         "control",
@@ -450,6 +462,60 @@ def test_validate_poc_promotes_executor_owned_non_flag_finding(
     assert actions.count("finding_confirmed") == 1
     assert stored_payload["finding_id"] == payload["finding_id"]
     assert stored_payload["vuln_class"] == "sql_injection"
+
+
+def test_validate_poc_unattested_summary_proof_does_not_bypass_lead_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ravage.web_core.poc_validator.ProbeSession",
+        _SqlErrorWithProofProbeSession,
+    )
+    state = AgentState(surface={"flag_objective": True})
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    audit = AuditStore(tmp_path / "audit.db")
+    action = {
+        "action": "validate_poc",
+        "steps": [
+            {
+                "method": "GET",
+                "url": "/search?q=%27",
+                "evidence_role": "exploit",
+                "expect_status": 200,
+                "expect_contains": "SQLite syntax error",
+            },
+            {
+                "method": "GET",
+                "url": "/search?q=ravage-control",
+                "evidence_role": "control",
+                "expect_status": 200,
+            },
+        ],
+        "finding": _finding_metadata("sql_injection"),
+    }
+    try:
+        outcome = execute_action(
+            action,
+            target_url="http://127.0.0.1/",
+            runtime=_ProofRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=2_000,
+            max_transcript_chars=4_000,
+            proof_recognition_enabled=True,
+            action_id="poc-proof-action",
+        )
+    finally:
+        audit.close()
+
+    assert outcome.stop is False
+    assert outcome.flag == ""
+    assert state.flags == []
+    assert pending_lead(state) is not None
 
 
 def test_validate_poc_keeps_distinct_affected_parameters_and_merges_duplicates(
@@ -2384,6 +2450,29 @@ class _SqlErrorProbeSession(_FakeProbeSession):
             elapsed_ms=1,
             headers={"content-type": "text/plain"},
             body=body,
+        )
+
+
+class _SqlErrorWithProofProbeSession(_SqlErrorProbeSession):
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> ProbeResponse:
+        response = super().request(method, url, data=data, headers=headers)
+        if "%27" not in url:
+            return response
+        return ProbeResponse(
+            method=response.method,
+            url=response.url,
+            status=response.status,
+            final_url=response.final_url,
+            elapsed_ms=response.elapsed_ms,
+            headers=response.headers,
+            body=response.body + " flag{validated_poc_target_proof_7c31}",
         )
 
 

--- a/packages/ravage/tests/test_report_generation.py
+++ b/packages/ravage/tests/test_report_generation.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import pytest
+import ravage.report as report_module
 from ravage import __main__ as cli
 from ravage.agent_core.action_executor import ActionResult
 from ravage.agent_core.ai_agent import AIWebAgentSettings
@@ -63,6 +64,9 @@ _AGENT_HTTP_SECRET = "flag{report-agent-http-secret}"  # noqa: S105 - redaction 
 _AGENT_HTTP_OBSERVATION_ID = "http:obs-report-agent-1"
 _ARGPARSE_ERROR = 2
 _PRIVATE_ARTIFACT_MODE = 0o600
+_DUAL_TRAFFIC_REQUEST_COUNT = 2
+_REPORT_IN_SCOPE = ("http://127.0.0.1:8765",)
+_REPORT_OUT_OF_SCOPE = ("http://127.0.0.1:9999",)
 
 
 def test_json_report_artifact_is_private_atomic_and_has_no_report_side_effects(
@@ -210,6 +214,57 @@ def test_write_pentest_report_generates_redacted_markdown_and_json(tmp_path: Pat
     assert "api_key=<SECRET_REDACTED>" in markdown
 
 
+def test_report_rejects_traffic_accounting_from_another_target(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    TrafficPolicyController.open(
+        workspace.root / "traffic-policy.json",
+        target_url="http://127.0.0.1:8766",
+        config=TrafficPolicyConfig(),
+    )
+    output_path = tmp_path / "run" / "wrong-target-accounting.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic accounting does not match the report target",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
+
+
+def test_report_accepts_the_policy_writers_unicode_host_normalization(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    target_url = "http://faß.de/path"
+    TrafficPolicyController.open(
+        workspace.root / "traffic-policy.json",
+        target_url=target_url,
+        config=TrafficPolicyConfig(),
+    )
+    output_path = tmp_path / "run" / "unicode-policy-origin.md"
+
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url=target_url,
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    assert report["traffic_accounting"]["status"] == "exact"
+    assert output_path.exists()
+
+
 def test_report_includes_path_free_scan_coverage_without_overclaiming(tmp_path: Path) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
@@ -324,6 +379,7 @@ def test_report_summarizes_deterministic_scan_work_recon_and_recorded_traffic(
         },
     )
     _add_deterministic_scan_traffic(workspace.root)
+    _add_agent_http_provenance(workspace.root)
     output_path = tmp_path / "run" / "deterministic-report.md"
 
     report = write_pentest_report(
@@ -380,6 +436,64 @@ def test_report_summarizes_deterministic_scan_work_recon_and_recorded_traffic(
     assert "Request accounting status: lower_bound" in markdown
     assert "Surface-map HTTP responses: 2/3 requests" in markdown
     assert "surface_map: received 2/3 HTTP response(s)" in markdown
+
+
+def test_report_revalidates_scan_lane_attribution_after_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.record_event(
+        kind="scan_probe",
+        payload={"probe": "surface_map", "requests": [], "findings": [], "errors": []},
+    )
+    _add_deterministic_scan_traffic(workspace.root)
+    graph_workspace = workspace.root / "autonomous-route" / "agent-graph"
+    TrafficStore.create(graph_workspace)
+    write_traffic_manifest(
+        graph_workspace,
+        TrafficRunManifest.create(
+            target_url="http://127.0.0.1:8765",
+            capture_session_id="scan-graph-session",
+            in_scope=_REPORT_IN_SCOPE,
+            out_of_scope=_REPORT_OUT_OF_SCOPE,
+        ).complete(),
+    )
+    original_resolver = report_module.resolve_workspaces
+
+    def resolve_then_tamper(supplied: Path) -> tuple[Path, ...]:
+        resolved = original_resolver(supplied)
+        manifest_path = graph_workspace / "traffic" / "run.json"
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["target_url"] = "http://127.0.0.1:8765/different-target"
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+        manifest_path.chmod(_PRIVATE_ARTIFACT_MODE)
+        return resolved
+
+    monkeypatch.setattr(
+        report_module,
+        "_agent_http_evidence_summary",
+        lambda *_args, **_kwargs: report_module._empty_agent_http_evidence_summary(),
+    )
+    monkeypatch.setattr(report_module, "resolve_workspaces", resolve_then_tamper)
+    output_path = tmp_path / "run" / "tampered-scan-lanes.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic history does not match the report target or scope",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
 
 
 def test_report_summarizes_orphan_tool_probe_without_duplicating_agent_actions(
@@ -460,7 +574,9 @@ def test_report_links_nested_agent_http_traffic_to_identifier_only_evidence(
         "material_evidence_count": len(material_evidence_ids),
         "links": [
             {
-                "request_id": request_id,
+                "lane": "autonomous_graph",
+                "request_id": f"autonomous_graph:{request_id}",
+                "local_request_id": request_id,
                 "status": "linked",
                 "observation_id": _AGENT_HTTP_OBSERVATION_ID,
                 "evidence_ids": list(evidence_ids),
@@ -487,6 +603,218 @@ def test_report_links_nested_agent_http_traffic_to_identifier_only_evidence(
     assert "route_fingerprint" not in json.dumps(provenance)
     assert "evidence_records" not in json.dumps(provenance)
     assert "payload" not in json.dumps(provenance)
+
+
+def test_report_aggregates_valid_base_and_graph_agent_http_histories(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    base_session_id = "base-agent-http-report-session"
+    base_observation_id = "http:obs-report-base-1"
+    base_store = TrafficStore.create(workspace.root)
+    write_traffic_manifest(
+        workspace.root,
+        TrafficRunManifest.create(
+            target_url="http://127.0.0.1:8765",
+            capture_session_id=base_session_id,
+            in_scope=_REPORT_IN_SCOPE,
+            out_of_scope=_REPORT_OUT_OF_SCOPE,
+        ).complete(),
+    )
+    base_blackboard = EvidenceBlackboard(
+        target_url="http://127.0.0.1:8765",
+        state_path=workspace.root / "evidence-blackboard.json",
+    )
+    base_blackboard.record_action_result(
+        producer_node_id="base-agent",
+        action={"action": "http_request", "method": "GET", "url": "/base-proof"},
+        result=ActionResult(
+            ok=True,
+            observation="base target response",
+            outcome="http_response_observed",
+            evidence_source_kind="tool_http_request",
+            evidence_observation="base target response",
+        ),
+        observation_id=base_observation_id,
+    )
+    base_store.append_exchange(
+        build_captured_http_exchange(
+            capture_session_id=base_session_id,
+            source="agent_http",
+            source_observation_id=base_observation_id,
+            method="GET",
+            url="http://127.0.0.1:8765/base-proof",
+            request_sent=True,
+            response_status=200,
+            response_final_url="http://127.0.0.1:8765/base-proof",
+            response_body="base target response",
+            scope_decision="allowed",
+        )
+    )
+    _add_agent_http_provenance(workspace.root)
+    output_path = tmp_path / "run" / "dual-agent-http-report.md"
+
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    provenance = report["agent_http_evidence"]
+    assert provenance["status"] == "available"
+    assert provenance["request_count"] == _DUAL_TRAFFIC_REQUEST_COUNT
+    assert provenance["linked_request_count"] == _DUAL_TRAFFIC_REQUEST_COUNT
+    assert len(provenance["links"]) == _DUAL_TRAFFIC_REQUEST_COUNT
+    assert [link["lane"] for link in provenance["links"]] == [
+        "base",
+        "autonomous_graph",
+    ]
+    assert [link["local_request_id"] for link in provenance["links"]] == [
+        "rq_0001",
+        "rq_0001",
+    ]
+    assert [link["request_id"] for link in provenance["links"]] == [
+        "base:rq_0001",
+        "autonomous_graph:rq_0001",
+    ]
+    assert output_path.exists()
+    assert _AGENT_HTTP_SECRET not in output_path.read_text(encoding="utf-8")
+
+
+def test_report_rejects_agent_http_evidence_from_another_target(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    other_target = "http://127.0.0.1:8766"
+    _add_agent_http_provenance(
+        workspace.root,
+        target_url=other_target,
+        in_scope=(other_target,),
+    )
+    output_path = tmp_path / "run" / "spliced-target-evidence.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic history does not match the report target or scope",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
+
+
+def test_report_rejects_agent_http_evidence_from_a_broader_scope(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    _add_agent_http_provenance(
+        workspace.root,
+        in_scope=(*_REPORT_IN_SCOPE, "http://127.0.0.1:8765/admin"),
+    )
+    output_path = tmp_path / "run" / "spliced-scope-evidence.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic history does not match the report target or scope",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
+
+
+def test_report_binds_unredacted_target_identity_when_url_shapes_match(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    TrafficStore.create(workspace.root)
+    write_traffic_manifest(
+        workspace.root,
+        TrafficRunManifest.create(
+            target_url="http://127.0.0.1:8765/private?token=first",
+            capture_session_id="raw-target-identity",
+            in_scope=_REPORT_IN_SCOPE,
+            out_of_scope=_REPORT_OUT_OF_SCOPE,
+        ).complete(),
+    )
+    output_path = tmp_path / "run" / "wrong-raw-target.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic history does not match the report target or scope",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765/private?token=second",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
+
+
+@pytest.mark.parametrize(
+    ("raw_target", "reported_target"),
+    [
+        (
+            "http://127.0.0.1:8765/private?token=first",
+            "http://127.0.0.1:8765/private?token=%5BREDACTED%5D",
+        ),
+        (
+            "http://127.0.0.1:8765/users/123456",
+            "http://127.0.0.1:8765/users/:id",
+        ),
+        ("http://127.0.0.1:8765", "http://127.0.0.1:8765/"),
+    ],
+)
+def test_report_accepts_a_matching_persisted_safe_target(
+    tmp_path: Path,
+    raw_target: str,
+    reported_target: str,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    TrafficStore.create(workspace.root)
+    write_traffic_manifest(
+        workspace.root,
+        TrafficRunManifest.create(
+            target_url=raw_target,
+            capture_session_id="redacted-target-identity",
+            in_scope=_REPORT_IN_SCOPE,
+            out_of_scope=_REPORT_OUT_OF_SCOPE,
+        ).complete(),
+    )
+    output_path = tmp_path / "run" / "redacted-target.md"
+
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url=reported_target,
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    assert report["agent_http_evidence"]["status"] == "not_available"
+    assert output_path.exists()
 
 
 def test_report_marks_agent_http_evidence_not_available_without_traffic(
@@ -569,6 +897,33 @@ def test_report_fails_closed_when_new_graph_http_state_loses_traffic(
         )
 
 
+def test_report_fails_closed_when_base_agent_http_state_loses_traffic(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    state_path = workspace.root / "agent-http-state.json"
+    state_path.write_text('{"version":2,"target_identity":"target:marker"}\n', encoding="utf-8")
+    state_path.chmod(0o600)
+    EvidenceBlackboard(
+        target_url="http://127.0.0.1:8765",
+        state_path=workspace.root / "evidence-blackboard.json",
+    )
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic artifacts are present but could not be validated",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=tmp_path / "run" / "missing-base-agent-http-traffic.md",
+            status="completed",
+            completed=True,
+        )
+
+
 def test_report_fails_closed_for_tampered_agent_http_blackboard(tmp_path: Path) -> None:
     brief_path = _brief(tmp_path)
     workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
@@ -644,7 +999,7 @@ def test_report_fails_closed_for_ambiguous_agent_http_provenance(tmp_path: Path)
     assert not output_path.exists()
 
 
-def test_report_fails_closed_for_unvalidated_or_multiple_traffic_roots(
+def test_report_fails_closed_for_unvalidated_or_mismatched_traffic_roots(
     tmp_path: Path,
 ) -> None:
     brief_path = _brief(tmp_path)
@@ -671,7 +1026,7 @@ def test_report_fails_closed_for_unvalidated_or_multiple_traffic_roots(
     write_traffic_manifest(
         workspace.root,
         TrafficRunManifest.create(
-            target_url="http://127.0.0.1:8765",
+            target_url="http://127.0.0.1:9998",
             capture_session_id="agent-http-report-base",
         ),
     )
@@ -688,6 +1043,36 @@ def test_report_fails_closed_for_unvalidated_or_multiple_traffic_roots(
             status="completed",
             completed=True,
         )
+
+
+def test_report_fails_closed_for_malformed_declared_traffic_workspace(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    declared_workspace = workspace.root / "legacy-http-workspace"
+    (declared_workspace / "traffic").mkdir(parents=True)
+    workspace.root.joinpath("run.json").write_text(
+        json.dumps({"workspace_dir": "legacy-http-workspace"}),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "run" / "malformed-declared-traffic.md"
+
+    with pytest.raises(
+        TrafficProvenanceError,
+        match="traffic artifacts are present but could not be validated",
+    ):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert not output_path.exists()
+    assert not output_path.with_suffix(".json").exists()
 
 
 def test_cli_report_surfaces_malformed_agent_http_store_without_traceback(
@@ -1085,6 +1470,10 @@ def _brief(tmp_path: Path) -> Path:
 
 def _add_agent_http_provenance(
     workspace: Path,
+    *,
+    target_url: str = "http://127.0.0.1:8765",
+    in_scope: tuple[str, ...] = _REPORT_IN_SCOPE,
+    out_of_scope: tuple[str, ...] = _REPORT_OUT_OF_SCOPE,
 ) -> tuple[Path, str, tuple[str, ...], tuple[str, ...]]:
     graph_workspace = workspace / "autonomous-route" / "agent-graph"
     capture_session_id = "agent-http-report-session"
@@ -1092,12 +1481,14 @@ def _add_agent_http_provenance(
     write_traffic_manifest(
         graph_workspace,
         TrafficRunManifest.create(
-            target_url="http://127.0.0.1:8765",
+            target_url=target_url,
             capture_session_id=capture_session_id,
+            in_scope=in_scope,
+            out_of_scope=out_of_scope,
         ).complete(),
     )
     blackboard = EvidenceBlackboard(
-        target_url="http://127.0.0.1:8765",
+        target_url=target_url,
         state_path=graph_workspace / "evidence-blackboard.json",
     )
     blackboard.record_action_result(
@@ -1119,11 +1510,11 @@ def _add_agent_http_provenance(
             source="agent_http",
             source_observation_id=_AGENT_HTTP_OBSERVATION_ID,
             method="GET",
-            url=(f"http://127.0.0.1:8765/proof?token={_AGENT_HTTP_SECRET}"),
+            url=(f"{target_url}/proof?token={_AGENT_HTTP_SECRET}"),
             request_headers={"Authorization": f"Bearer {_AGENT_HTTP_SECRET}"},
             request_sent=True,
             response_status=200,
-            response_final_url="http://127.0.0.1:8765/proof",
+            response_final_url=f"{target_url}/proof",
             response_headers={"Set-Cookie": f"proof={_AGENT_HTTP_SECRET}"},
             response_body=f"target returned {_AGENT_HTTP_SECRET}",
             scope_decision="allowed",
@@ -1152,6 +1543,8 @@ def _add_deterministic_scan_traffic(workspace: Path) -> None:
     manifest = TrafficRunManifest.create(
         target_url="http://127.0.0.1:8765",
         capture_session_id=capture_session_id,
+        in_scope=_REPORT_IN_SCOPE,
+        out_of_scope=_REPORT_OUT_OF_SCOPE,
     )
     write_traffic_manifest(workspace, manifest.complete())
     for path, status in (("/", 200), ("/admin", 403)):

--- a/packages/ravage/tests/test_ssti_required_params.py
+++ b/packages/ravage/tests/test_ssti_required_params.py
@@ -6,9 +6,12 @@ from urllib.parse import parse_qs, urlsplit
 
 from ravage import probe_suite
 from ravage.agent_core.agent_state import AgentState
+from ravage.agent_core.surface_graph import SurfaceGraphState
+from ravage.agent_core.surface_graph_ingest import project_surface_graph
+from ravage.probe_suite import run_builtin_probe
+from ravage.probes.specialists.shared import _generic_input_targets
 from ravage.probes.specialists.ssti import _ssti_expression_targets
 from ravage.web_core.http_probe import ProbeResponse
-from ravage.probe_suite import run_builtin_probe
 
 _FLAG = "flag{ssti_loan_calc_required_params_7c2a}"
 
@@ -200,6 +203,49 @@ class _AuthenticatedReminderJinjaSession(_BaseFakeSession):
         )
 
 
+class _ObservedGenerateErbSession(_BaseFakeSession):
+    """ERB sink reachable only through the observed POST form contract."""
+
+    def post_form(
+        self,
+        url: str,
+        fields: dict[str, str],
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> ProbeResponse:
+        del headers
+        if urlsplit(url).path != "/generate":
+            return self._not_found("POST", url)
+        sentence = fields.get("sentence", "")
+        rendered = sentence
+        if sentence == "<%= 7*7 %>":
+            rendered = "49"
+        elif sentence.startswith("<%= `"):
+            rendered = _GENERATE_FLAG
+        return ProbeResponse(
+            method="POST",
+            url=url,
+            status=200,
+            final_url=url,
+            elapsed_ms=5,
+            body=f"<p>{rendered}</p>",
+        )
+
+    def _response(self, method: str, url: str) -> ProbeResponse:
+        return self._not_found(method, url)
+
+    @staticmethod
+    def _not_found(method: str, url: str) -> ProbeResponse:
+        return ProbeResponse(
+            method=method,
+            url=url,
+            status=404,
+            final_url=url,
+            elapsed_ms=5,
+            body="Not Found",
+        )
+
+
 def _filtered_numeric_flag_ordinal(payload: str) -> int:
     match = re.search(r"head -c (\d+)", payload)
     if match is None:
@@ -220,6 +266,7 @@ def _looks_number(value: str) -> bool:
 
 _USERNAME_FLAG = "flag{ssti_username_openapi_signal_9c6d}"
 _REMINDER_FLAG = "flag{ssti_reminder_date_signal_3c58}"
+_GENERATE_FLAG = "flag{ssti_observed_generate_form_8a42}"
 
 
 def _state_with_calculator_param() -> AgentState:
@@ -322,6 +369,63 @@ def _state_with_generated_username_endpoint_only() -> AgentState:
     return state
 
 
+def _state_with_observed_generate_form_and_noisy_endpoints() -> AgentState:
+    state = AgentState()
+    generate_url = "http://127.0.0.1/generate"
+    form = {
+        "action": generate_url,
+        "categories": ["command_boundary"],
+        "inputs": [
+            {"name": "sentence", "required": True, "type": "text", "value": ""},
+            {"name": "number", "required": True, "type": "number", "value": ""},
+        ],
+        "method": "POST",
+    }
+    state.surface = {
+        "target_url": "http://127.0.0.1/",
+        "origin": "http://127.0.0.1",
+        "forms": [form],
+        "parameters": [
+            {
+                "name": "sentence",
+                "locations": [generate_url],
+                "priority": 4,
+                "sources": ["form:post", "surface_graph:form"],
+            },
+            {
+                "name": "number",
+                "locations": [generate_url],
+                "priority": 4,
+                "sources": ["form:post", "surface_graph:form"],
+            },
+        ],
+        "endpoints": [{"url": "http://127.0.0.1/"}, {"url": generate_url}],
+        "request_templates": [
+            {
+                "fields": {"number": "", "sentence": ""},
+                "method": "POST",
+                "source": "surface_graph",
+                "url": generate_url,
+            }
+        ],
+    }
+    state.signals["parameters"] = ["number", "sentence"]
+    state.signals["endpoints"] = [
+        "/",
+        "/a",
+        "/button",
+        "/div",
+        "/form",
+        "/generate",
+        "/li",
+        "/nav",
+        "/p",
+        "/span",
+        "/ul",
+    ]
+    return state
+
+
 def test_ssti_missing_param_recovery_skips_when_no_validation_error(monkeypatch) -> None:
     class _PlainReflectionSession(_BaseFakeSession):
         def _response(self, method: str, url: str) -> ProbeResponse:
@@ -377,6 +481,150 @@ def test_ssti_does_not_post_generated_username_query_endpoint(monkeypatch) -> No
         _is_generated_username_post(request)
         for request in result.requests
     )
+
+
+def test_observed_generate_form_outranks_inferred_query_targets() -> None:
+    targets = _generic_input_targets(
+        _state_with_observed_generate_form_and_noisy_endpoints(),
+        limit=12,
+    )
+
+    assert targets[0]["kind"] == "form"
+    assert targets[0]["url"] == "http://127.0.0.1/generate"
+    assert targets[0]["input"] == "sentence"
+    assert targets[0]["authority"] == "target_observed"
+    first_inferred = next(
+        index for index, target in enumerate(targets) if target["authority"] == "inferred"
+    )
+    assert all(target["kind"] == "form" for target in targets[:2])
+    assert first_inferred >= 2
+
+
+def test_surface_graph_form_parameter_preserves_observed_form_transport() -> None:
+    state = AgentState(
+        surface={"target_url": "http://127.0.0.1/", "origin": "http://127.0.0.1"},
+        surface_graph=SurfaceGraphState.for_target("http://127.0.0.1/"),
+    )
+    state.surface_graph.add(
+        url="http://127.0.0.1/generate",
+        method="POST",
+        parameters=({"name": "sentence", "location": "form"},),
+        hints=("form",),
+        source_kind="native_recon",
+    )
+    state.surface = project_surface_graph(state.surface_graph, state.surface)
+
+    targets = _generic_input_targets(state, limit=12)
+    sentence = next(target for target in targets if target["input"] == "sentence")
+
+    assert sentence["kind"] == "form"
+    assert sentence["url"] == "http://127.0.0.1/generate"
+    assert sentence["authority"] == "target_observed"
+
+
+def test_surface_graph_body_parameter_is_not_fabricated_as_query() -> None:
+    state = AgentState(
+        surface={"target_url": "http://127.0.0.1/", "origin": "http://127.0.0.1"},
+        surface_graph=SurfaceGraphState.for_target("http://127.0.0.1/"),
+    )
+    state.surface_graph.add(
+        url="http://127.0.0.1/api/generate",
+        method="POST",
+        parameters=({"name": "sentence", "location": "body"},),
+        source_kind="openapi",
+    )
+    state.surface = project_surface_graph(state.surface_graph, state.surface)
+
+    targets = _generic_input_targets(state, limit=12)
+
+    assert not any(target["input"] == "sentence" for target in targets)
+
+
+def test_weak_query_shaped_parameter_does_not_outrank_observed_body_target() -> None:
+    state = AgentState(
+        surface={"target_url": "http://127.0.0.1/", "origin": "http://127.0.0.1"},
+        surface_graph=SurfaceGraphState.for_target("http://127.0.0.1/"),
+    )
+    state.surface_graph.add(
+        url="http://127.0.0.1/generate",
+        method="POST",
+        parameters=({"name": "sentence", "location": "form"},),
+        hints=("form",),
+        source_kind="native_recon",
+    )
+    state.surface = project_surface_graph(state.surface_graph, state.surface)
+    parameters = state.surface["parameters"]
+    assert isinstance(parameters, list)
+    parameters.append(
+        {
+            "name": "q",
+            "locations": ["http://127.0.0.1/search?q=reflected"],
+            "priority": 100,
+            "sources": ["response_text"],
+        }
+    )
+
+    targets = _generic_input_targets(state, limit=12)
+    q_target = next(target for target in targets if target["input"] == "q")
+
+    assert targets[0]["input"] == "sentence"
+    assert targets[0]["kind"] == "form"
+    assert targets[0]["authority"] == "target_observed"
+    assert q_target["authority"] == "observed_input"
+
+
+def test_ssti_closes_observed_generate_post_before_guessed_gets(monkeypatch) -> None:
+    monkeypatch.setattr(probe_suite, "ProbeSession", _ObservedGenerateErbSession)
+
+    result = run_builtin_probe(
+        "ssti_fingerprint",
+        target_url="http://127.0.0.1/",
+        state=_state_with_observed_generate_form_and_noisy_endpoints(),
+    )
+
+    assert result.ok
+    assert result.findings[0]["type"] == "ssti_extracted_proof"
+    assert _GENERATE_FLAG in result.findings[0]["proofs"]
+    first_baseline = next(
+        request for request in result.requests if request.get("probe_kind") == "baseline"
+    )
+    assert first_baseline["target"] == {
+        "kind": "form",
+        "url": "http://127.0.0.1/generate",
+        "input": "sentence",
+        "hints": ["command_boundary"],
+    }
+    assert all(
+        not isinstance(request.get("target"), dict)
+        or request["target"].get("kind") == "form"
+        for request in result.requests
+    )
+
+
+def test_ssti_expression_ranking_keeps_observed_form_ahead_of_guessed_query() -> None:
+    state = AgentState()
+    state.surface = {
+        "target_url": "http://127.0.0.1/",
+        "origin": "http://127.0.0.1",
+        "forms": [
+            {
+                "action": "http://127.0.0.1/remind",
+                "inputs": [{"name": "date", "type": "text"}],
+                "method": "POST",
+            }
+        ],
+        "parameters": [],
+        "endpoints": [{"url": "http://127.0.0.1/remind"}],
+    }
+    state.signals["endpoints"] = ["/remind"]
+    generic = _generic_input_targets(state, limit=12)
+
+    targets = _ssti_expression_targets(state, generic)
+
+    assert targets[0]["kind"] == "form"
+    assert targets[0]["url"] == "http://127.0.0.1/remind"
+    assert targets[0]["input"] == "date"
+    assert targets[0]["authority"] == "target_observed"
 
 
 def test_ssti_uses_auth_cookie_for_reminder_date_endpoint(monkeypatch) -> None:

--- a/packages/ravage/tests/test_stateful_http_action.py
+++ b/packages/ravage/tests/test_stateful_http_action.py
@@ -1,0 +1,1714 @@
+# ruff: noqa: PLR2004
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from io import StringIO
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
+from uuid import uuid4
+
+import pytest
+from ai_agent_fixtures import BRIEF_YAML, ScriptedModelClient
+from pentest_schemas import Scope
+from ravage.agent_core import ai_agent
+from ravage.agent_core.action_executor import execute_action
+from ravage.agent_core.action_parser import parse_action
+from ravage.agent_core.agent_state import AgentState, save_agent_state
+from ravage.agent_core.agent_strategy import action_fingerprint
+from ravage.agent_core.ai_agent import (
+    AIWebAgentSettings,
+    _update_state_from_action,
+    run_ai_web_agent,
+)
+from ravage.agent_core.autonomous_graph.scoped_http import ScopedGraphHttpExecutor
+from ravage.agent_core.stateful_http import StatefulHttpActionSession
+from ravage.probes.specialists.shared import _generic_input_targets
+from ravage.run_data.audit import AuditStore
+from ravage.run_data.workspace import AgentWorkspace
+from ravage.runtime import NoProcessToolRuntime
+from ravage.traffic.policy import (
+    TrafficPolicyConfig,
+    TrafficPolicyController,
+    TrafficPolicyMode,
+)
+from ravage.traffic.store import TrafficStore
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+_FAKE_REQUEST_PROOF = "flag{request_payload_is_not_target_evidence_42a8}"
+_FORGED_VALIDATOR_PROOF = "flag{validator_expectation_forgery_73c9}"
+_LATE_RESPONSE_PROOF = "flag{late_persistent_validator_proof_91c7}"
+
+
+@dataclass(frozen=True)
+class _HttpTarget:
+    url: str
+    requests: list[dict[str, object]]
+
+
+@pytest.fixture
+def stateful_http_target() -> Iterator[_HttpTarget]:  # noqa: C901
+    requests: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            requests.append(
+                {
+                    "method": "POST",
+                    "path": self.path,
+                    "cookie": self.headers.get("Cookie", ""),
+                    "form": parse_qs(body.decode()),
+                }
+            )
+            if self.path == "/login":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Set-Cookie", "session=persistent; Path=/; HttpOnly")
+                self.send_header("Content-Length", str(len(b"session established")))
+                self.end_headers()
+                self.wfile.write(b"session established")
+                return
+            if self.path == "/rotate":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Set-Cookie", "session=rotated; Path=/; HttpOnly")
+                self.send_header("Content-Length", str(len(b"session rotated")))
+                self.end_headers()
+                self.wfile.write(b"session rotated")
+                return
+            if self.path == "/reflect-form":
+                self._respond(
+                    200,
+                    (
+                        b'<html><form method="post" action="/poisoned">'
+                        b'<input name="fabricated_field" value="attacker-controlled">'
+                        b"</form></html>"
+                    ),
+                )
+                return
+            self._respond(404, b"not found")
+
+        def do_GET(self) -> None:
+            cookie = self.headers.get("Cookie", "")
+            requests.append(
+                {
+                    "method": "GET",
+                    "path": self.path,
+                    "cookie": cookie,
+                }
+            )
+            if self.path == "/redirect-outside":
+                self._redirect(
+                    "https://outside.example/private?token=redirect-secret-value"
+                )
+                return
+            if self.path.startswith("/redirect-loop"):
+                self._redirect("/redirect-loop?token=redirect-secret-value")
+                return
+            if self.path == "/dashboard":
+                body = (
+                    b"authenticated dashboard"
+                    if "session=persistent" in cookie
+                    else b"public login shell"
+                )
+                self._respond(200, body)
+                return
+            if self.path.startswith("/reflect"):
+                self._respond(200, b"hello {{7*7}} response 49")
+                return
+            if self.path == "/long-proof":
+                self._respond(200, (b"x" * 340) + b"\n" + _LATE_RESPONSE_PROOF.encode())
+                return
+            if self.path == "/form":
+                self._respond(
+                    200,
+                    (
+                        b'<html><form method="post" action="/generate">'
+                        b'<input name="sentence" value="not-retained">'
+                        b'<input type="hidden" name="csrf_token" value="secret">'
+                        b"</form></html>"
+                    ),
+                )
+                return
+            if self.path == "/private" and "session=persistent" in cookie:
+                self._respond(200, b"authenticated follow-up")
+                return
+            self._respond(401, b"authentication required")
+
+        def _respond(self, status: int, body: bytes) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _redirect(self, location: str) -> None:
+            self.send_response(302)
+            self.send_header("Location", location)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield _HttpTarget(url=f"http://{host}:{port}/", requests=requests)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_parser_validates_structured_http_request_shape() -> None:
+    valid = parse_action(
+        json.dumps(
+            {
+                "action": "http_request",
+                "task_id": "authenticated-follow-up",
+                "method": "POST",
+                "path": "/login",
+                "headers": {"Accept": "text/plain"},
+                "form": {"username": "user", "password": "pass"},
+            }
+        )
+    )
+
+    assert valid["action"] == "http_request"
+    assert valid["method"] == "POST"
+    assert valid["path"] == "/login"
+    assert valid["form"] == {"username": "user", "password": "pass"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"action": "http_request", "method": "GET"}, "requires url or path"),
+        (
+            {"action": "http_request", "method": "DELETE", "path": "/item"},
+            "method is not allowed",
+        ),
+        (
+            {
+                "action": "http_request",
+                "method": "POST",
+                "path": "/item",
+                "body": "raw",
+                "json": {"value": "json"},
+            },
+            "accepts only one",
+        ),
+        (
+            {
+                "action": "http_request",
+                "method": "GET",
+                "path": "/item",
+                "form": {"value": "body"},
+            },
+            "cannot include a body",
+        ),
+        (
+            {
+                "action": "http_request",
+                "method": "POST",
+                "path": "/item",
+                "headers": ["X-Test: invalid-shape"],
+            },
+            "headers must be an object",
+        ),
+    ],
+)
+def test_parser_rejects_invalid_structured_http_requests(
+    payload: dict[str, object],
+    error: str,
+) -> None:
+    parsed = parse_action(json.dumps(payload))
+
+    assert parsed["action"] == "invalid"
+    assert error in str(parsed["error"])
+
+
+def test_http_fingerprint_uses_dispatch_material_not_mutable_notes() -> None:
+    request = {
+        "action": "http_request",
+        "method": "POST",
+        "path": "/generate",
+        "form": {"sentence": "<%= 7 * 7 %>"},
+        "notes": "first explanation",
+    }
+
+    same_dispatch = {**request, "notes": "rewritten explanation", "task_id": "other"}
+    changed_dispatch = {**request, "form": {"sentence": "<%= 8 * 8 %>"}}
+
+    assert action_fingerprint(request) == action_fingerprint(same_dispatch)
+    assert action_fingerprint(request) != action_fingerprint(changed_dispatch)
+
+
+def test_http_action_memory_retains_replay_shape_without_values() -> None:
+    state = AgentState()
+    action = {
+        "action": "http_request",
+        "method": "POST",
+        "url": "https://target.example/search?q=private-search-value",
+        "headers": {
+            "Authorization": "Bearer private-token",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        "form": {"query": "private-body-value", "submit": "Search"},
+    }
+
+    _update_state_from_action(
+        state,
+        action=action,
+        outcome={"ok": True, "outcome": "http_response_observed"},
+    )
+
+    serialized = json.dumps(state.actions)
+    assert "private-search-value" not in serialized
+    assert "private-token" not in serialized
+    assert "private-body-value" not in serialized
+    shape = state.actions[-1]["request_shape"]
+    assert shape == {
+        "method": "POST",
+        "url_shape": "https://target.example/search?q",
+        "body_encoding": "form",
+        "field_names": ["query", "submit"],
+        "header_names": ["authorization", "content-type"],
+        "values_retained": False,
+    }
+
+
+def test_http_action_memory_recognizes_json_array_without_retaining_values() -> None:
+    state = AgentState()
+    action = {
+        "action": "http_request",
+        "method": "POST",
+        "path": "/batch",
+        "json": [{"secret": "private-list-value"}],
+    }
+
+    _update_state_from_action(
+        state,
+        action=action,
+        outcome={"ok": True, "outcome": "http_response_observed"},
+    )
+
+    serialized = json.dumps(state.actions)
+    assert "private-list-value" not in serialized
+    assert state.actions[-1]["request_shape"] == {
+        "method": "POST",
+        "url_shape": "/batch",
+        "body_encoding": "json",
+        "field_names": [],
+        "header_names": [],
+        "values_retained": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("content_type", "body", "encoding", "field_names", "secret"),
+    [
+        (
+            "application/x-www-form-urlencoded; charset=utf-8",
+            "query=private-form-value&submit=Search",
+            "form",
+            ["query", "submit"],
+            "private-form-value",
+        ),
+        (
+            "application/problem+json",
+            '{"query":"private-json-value"}',
+            "json",
+            ["query"],
+            "private-json-value",
+        ),
+    ],
+)
+def test_http_action_memory_recovers_safe_fields_from_typed_raw_body(
+    content_type: str,
+    body: str,
+    encoding: str,
+    field_names: list[str],
+    secret: str,
+) -> None:
+    state = AgentState()
+
+    _update_state_from_action(
+        state,
+        action={
+            "action": "http_request",
+            "method": "POST",
+            "path": "/submit",
+            "headers": {"Content-Type": content_type},
+            "body": body,
+        },
+        outcome={"ok": True, "outcome": "http_response_observed"},
+    )
+
+    serialized = json.dumps(state.actions)
+    assert secret not in serialized
+    shape = state.actions[-1]["request_shape"]
+    assert isinstance(shape, dict)
+    assert shape["body_encoding"] == encoding
+    assert shape["field_names"] == field_names
+
+
+def test_validate_poc_memory_persists_ordered_secret_free_request_shapes() -> None:
+    state = AgentState()
+
+    _update_state_from_action(
+        state,
+        action={
+            "action": "validate_poc",
+            "steps": [
+                {
+                    "method": "POST",
+                    "path": "/search?q=private-query-value",
+                    "form": {"sentence": "private-form-value"},
+                },
+                {
+                    "method": "PATCH",
+                    "url": "https://target.example/items/7?mode=private-mode",
+                    "headers": {
+                        "Authorization": "Bearer private-token",
+                        "Content-Type": "application/json",
+                    },
+                    "body": '{"title":"private-json-value"}',
+                },
+            ],
+        },
+        outcome={"ok": False, "outcome": "blocked"},
+    )
+
+    serialized = json.dumps(state.to_json())
+    for secret in (
+        "private-query-value",
+        "private-form-value",
+        "private-mode",
+        "private-token",
+        "private-json-value",
+    ):
+        assert secret not in serialized
+    shapes = state.actions[-1]["request_shapes"]
+    assert shapes == [
+        {
+            "method": "POST",
+            "url_shape": "/search?q",
+            "body_encoding": "form",
+            "field_names": ["sentence"],
+            "header_names": [],
+            "values_retained": False,
+        },
+        {
+            "method": "PATCH",
+            "url_shape": "https://target.example/items/7?mode",
+            "body_encoding": "json",
+            "field_names": ["title"],
+            "header_names": ["authorization", "content-type"],
+            "values_retained": False,
+        },
+    ]
+    restored = AgentState.from_json(state.to_json())
+    assert restored.actions[-1]["request_shapes"] == shapes
+
+
+def test_same_name_cookie_rotation_reactivates_lead_without_advancing_repeat_epoch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    state = AgentState()
+    session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=Scope(in_scope=[target_url], out_of_scope=[]),
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    reactivations: list[AgentState] = []
+    monkeypatch.setattr(
+        "ravage.agent_core.stateful_http.reactivate_for_session_change",
+        reactivations.append,
+    )
+    try:
+        session(
+            node_id="base-agent",
+            arguments={"method": "POST", "url": "/login", "form": {}},
+            action_id="login",
+        )
+        epoch_after_login = state.surface["http_state_epoch"]
+        reactivations.clear()
+
+        session(
+            node_id="base-agent",
+            arguments={"method": "POST", "url": "/rotate", "form": {}},
+            action_id="rotate",
+        )
+    finally:
+        session.finalize()
+
+    assert state.surface["http_state_epoch"] == epoch_after_login
+    assert reactivations == [state]
+
+
+def test_direct_http_reuses_cookie_and_links_traffic_evidence(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+        proof_recognition_enabled=True,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    engagement_id = uuid4()
+    try:
+        login = execute_action(
+            {
+                "action": "http_request",
+                "task_id": "authenticated-follow-up",
+                "method": "POST",
+                "path": "/login",
+                "form": {"username": _FAKE_REQUEST_PROOF, "password": "pass"},
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=engagement_id,
+            proof_recognition_enabled=True,
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="direct-login",
+            http_executor=http_session,
+        )
+        private = execute_action(
+            {
+                "action": "http_request",
+                "task_id": "authenticated-follow-up",
+                "method": "GET",
+                "path": "/private",
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=engagement_id,
+            proof_recognition_enabled=True,
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="direct-private",
+            http_executor=http_session,
+        )
+        terminal = http_session.finalize()
+    finally:
+        audit.close()
+
+    assert login.ok is True
+    assert login.flag == ""
+    assert login.stop is False
+    assert private.ok is True
+    assert private.flag == ""
+    assert private.stop is False
+    assert json.loads(private.evidence_observation)["response"]["body"] == (
+        "authenticated follow-up"
+    )
+    assert state.flags == []
+    assert all(
+        _FAKE_REQUEST_PROOF not in value for values in state.signals.values() for value in values
+    )
+    assert stateful_http_target.requests == [
+        {
+            "method": "POST",
+            "path": "/login",
+            "cookie": "",
+            "form": {"username": [_FAKE_REQUEST_PROOF], "password": ["pass"]},
+        },
+        {
+            "method": "GET",
+            "path": "/private",
+            "cookie": "session=persistent",
+        },
+    ]
+
+    assert terminal is not None
+    assert terminal.agent_http_exchange_count == 2
+    assert terminal.manifest_completed is True
+    http_state = json.loads((workspace.root / "agent-http-state.json").read_text())
+    assert http_state["request_count"] == 2
+
+    exchanges = TrafficStore.open(workspace.root).exchanges()
+    assert len(exchanges) == 2
+    events = [json.loads(line) for line in workspace.events_path.read_text().splitlines()]
+    http_events = [event for event in events if event["kind"] == "tool_http_request"]
+    assert len(http_events) == 2
+    for event, exchange in zip(http_events, exchanges, strict=True):
+        payload = event["payload"]
+        assert payload["observation_id"] == exchange.source_observation_id
+        assert payload["recognized_proofs"] == []
+        evidence = json.loads(payload["result"])
+        assert evidence["traffic_exchange_ids"] == [exchange.exchange_id]
+        assert all(
+            receipt["request_body_sha256"] == "unavailable"
+            for receipt in evidence["requests"]
+        )
+    assert _FAKE_REQUEST_PROOF not in (workspace.root / "traffic" / "exchanges.jsonl").read_text()
+
+    blackboard = json.loads((workspace.root / "evidence-blackboard.json").read_text())
+    raw_records = [
+        record for record in blackboard["records"] if record["kind"] == "raw_observation"
+    ]
+    assert {record["observation_id"] for record in raw_records} == {
+        exchange.source_observation_id for exchange in exchanges
+    }
+    assert all(record["source"] == "tool_http_request" for record in raw_records)
+    assert all(record["kind"] != "proof_confirmed" for record in blackboard["records"])
+
+
+def test_resume_releases_nonpersisted_session_and_clears_durable_marker(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    initial = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+
+    execution = initial(
+        node_id="initial-http",
+        arguments={"method": "GET", "path": "/public"},
+        action_id="initial-http-action",
+    )
+    assert execution.result.ok is True
+    initial.finalize()
+    assert state.surface["http_session_dirty"] is True
+    persisted_before = json.loads(
+        (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+    )
+    assert persisted_before["session_dirty"] is True
+
+    resumed = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+        resume_expected=True,
+    )
+    try:
+        assert resumed.opened is True
+        assert "http_session_dirty" not in state.surface
+        assert state.surface["http_state_epoch"] == 1
+        assert any("session was reset on resume" in fact for fact in state.facts)
+        persisted_after = json.loads(
+            (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+        )
+        assert persisted_after["session_dirty"] is False
+    finally:
+        resumed.finalize()
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_request_count"),
+    [
+        ("/redirect-outside", 1),
+        ("/redirect-loop", 5),
+    ],
+)
+def test_redirect_policy_failure_closes_evidence_transaction_and_can_resume(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+    path: str,
+    expected_request_count: int,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    initial = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {"action": "http_request", "method": "GET", "path": path},
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="redirect-policy-failure",
+            http_executor=initial,
+        )
+        terminal = initial.finalize()
+    finally:
+        audit.close()
+
+    assert outcome.ok is False
+    assert outcome.outcome == "blocked"
+    assert terminal is not None
+    assert terminal.agent_http_exchange_count == expected_request_count
+    assert len(stateful_http_target.requests) == expected_request_count
+    http_state = json.loads(
+        (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+    )
+    assert http_state["request_count"] == expected_request_count
+    exchanges = TrafficStore.open(workspace.root).exchanges()
+    assert len(exchanges) == expected_request_count
+    observation_ids = {item.source_observation_id for item in exchanges}
+    assert len(observation_ids) == 1
+    assert "" not in observation_ids
+
+    blackboard_text = (workspace.root / "evidence-blackboard.json").read_text(
+        encoding="utf-8"
+    )
+    blackboard = json.loads(blackboard_text)
+    raw_records = [
+        record
+        for record in blackboard["records"]
+        if record["kind"] == "raw_observation"
+        and record["source"] == "tool_http_request"
+    ]
+    assert len(raw_records) == 1
+    assert raw_records[0]["observation_id"] in observation_ids
+    assert raw_records[0]["material"] is False
+    assert raw_records[0]["payload"]["ok"] is False
+    assert raw_records[0]["payload"]["outcome"] == "http_request_interrupted"
+    assert "redirect-secret-value" not in blackboard_text
+    assert "redirect-secret-value" not in workspace.events_path.read_text(encoding="utf-8")
+
+    resumed = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+        resume_expected=True,
+    )
+    try:
+        assert resumed.opened is True
+        resumed_state = json.loads(
+            (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+        )
+        assert resumed_state["request_count"] == expected_request_count
+    finally:
+        resumed.finalize()
+
+    assert len(stateful_http_target.requests) == expected_request_count
+
+
+def test_transport_interrupt_closes_request_traffic_evidence_transaction(
+    tmp_path: Path,
+) -> None:
+    target_url = "http://127.0.0.1:8765"
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    initial = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+
+    class InterruptingTransport:
+        @staticmethod
+        def send(_request: object) -> None:
+            raise KeyboardInterrupt
+
+    executor = initial._open()  # noqa: SLF001
+    executor.transport = InterruptingTransport()
+    with pytest.raises(KeyboardInterrupt):
+        initial(
+            node_id="interrupted-http",
+            arguments={"method": "GET", "path": "/interrupted"},
+            action_id="interrupted-http",
+        )
+    terminal = initial.finalize()
+
+    assert terminal is not None
+    assert terminal.agent_http_exchange_count == 1
+    http_state = json.loads(
+        (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+    )
+    assert http_state["request_count"] == 1
+    [exchange] = TrafficStore.open(workspace.root).exchanges()
+    assert exchange.request_sent is True
+    assert exchange.response_status is None
+    assert exchange.response_error == "KeyboardInterrupt:transport dispatch interrupted"
+    blackboard = json.loads(
+        (workspace.root / "evidence-blackboard.json").read_text(encoding="utf-8")
+    )
+    raw_records = [
+        record
+        for record in blackboard["records"]
+        if record["kind"] == "raw_observation"
+        and record["source"] == "tool_http_request"
+    ]
+    assert len(raw_records) == 1
+    assert raw_records[0]["observation_id"] == exchange.source_observation_id
+    assert raw_records[0]["payload"]["outcome"] == "http_request_interrupted"
+
+    resumed = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+        resume_expected=True,
+    )
+    try:
+        assert resumed.opened is True
+        resumed_state = json.loads(
+            (workspace.root / "agent-http-state.json").read_text(encoding="utf-8")
+        )
+        assert resumed_state["request_count"] == 1
+    finally:
+        resumed.finalize()
+
+
+def test_failed_fresh_lane_initialization_rolls_back_partial_artifacts(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+
+    class FailingExecutor:
+        def __init__(self, **_kwargs: object) -> None:
+            message = "injected executor initialization failure"
+            raise RuntimeError(message)
+
+    monkeypatch.setattr(
+        "ravage.agent_core.stateful_http.ScopedGraphHttpExecutor",
+        FailingExecutor,
+    )
+    session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=Scope(in_scope=[target_url], out_of_scope=[]),
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=AgentState(),
+    )
+
+    with pytest.raises(RuntimeError, match="injected executor initialization failure"):
+        session._open()  # noqa: SLF001
+
+    assert not (workspace.root / "agent-http-state.json").exists()
+    assert not (workspace.root / "evidence-blackboard.json").exists()
+    assert not (workspace.root / "traffic").exists()
+
+
+def test_failed_resumed_evidence_validation_closes_opened_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_url = "http://127.0.0.1:8765"
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    initial = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    initial._open()  # noqa: SLF001
+    initial.finalize()
+
+    finalize_calls: list[StatefulHttpActionSession] = []
+    ordinary_finalize = StatefulHttpActionSession.finalize
+
+    def recording_finalize(
+        session: StatefulHttpActionSession,
+    ) -> object:
+        finalize_calls.append(session)
+        return ordinary_finalize(session)
+
+    def fail_validation(
+        _session: StatefulHttpActionSession,
+        _traffic: object,
+    ) -> None:
+        raise RuntimeError("injected resumed evidence failure")
+
+    monkeypatch.setattr(StatefulHttpActionSession, "finalize", recording_finalize)
+    monkeypatch.setattr(
+        StatefulHttpActionSession,
+        "_validate_resumed_evidence",
+        fail_validation,
+    )
+
+    with pytest.raises(RuntimeError, match="injected resumed evidence failure"):
+        StatefulHttpActionSession(
+            target_url=target_url,
+            scope=scope,
+            allow_remote_target=False,
+            roe_max_rps=100,
+            max_total_requests=5,
+            workspace_dir=workspace.root,
+            state=state,
+            resume_expected=True,
+        )
+
+    assert len(finalize_calls) == 1
+
+
+def test_failed_resumed_session_marker_persistence_closes_opened_lane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_url = "http://127.0.0.1:8765"
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    initial = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    executor = initial._open()  # noqa: SLF001
+    executor.mark_session_dirty()
+    initial.finalize()
+
+    finalize_calls: list[StatefulHttpActionSession] = []
+    ordinary_finalize = StatefulHttpActionSession.finalize
+
+    def recording_finalize(
+        session: StatefulHttpActionSession,
+    ) -> object:
+        finalize_calls.append(session)
+        return ordinary_finalize(session)
+
+    def fail_clear(_executor: ScopedGraphHttpExecutor) -> None:
+        raise OSError("injected session marker persistence failure")
+
+    monkeypatch.setattr(StatefulHttpActionSession, "finalize", recording_finalize)
+    monkeypatch.setattr(ScopedGraphHttpExecutor, "clear_session_dirty", fail_clear)
+
+    with pytest.raises(OSError, match="injected session marker persistence failure"):
+        StatefulHttpActionSession(
+            target_url=target_url,
+            scope=scope,
+            allow_remote_target=False,
+            roe_max_rps=100,
+            max_total_requests=5,
+            workspace_dir=workspace.root,
+            state=state,
+            resume_expected=True,
+        )
+
+    assert len(finalize_calls) == 1
+
+
+def test_http_finalizer_preserves_first_failure_and_reports_later_cleanup(
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    class FailingExecutor:
+        def close(self) -> None:
+            calls.append("executor")
+            raise RuntimeError("executor-close-primary")
+
+    class FailingTraffic:
+        def finalize(self) -> None:
+            calls.append("traffic")
+            raise ValueError("traffic-finalize-secondary")
+
+    session = StatefulHttpActionSession(
+        target_url="http://127.0.0.1:8765",
+        scope=Scope(in_scope=["http://127.0.0.1:8765"], out_of_scope=[]),
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=5,
+        workspace_dir=tmp_path,
+        state=AgentState(),
+    )
+    session._executor = FailingExecutor()  # type: ignore[assignment]  # noqa: SLF001
+    session._traffic = FailingTraffic()  # type: ignore[assignment]  # noqa: SLF001
+
+    with pytest.raises(RuntimeError, match="executor-close-primary") as error:
+        session.finalize()
+
+    assert calls == ["executor", "traffic"]
+    assert any(
+        "traffic finalization also failed: ValueError" in note
+        for note in getattr(error.value, "__notes__", ())
+    )
+
+
+def test_http_last_observation_keeps_only_response_metadata(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {
+                "action": "http_request",
+                "method": "POST",
+                "path": "/login",
+                "form": {"username": _FAKE_REQUEST_PROOF, "password": "pass"},
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="response-memory",
+            http_executor=http_session,
+        )
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.ok is True
+    response = state.last_observation["http_response"]
+    assert isinstance(response, dict)
+    assert response["status"] == 200
+    assert response["final_url"] == f"{target_url}login"
+    assert response["truncated"] is False
+    assert response["error"] == ""
+    headers = {str(name).casefold(): value for name, value in response["headers"].items()}
+    assert headers["content-type"] == "text/plain"
+    assert "session=persistent" not in str(headers["set-cookie"])
+    assert _FAKE_REQUEST_PROOF not in json.dumps(state.last_observation)
+    assert "username" not in json.dumps(state.last_observation)
+
+
+def test_clean_get_retains_passive_form_as_canonical_request_template(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {
+                "action": "http_request",
+                "method": "GET",
+                "path": "/form",
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="passive-form-discovery",
+            http_executor=http_session,
+        )
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.ok is True
+    expected_url = f"{target_url}generate"
+    assert {
+        "source": "surface_graph",
+        "method": "POST",
+        "url": expected_url,
+        "fields": {"csrf_token": "", "sentence": ""},
+    } in state.surface["request_templates"]
+    discovered = [
+        operation
+        for operation in (state.surface_graph.operations or {}).values()
+        if operation.method == "POST" and operation.structural_url == expected_url
+    ]
+    assert len(discovered) == 1
+    assert any(
+        observation.operation_id == discovered[0].operation_id
+        and observation.access_level == "declared"
+        and observation.response_status is None
+        for observation in (state.surface_graph.observations or {}).values()
+    )
+    assert {(item.location, item.name) for item in discovered[0].parameters} == {
+        ("form", "csrf_token"),
+        ("form", "sentence"),
+    }
+    [first_target, *_rest] = _generic_input_targets(state, limit=4)
+    assert first_target["kind"] == "form"
+    assert first_target["url"] == expected_url
+    assert first_target["input"] == "sentence"
+    assert first_target["authority"] == "target_observed"
+    serialized = json.dumps(state.surface_graph.to_json(), sort_keys=True)
+    assert "not-retained" not in serialized
+    assert '"secret"' not in serialized
+
+
+def test_mutated_response_cannot_poison_signals_or_surface_templates(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {
+                "action": "http_request",
+                "method": "POST",
+                "path": "/reflect-form",
+                "form": {"echo": "attacker-controlled"},
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="mutated-form-reflection",
+            http_executor=http_session,
+        )
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.ok is True
+    poisoned_url = f"{target_url}poisoned"
+    assert all(
+        template.get("url") != poisoned_url
+        for template in state.surface.get("request_templates", [])
+    )
+    assert all(
+        operation.structural_url != poisoned_url
+        for operation in (state.surface_graph.operations or {}).values()
+    )
+    assert "fabricated_field" not in state.signals.get("parameters", [])
+    assert all("/poisoned" not in value for value in state.signals.get("endpoints", []))
+    assert all("/poisoned" not in value for value in state.signals.get("forms", []))
+
+
+def test_cookie_transition_makes_same_get_fresh_in_agent_repeat_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    monkeypatch.setattr(ai_agent, "_seed_recon", lambda **_kwargs: None)
+    monkeypatch.setattr(ai_agent, "refresh_mission_board", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ai_agent, "_forced_evidence_probe_action", lambda **_kwargs: None)
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(
+        (
+            f'engagement_id: "{uuid4()}"\n'
+            "scope:\n"
+            "  in_scope:\n"
+            f'    - "{stateful_http_target.url}"\n'
+            "  out_of_scope: []\n"
+            "roe:\n"
+            "  max_rps: 100\n"
+            "  no_destructive_actions: true\n"
+            '  data_handling: "placeholders_only"\n'
+            "objectives:\n"
+            '  - "web_application_assessment"\n'
+            "budget:\n"
+            "  max_cost_usd: 1.0\n"
+            "  max_runtime_min: 10\n"
+        ),
+        encoding="utf-8",
+    )
+    dashboard = {
+        "action": "http_request",
+        "task_id": "stateful-session",
+        "method": "GET",
+        "path": "/dashboard",
+    }
+    model = ScriptedModelClient(
+        [
+            dashboard,
+            {
+                "action": "http_request",
+                "task_id": "stateful-session",
+                "method": "POST",
+                "path": "/login",
+                "form": {"username": "user", "password": "pass"},
+            },
+            dashboard,
+            {"action": "final", "summary": "session replay complete"},
+        ]
+    )
+    workspace_dir = tmp_path / "workspace"
+
+    run_ai_web_agent(
+        brief_path=brief_path,
+        target_url=stateful_http_target.url,
+        settings=AIWebAgentSettings(
+            tool_runtime_mode="host",
+            tool_runtime=NoProcessToolRuntime(),
+            db_path=tmp_path / "audit.db",
+            workspace_dir=workspace_dir,
+            model_client=model,
+            stdout=StringIO(),
+            max_turns=4,
+        ),
+    )
+
+    events = [
+        json.loads(line)
+        for line in (workspace_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    selections = [
+        event["payload"] for event in events if event["kind"] == "agent_action_selected"
+    ]
+    http_selections = [
+        item for item in selections if item["action"]["action"] == "http_request"
+    ]
+    assert [item["repeat_count"] for item in http_selections] == [1, 1, 1]
+    assert http_selections[0]["action"]["path"] == "/dashboard"
+    assert http_selections[2]["action"]["path"] == "/dashboard"
+    assert stateful_http_target.requests == [
+        {"method": "GET", "path": "/dashboard", "cookie": ""},
+        {
+            "method": "POST",
+            "path": "/login",
+            "cookie": "",
+            "form": {"username": ["user"], "password": ["pass"]},
+        },
+        {
+            "method": "GET",
+            "path": "/dashboard",
+            "cookie": "session=persistent",
+        },
+    ]
+    saved = json.loads((workspace_dir / "working_state.json").read_text(encoding="utf-8"))
+    assert saved["state"]["surface"]["http_state_epoch"] == 1
+
+
+def test_default_structured_http_ceiling_is_independent_of_max_turns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ceilings: list[int] = []
+
+    class RecordingHttpSession:
+        def __init__(self, **kwargs: object) -> None:
+            ceilings.append(int(kwargs["max_total_requests"]))
+
+        def finalize(self) -> None:
+            return None
+
+    monkeypatch.setattr(ai_agent, "_seed_recon", lambda **_kwargs: None)
+    monkeypatch.setattr(ai_agent, "refresh_mission_board", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ai_agent, "StatefulHttpActionSession", RecordingHttpSession)
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
+
+    for max_turns in (1, 73):
+        run_ai_web_agent(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            settings=AIWebAgentSettings(
+                tool_runtime_mode="host",
+                tool_runtime=NoProcessToolRuntime(),
+                db_path=tmp_path / f"audit-{max_turns}.db",
+                workspace_dir=tmp_path / f"workspace-{max_turns}",
+                model_client=ScriptedModelClient(
+                    [{"action": "final", "summary": "setup captured"}]
+                ),
+                stdout=StringIO(),
+                max_turns=max_turns,
+            ),
+        )
+
+    assert ceilings == [10_000, 10_000]
+
+
+def test_partial_http_resume_closes_owned_runtime_before_raising(tmp_path: Path) -> None:
+    target_url = "http://127.0.0.1:8765"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
+    state_path = workspace_dir / "working_state.json"
+    save_agent_state(state_path, target_url=target_url, state=AgentState())
+    TrafficPolicyController.open(
+        workspace_dir / "traffic-policy.json",
+        target_url=target_url,
+        config=TrafficPolicyConfig(mode=TrafficPolicyMode.OBSERVE),
+    )
+    # Deliberately interrupted lane: request state exists, while its traffic
+    # history and evidence ledger do not.
+    (workspace_dir / "agent-http-state.json").write_text("{}\n", encoding="utf-8")
+
+    class ClosingRuntime:
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        def close(self) -> None:
+            self.close_count += 1
+
+    runtime = ClosingRuntime()
+    with pytest.raises(
+        RuntimeError,
+        match="structured HTTP resume requires request state, traffic history, and evidence",
+    ):
+        run_ai_web_agent(
+            brief_path=brief_path,
+            target_url=target_url,
+            settings=AIWebAgentSettings(
+                workspace_dir=workspace_dir,
+                resume_from=state_path,
+                tool_runtime=runtime,
+                tool_runtime_mode="host",
+                model_client=object(),
+                stdout=StringIO(),
+            ),
+        )
+
+    assert runtime.close_count == 1
+
+
+def test_startup_validation_failure_finalizes_all_open_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_url = "http://127.0.0.1:8765"
+    workspace_dir = tmp_path / "workspace"
+    brief_path = tmp_path / "brief.yaml"
+    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
+
+    class ClosingRuntime:
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        def close(self) -> None:
+            self.close_count += 1
+
+    class ClosingHttpSession:
+        def __init__(self, **_kwargs: object) -> None:
+            self.finalize_count = 0
+            sessions.append(self)
+
+        def finalize(self) -> None:
+            self.finalize_count += 1
+
+    sessions: list[ClosingHttpSession] = []
+    monkeypatch.setattr(ai_agent, "StatefulHttpActionSession", ClosingHttpSession)
+    ordinary_audit_close = AuditStore.close
+
+    def close_audit_then_fail(store: AuditStore) -> None:
+        ordinary_audit_close(store)
+        raise OSError("audit-close-secondary")
+
+    monkeypatch.setattr(ai_agent.AuditStore, "close", close_audit_then_fail)
+
+    runtime = ClosingRuntime()
+    with pytest.raises(
+        ValueError,
+        match="digest requires a knowledge-pack path",
+    ) as error:
+        run_ai_web_agent(
+            brief_path=brief_path,
+            target_url=target_url,
+            settings=AIWebAgentSettings(
+                workspace_dir=workspace_dir,
+                tool_runtime=runtime,
+                tool_runtime_mode="host",
+                model_client=object(),
+                knowledge_pack_sha256="0" * 64,
+                stdout=StringIO(),
+            ),
+        )
+
+    assert runtime.close_count == 1
+    assert len(sessions) == 1
+    assert sessions[0].finalize_count == 1
+    assert any(
+        "audit store cleanup also failed: OSError" in note
+        for note in getattr(error.value, "__notes__", ())
+    )
+
+
+def test_validate_poc_captures_executor_proof_beyond_validator_summary(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+        proof_recognition_enabled=True,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {
+                "action": "validate_poc",
+                "task_id": "flag-and-secret-sweep",
+                "steps": [
+                    {
+                        "method": "GET",
+                        "url": "/long-proof",
+                        "expect_status": 200,
+                    }
+                ],
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            proof_recognition_enabled=True,
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="late-proof-validation",
+            http_executor=http_session,
+        )
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.ok is True
+    assert outcome.stop is True
+    assert outcome.outcome == "flag_candidate"
+    assert outcome.flag == _LATE_RESPONSE_PROOF
+    assert state.flags == [_LATE_RESPONSE_PROOF]
+    assert _LATE_RESPONSE_PROOF not in outcome.evidence_observation
+    validation = json.loads(outcome.evidence_observation)
+    response_summary = validation["steps"][0]["response"]
+    assert response_summary["body_len"] > 300
+    assert "...[truncated" in response_summary["body_snippet"]
+    events = [
+        json.loads(line)
+        for line in workspace.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    outer = next(event for event in events if event["kind"] == "tool_validate_poc")
+    assert outer["payload"]["recognized_proofs"] == [_LATE_RESPONSE_PROOF]
+
+
+def test_validate_poc_does_not_capture_proof_from_authored_expectation(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState()
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+        proof_recognition_enabled=True,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            {
+                "action": "validate_poc",
+                "task_id": "forged-validator-proof",
+                "steps": [
+                    {
+                        "method": "GET",
+                        "url": "/dashboard",
+                        "expect_contains": _FORGED_VALIDATOR_PROOF,
+                    }
+                ],
+            },
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            proof_recognition_enabled=True,
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="forged-validator-proof",
+            http_executor=http_session,
+        )
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.stop is False
+    assert outcome.flag == ""
+    assert state.flags == []
+    assert _FORGED_VALIDATOR_PROOF not in outcome.evidence_observation
+    assert "[REDACTED-PROOF]" in outcome.evidence_observation
+    events = [
+        json.loads(line)
+        for line in workspace.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    outer = next(event for event in events if event["kind"] == "tool_validate_poc")
+    assert outer["payload"]["recognized_proofs"] == []
+
+
+def test_low_noise_http_does_not_replay_pre_login_get_after_cookie_transition(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    traffic_policy = TrafficPolicyController.open(
+        workspace.root / "traffic-policy.json",
+        target_url=target_url,
+        config=TrafficPolicyConfig.low_noise(
+            max_physical_requests=10,
+            max_rps=100,
+        ),
+    )
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=AgentState(),
+        traffic_policy=traffic_policy,
+        low_noise=True,
+    )
+
+    try:
+        before_login = http_session(
+            node_id="base-agent",
+            arguments={"method": "GET", "path": "/dashboard"},
+            action_id="dashboard-before-login",
+        )
+        http_session(
+            node_id="base-agent",
+            arguments={
+                "method": "POST",
+                "path": "/login",
+                "form": {"username": "user", "password": "pass"},
+            },
+            action_id="login",
+        )
+        after_login = http_session(
+            node_id="base-agent",
+            arguments={"method": "GET", "path": "/dashboard"},
+            action_id="dashboard-after-login",
+        )
+    finally:
+        http_session.finalize()
+
+    assert json.loads(before_login.result.evidence_observation)["response"]["body"] == (
+        "public login shell"
+    )
+    assert json.loads(after_login.result.evidence_observation)["response"]["body"] == (
+        "authenticated dashboard"
+    )
+    assert stateful_http_target.requests == [
+        {"method": "GET", "path": "/dashboard", "cookie": ""},
+        {
+            "method": "POST",
+            "path": "/login",
+            "cookie": "",
+            "form": {"username": ["user"], "password": ["pass"]},
+        },
+        {
+            "method": "GET",
+            "path": "/dashboard",
+            "cookie": "session=persistent",
+        },
+    ]
+    snapshot = traffic_policy.snapshot()
+    assert snapshot.physical_request_count == 3
+    assert snapshot.cache_hit_count == 0
+
+
+def test_http_request_visible_request_cannot_promote_file_read_primitive() -> None:
+    state = AgentState(turn=1)
+    action = {
+        "action": "http_request",
+        "method": "GET",
+        "path": "/?q=root:x:0:0:",
+    }
+    outcome = {
+        "ok": True,
+        "observation": json.dumps(
+            {
+                "requests": [{"url": "http://target.invalid/?q=root:x:0:0:"}],
+                "response": {"body": "clean response", "status": 200},
+            }
+        ),
+        "stop": False,
+        "exit_code": None,
+        "timed_out": False,
+        "repeat_count": 1,
+        "outcome": "http_response_observed",
+        "flag": "",
+    }
+
+    _update_state_from_action(state, action=action, outcome=outcome)
+
+    assert "local file read evidence observed" not in state.facts
+    assert "file_read_confirmed" not in state.primitives
+
+
+def test_reflected_ssti_text_from_raw_http_cannot_confirm_primitive(
+    tmp_path: Path,
+    stateful_http_target: _HttpTarget,
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "workspace")
+    target_url = stateful_http_target.url
+    scope = Scope(in_scope=[target_url], out_of_scope=[])
+    state = AgentState(turn=1)
+    action = {
+        "action": "http_request",
+        "task_id": "server-rendering",
+        "method": "GET",
+        "path": "/reflect?value=%7B%7B7*7%7D%7D",
+    }
+    http_session = StatefulHttpActionSession(
+        target_url=target_url,
+        scope=scope,
+        allow_remote_target=False,
+        roe_max_rps=100,
+        max_total_requests=10,
+        workspace_dir=workspace.root,
+        state=state,
+    )
+    audit = AuditStore(tmp_path / "audit.db", scope=scope)
+    try:
+        outcome = execute_action(
+            action,
+            target_url=target_url,
+            runtime=NoProcessToolRuntime(),
+            state=state,
+            workspace=workspace,
+            audit=audit,
+            engagement_id=uuid4(),
+            repeat_count=1,
+            max_observation_chars=4_000,
+            max_transcript_chars=20_000,
+            action_id="reflected-ssti",
+            http_executor=http_session,
+        )
+        _update_state_from_action(state, action=action, outcome=outcome.to_json())
+    finally:
+        http_session.finalize()
+        audit.close()
+
+    assert outcome.ok is True
+    assert "hello {{7*7}} response 49" in outcome.evidence_observation
+    assert "ssti_fingerprint_signal" not in state.signals.get("markers", [])
+    assert "ssti_confirmed" not in state.primitives

--- a/packages/ravage/tests/test_surface_graph.py
+++ b/packages/ravage/tests/test_surface_graph.py
@@ -145,6 +145,99 @@ def test_exchange_ingestion_keeps_shapes_but_never_values_or_bodies() -> None:
         assert secret not in serialized
 
 
+@pytest.mark.parametrize("response_status", [200, 204, 300, 399])
+def test_successful_agent_http_exchange_promotes_method_and_route(
+    response_status: int,
+) -> None:
+    exchange = build_captured_http_exchange(
+        capture_session_id="agent-http-success",
+        source="agent_http",
+        source_observation_id="agent-http-observation",
+        method="PATCH",
+        url=f"{TARGET}/confirmed-route",
+        request_sent=True,
+        response_status=response_status,
+        response_final_url=f"{TARGET}/confirmed-route",
+        scope_decision="allowed",
+    ).with_store_identity(exchange_id="rq_0001", sequence=1)
+    graph = SurfaceGraphState.for_target(TARGET)
+
+    operation = graph.ingest_exchange(exchange)
+
+    assert operation.method == "PATCH"
+    assert operation.route_shape == "/confirmed-route"
+    assert operation.provenance == ("agent_http_response",)
+    assert operation.actionable is True
+    projected = project_surface_graph(graph)
+    assert {item["url"] for item in projected["endpoints"]} == {
+        f"{TARGET}/confirmed-route"
+    }
+
+
+def test_successful_agent_http_exchange_excludes_model_authored_request_metadata() -> None:
+    exchange = build_captured_http_exchange(
+        capture_session_id="agent-http-fields",
+        source="agent_http",
+        source_observation_id="agent-http-observation",
+        method="POST",
+        url=f"{TARGET}/confirmed-submit?fabricated_query=value",
+        resource_type="fabricated_hint",
+        request_headers={
+            "Content-Type": "application/json",
+            "X-Fabricated-Header": "value",
+        },
+        request_body={"invented_body_field": "value"},
+        request_sent=True,
+        response_status=201,
+        response_final_url=f"{TARGET}/confirmed-submit",
+        scope_decision="allowed",
+    ).with_store_identity(exchange_id="rq_0001", sequence=1)
+    graph = SurfaceGraphState.for_target(TARGET)
+
+    operation = graph.ingest_exchange(exchange)
+
+    assert operation.parameters == ()
+    assert operation.content_types == ()
+    assert operation.header_names == ()
+    assert operation.hints == ()
+    serialized = json.dumps(graph.to_json())
+    for model_authored_value in (
+        "fabricated_query",
+        "invented_body_field",
+        "x-fabricated-header",
+        "application/json",
+        "fabricated_hint",
+    ):
+        assert model_authored_value not in serialized
+
+
+@pytest.mark.parametrize("response_status", [None, 199, 400, 599])
+def test_agent_http_without_successful_response_remains_non_actionable(
+    response_status: int | None,
+) -> None:
+    exchange = build_captured_http_exchange(
+        capture_session_id="agent-http-failure",
+        source="agent_http",
+        source_observation_id="agent-http-observation",
+        method="GET",
+        url=f"{TARGET}/unconfirmed-route?fabricated_query=value",
+        request_headers={"X-Fabricated-Header": "value"},
+        request_sent=True,
+        response_status=response_status,
+        response_final_url=f"{TARGET}/unconfirmed-route" if response_status is not None else "",
+        scope_decision="allowed",
+    ).with_store_identity(exchange_id="rq_0001", sequence=1)
+    graph = SurfaceGraphState.for_target(TARGET)
+
+    operation = graph.ingest_exchange(exchange)
+
+    assert operation.provenance == ("probe",)
+    assert operation.actionable is False
+    assert operation.parameters == ()
+    assert operation.header_names == ()
+    assert project_surface_graph(graph)["endpoints"] == []
+
+
 def test_recon_javascript_openapi_and_graphql_feed_one_graph() -> None:
     graph = SurfaceGraphState.for_target(TARGET)
     ingest_recon_surface(

--- a/packages/ravage/tests/test_traffic_provenance.py
+++ b/packages/ravage/tests/test_traffic_provenance.py
@@ -269,6 +269,71 @@ def test_cli_exposes_only_identifier_provenance_for_valid_blackboards(
     assert _SECRET not in human
 
 
+def test_cli_validates_provenance_independently_for_both_traffic_lanes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_dir, base_workspace, base_store = _run(tmp_path)
+    _base_board, base_refs = _blackboard(
+        base_workspace,
+        observation_id="http:base-observation",
+    )
+    _append_exchange(
+        base_store,
+        observation_id="http:base-observation",
+        path="/base-proof",
+    )
+
+    graph_workspace = base_workspace / "autonomous-route" / "agent-graph"
+    graph_store = TrafficStore.create(graph_workspace)
+    write_traffic_manifest(
+        graph_workspace,
+        TrafficRunManifest.create(
+            target_url=_TARGET_URL,
+            capture_session_id=_CAPTURE_SESSION_ID,
+        ).complete(),
+    )
+    _graph_board, graph_refs = _blackboard(
+        graph_workspace,
+        observation_id="http:graph-observation",
+    )
+    _append_exchange(
+        graph_store,
+        observation_id="http:graph-observation",
+        path="/graph-proof",
+    )
+
+    main(["traffic", "list", str(run_dir), "--json"])
+    output = capsys.readouterr().out
+    requests = json.loads(output)["requests"]
+
+    assert [item["id"] for item in requests] == [
+        "base:rq_0001",
+        "autonomous_graph:rq_0001",
+    ]
+    assert requests[0]["agent_evidence"]["evidence_refs"] == list(base_refs)
+    assert requests[1]["agent_evidence"]["evidence_refs"] == list(graph_refs)
+    assert all(item["agent_evidence"]["status"] == "linked" for item in requests)
+    assert _SECRET not in output
+
+    main(
+        [
+            "traffic",
+            "show",
+            str(run_dir),
+            "autonomous_graph:rq_0001",
+            "--json",
+        ]
+    )
+    shown_text = capsys.readouterr().out
+    shown = json.loads(shown_text)
+    assert shown["lane"] == "autonomous_graph"
+    assert shown["agent_evidence"]["blackboard_path"] == str(
+        graph_workspace / "evidence-blackboard.json"
+    )
+    assert _SECRET not in shown_text
+
+
 def test_query_target_uses_one_way_manifest_identity_for_the_join(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/packages/ravage/tests/test_traffic_workflow.py
+++ b/packages/ravage/tests/test_traffic_workflow.py
@@ -4,11 +4,13 @@ import json
 import multiprocessing
 import os
 import threading
+from dataclasses import replace
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
 import ravage.__main__ as cli
+import ravage.traffic.cli as traffic_cli_module
 import ravage.traffic.store as traffic_store_module
 from ravage.__main__ import main
 from ravage.probe_suite_parts.result import ProbeRunResult
@@ -23,6 +25,7 @@ from ravage.traffic.manifest import (
     TrafficRunManifest,
     read_traffic_manifest,
     resolve_workspace,
+    resolve_workspaces,
     write_traffic_manifest,
 )
 from ravage.traffic.recorders import BrowserExchangeRecorder, ProbeTrafficRecorder
@@ -36,6 +39,7 @@ if TYPE_CHECKING:
 _OK_STATUS = 200
 _PRIVATE_FILE_MODE = 0o600
 _CAPTURED_REQUESTS = 2
+_ARGPARSE_ERROR = 2
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -124,12 +128,13 @@ def _exchange(
     method: str = "GET",
     body: bytes | None = None,
     unresolved_slots: tuple[str, ...] = (),
+    capture_session_id: str = "browser-test",
 ) -> CapturedHttpExchange:
     headers = {"Accept": "application/json"}
     if body is not None:
         headers["Content-Type"] = "application/json"
     return build_captured_http_exchange(
-        capture_session_id="browser-test",
+        capture_session_id=capture_session_id,
         source="browser",
         method=method,
         url=url,
@@ -208,7 +213,158 @@ def test_workspace_resolution_finds_nested_agent_graph_and_refuses_ambiguity(
 
     with pytest.raises(TrafficRunError, match="multiple traffic histories"):
         resolve_workspace(run_dir)
+    assert resolve_workspaces(run_dir) == (
+        base_workspace.resolve(),
+        graph_workspace.resolve(),
+    )
+    assert resolve_workspace(base_workspace) == base_workspace.resolve()
     assert resolve_workspace(graph_workspace) == graph_workspace.resolve()
+
+
+def test_workspace_resolution_preserves_a_contained_relative_manifest_workspace(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "legacy-run"
+    workspace = run_dir / "custom-workspace"
+    store = TrafficStore.create(workspace)
+    write_traffic_manifest(
+        workspace,
+        TrafficRunManifest.create(
+            target_url="http://127.0.0.1:4321/",
+            capture_session_id="legacy-layout",
+        ).complete(),
+    )
+    run_dir.joinpath("run.json").write_text(
+        json.dumps({"workspace_dir": "custom-workspace"}),
+        encoding="utf-8",
+    )
+    store.append_exchange(
+        _exchange(
+            "http://127.0.0.1:4321/custom",
+            capture_session_id="legacy-layout",
+        )
+    )
+
+    assert resolve_workspaces(run_dir) == (workspace.resolve(),)
+    assert resolve_workspace(run_dir) == workspace.resolve()
+
+
+def test_plural_workspace_resolution_returns_empty_without_traffic(tmp_path: Path) -> None:
+    empty_run = tmp_path / "empty-run"
+    empty_run.mkdir()
+
+    assert resolve_workspaces(empty_run) == ()
+
+
+def test_plural_workspace_resolution_fails_closed_for_malformed_or_mismatched_lanes(
+    tmp_path: Path,
+) -> None:
+    run_dir, _base_store = _traffic_run(tmp_path, "http://127.0.0.1:4321")
+    base_workspace = run_dir / "workspace"
+    graph_workspace = base_workspace / "autonomous-route" / "agent-graph"
+    TrafficStore.create(graph_workspace)
+
+    # An explicitly supplied valid workspace remains usable, but a run-root
+    # aggregation cannot silently ignore the asserted malformed graph lane.
+    assert resolve_workspace(base_workspace) == base_workspace.resolve()
+    with pytest.raises(TrafficRunError, match="no traffic history found"):
+        resolve_workspaces(run_dir)
+
+    base_manifest = read_traffic_manifest(base_workspace)
+    forged_graph_manifest = replace(
+        TrafficRunManifest.create(
+            target_url="http://127.0.0.1:4321/different-target",
+            capture_session_id="mismatched-graph",
+        ).complete(),
+        target_identity=base_manifest.target_identity,
+    )
+    write_traffic_manifest(graph_workspace, forged_graph_manifest)
+    with pytest.raises(TrafficRunError, match="disagree on target or scope"):
+        resolve_workspaces(run_dir)
+
+
+def test_run_root_cli_rejects_http_state_whose_traffic_lane_is_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_dir, _base_store = _traffic_run(tmp_path, "http://127.0.0.1:4321")
+    graph_workspace = run_dir / "workspace" / "autonomous-route" / "agent-graph"
+    graph_workspace.mkdir(parents=True)
+    state_path = graph_workspace / "graph-http-state.json"
+    state_path.write_text('{"version":2,"target_identity":"target:marker"}\n', encoding="utf-8")
+    state_path.chmod(_PRIVATE_FILE_MODE)
+
+    with pytest.raises(
+        TrafficRunError,
+        match="durable HTTP state exists without its canonical traffic history",
+    ):
+        resolve_workspaces(run_dir)
+    with pytest.raises(SystemExit) as stopped:
+        main(["traffic", "list", str(run_dir), "--json"])
+
+    assert stopped.value.code == _ARGPARSE_ERROR
+    assert "durable HTTP state exists without its canonical traffic history" in (
+        capsys.readouterr().err
+    )
+
+
+def test_run_root_cli_rejects_a_looping_canonical_workspace_symlink(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_dir, _base_store = _traffic_run(tmp_path, "http://127.0.0.1:4321")
+    graph_parent = run_dir / "workspace" / "autonomous-route"
+    graph_parent.mkdir(parents=True)
+    (graph_parent / "agent-graph").symlink_to("agent-graph", target_is_directory=True)
+
+    with pytest.raises(
+        TrafficRunError,
+        match="could not resolve canonical traffic workspace",
+    ):
+        resolve_workspaces(run_dir)
+    with pytest.raises(SystemExit) as stopped:
+        main(["traffic", "list", str(run_dir), "--json"])
+
+    assert stopped.value.code == _ARGPARSE_ERROR
+    error = capsys.readouterr().err
+    assert "could not resolve canonical traffic workspace" in error
+    assert "Traceback" not in error
+
+
+def test_run_root_cli_revalidates_lane_boundaries_after_resolution(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_url = "http://127.0.0.1:4321"
+    run_dir, _base_store = _traffic_run(tmp_path, target_url)
+    graph_workspace = run_dir / "workspace" / "autonomous-route" / "agent-graph"
+    TrafficStore.create(graph_workspace)
+    write_traffic_manifest(
+        graph_workspace,
+        TrafficRunManifest.create(
+            target_url=target_url,
+            capture_session_id="agent-graph-test",
+        ).complete(),
+    )
+    original_resolver = traffic_cli_module.resolve_workspaces
+
+    def resolve_then_tamper(supplied: Path) -> tuple[Path, ...]:
+        resolved = original_resolver(supplied)
+        manifest_path = graph_workspace / "traffic" / "run.json"
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["target_url"] = f"{target_url}/different-target"
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+        manifest_path.chmod(_PRIVATE_FILE_MODE)
+        return resolved
+
+    monkeypatch.setattr(traffic_cli_module, "resolve_workspaces", resolve_then_tamper)
+
+    with pytest.raises(SystemExit) as stopped:
+        main(["traffic", "list", str(run_dir), "--json"])
+
+    assert stopped.value.code == _ARGPARSE_ERROR
+    assert "traffic histories disagree on target or scope" in capsys.readouterr().err
 
 
 def test_manifest_rejects_dynamic_scope_paths_and_refuses_external_pointer(
@@ -1082,6 +1238,127 @@ def test_traffic_cli_lists_shows_and_diffs_without_network(
     assert listing["requests"][0]["id"] == "rq_0001"
     assert shown["exchange"]["exchange_id"] == "rq_0001"
     assert difference["right"]["id"] == "rp_0001"
+
+
+def test_traffic_cli_qualifies_and_routes_duplicate_ids_across_both_lanes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target_url = "http://127.0.0.1:4321"
+    run_dir, base_store = _traffic_run(tmp_path, target_url)
+    graph_workspace = run_dir / "workspace" / "autonomous-route" / "agent-graph"
+    graph_store = TrafficStore.create(graph_workspace)
+    write_traffic_manifest(
+        graph_workspace,
+        TrafficRunManifest.create(
+            target_url=target_url,
+            capture_session_id="agent-graph-test",
+        ).complete(),
+    )
+    base_store.append_exchange(_exchange(f"{target_url}/base"))
+    base_store.append_exchange(_exchange(f"{target_url}/base-only"))
+    graph_store.append_exchange(
+        _exchange(
+            f"{target_url}/graph?token=%5BREDACTED%5D",
+            unresolved_slots=("query.token",),
+            capture_session_id="agent-graph-test",
+        )
+    )
+
+    main(["traffic", "list", str(run_dir), "--json"])
+    listing = json.loads(capsys.readouterr().out)
+
+    assert [item["id"] for item in listing["requests"]] == [
+        "base:rq_0001",
+        "base:rq_0002",
+        "autonomous_graph:rq_0001",
+    ]
+    assert [item["lane"] for item in listing["requests"]] == [
+        "base",
+        "base",
+        "autonomous_graph",
+    ]
+    assert [item["lane"] for item in listing["workspaces"]] == [
+        "base",
+        "autonomous_graph",
+    ]
+
+    main(["traffic", "list", str(run_dir / "workspace"), "--json"])
+    explicit_base = json.loads(capsys.readouterr().out)
+    assert [item["id"] for item in explicit_base["requests"]] == ["rq_0001", "rq_0002"]
+    assert all("lane" not in item for item in explicit_base["requests"])
+    assert "workspaces" not in explicit_base
+
+    with pytest.raises(SystemExit) as ambiguous:
+        main(["traffic", "show", str(run_dir), "rq_0001", "--json"])
+    assert ambiguous.value.code == _ARGPARSE_ERROR
+    ambiguity_error = capsys.readouterr().err
+    assert "request ID rq_0001 is ambiguous" in ambiguity_error
+    assert "base:rq_0001" in ambiguity_error
+    assert "autonomous_graph:rq_0001" in ambiguity_error
+
+    main(["traffic", "show", str(run_dir), "rq_0002", "--json"])
+    unique = json.loads(capsys.readouterr().out)
+    assert unique["lane"] == "base"
+    assert unique["qualified_id"] == "base:rq_0002"
+
+    main(
+        [
+            "traffic",
+            "show",
+            str(run_dir),
+            "autonomous_graph:rq_0001",
+            "--json",
+        ]
+    )
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["lane"] == "autonomous_graph"
+    assert shown["qualified_id"] == "autonomous_graph:rq_0001"
+    assert shown["exchange"]["request"]["url"].startswith(f"{target_url}/graph")
+
+    with pytest.raises(SystemExit) as blocked:
+        main(
+            [
+                "traffic",
+                "replay",
+                str(run_dir),
+                "autonomous_graph:rq_0001",
+                "--json",
+            ]
+        )
+    assert blocked.value.code == _ARGPARSE_ERROR
+    replay = json.loads(capsys.readouterr().out)
+    assert replay["lane"] == "autonomous_graph"
+    assert replay["qualified_id"] == "autonomous_graph:rp_0001"
+    assert replay["source_request_ref"] == "autonomous_graph:rq_0001"
+
+    main(
+        [
+            "traffic",
+            "diff",
+            str(run_dir),
+            "autonomous_graph:rq_0001",
+            "autonomous_graph:rp_0001",
+            "--json",
+        ]
+    )
+    difference = json.loads(capsys.readouterr().out)
+    assert difference["lane"] == "autonomous_graph"
+    assert difference["left_ref"] == "autonomous_graph:rq_0001"
+    assert difference["right_ref"] == "autonomous_graph:rp_0001"
+
+    with pytest.raises(SystemExit) as cross_lane:
+        main(
+            [
+                "traffic",
+                "diff",
+                str(run_dir),
+                "base:rq_0001",
+                "autonomous_graph:rq_0001",
+            ]
+        )
+    assert cross_lane.value.code == _ARGPARSE_ERROR
+    assert "same lane/store" in capsys.readouterr().err
 
 
 def test_show_prints_a_complete_remote_mutation_replay_skeleton(

--- a/scripts/check_pypi_version.py
+++ b/scripts/check_pypi_version.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+if __name__ == "__main__":
+    runpy.run_path(
+        str(Path(__file__).resolve().parent / "qa" / "check_pypi_version.py"),
+        run_name="__main__",
+    )

--- a/scripts/qa/check_pypi_version.py
+++ b/scripts/qa/check_pypi_version.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INDEX_BASE = "https://pypi.org/pypi"
+HTTP_OK = 200
+HTTP_NOT_FOUND = 404
+PACKAGES = (
+    ROOT / "packages/schemas/pyproject.toml",
+    ROOT / "packages/ravage/pyproject.toml",
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when a local package version is already occupied on PyPI."
+    )
+    parser.add_argument(
+        "--index-base",
+        default=DEFAULT_INDEX_BASE,
+        help="JSON API base URL (default: %(default)s)",
+    )
+    parsed = parser.parse_args(argv)
+
+    errors: list[str] = []
+    checked: list[str] = []
+    for pyproject_path in PACKAGES:
+        project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]
+        name = str(project["name"])
+        version = str(project["version"])
+        checked.append(f"{name}=={version}")
+        try:
+            url = _release_url(parsed.index_base, name, version)
+            status = _release_status(url)
+        except RegistryCheckError as exc:
+            errors.append(f"{name}=={version}: {exc}")
+            continue
+        if status == HTTP_OK:
+            errors.append(
+                f"{name}=={version} already exists at {url}; "
+                "published versions are immutable"
+            )
+        elif status != HTTP_NOT_FOUND:
+            errors.append(f"{name}=={version}: registry returned HTTP {status} for {url}")
+
+    if errors:
+        for error in errors:
+            sys.stderr.write(f"PyPI version check failed: {error}\n")
+        return 1
+
+    sys.stdout.write(f"PyPI version check passed: {', '.join(checked)} are unused\n")
+    return 0
+
+
+def _release_url(index_base: str, name: str, version: str) -> str:
+    base = index_base.rstrip("/")
+    parsed = urllib.parse.urlparse(base)
+    if parsed.scheme != "https" or not parsed.netloc:
+        message = "registry JSON API must use an absolute HTTPS URL"
+        raise RegistryCheckError(message)
+    quoted_name = urllib.parse.quote(name, safe="")
+    quoted_version = urllib.parse.quote(version, safe="")
+    return f"{base}/{quoted_name}/{quoted_version}/json"
+
+
+def _release_status(url: str) -> int:
+    request = urllib.request.Request(  # noqa: S310 - HTTPS is validated above.
+        url,
+        headers={"User-Agent": "ravage-release-check/1"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:  # noqa: S310
+            return int(response.status)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code)
+    except (OSError, urllib.error.URLError) as exc:
+        message = f"could not verify registry state: {exc}"
+        raise RegistryCheckError(message) from exc
+
+
+class RegistryCheckError(RuntimeError):
+    """Raised when registry occupancy cannot be verified safely."""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qa/check_release.py
+++ b/scripts/qa/check_release.py
@@ -25,6 +25,12 @@ PACKAGES = (
         ROOT / "packages/ravage/src/ravage/_version.py",
     ),
 )
+ROOT_PYPROJECT = ROOT / "pyproject.toml"
+CITATION_FILE = ROOT / "CITATION.cff"
+RELEASE_MANIFEST = ROOT / "tools/release/.release-please-manifest.json"
+LOCK_FILE = ROOT / "uv.lock"
+CHANGELOG_FILE = ROOT / "CHANGELOG.md"
+WORKSPACE_PROJECTS = ("pentest-agent", "ravage", "ravage-schemas")
 
 
 def main() -> int:
@@ -62,7 +68,9 @@ def main() -> int:
         )
 
     expected = next(iter(versions.values()))
+    errors.extend(_workspace_version_errors(expected))
     errors.extend(_release_ref_errors(expected, os.environ))
+    errors.extend(_release_changelog_errors(expected, os.environ))
 
     if errors:
         for error in errors:
@@ -71,6 +79,39 @@ def main() -> int:
 
     sys.stdout.write(f"release check passed: {next(iter(versions.values()))}\n")
     return 0
+
+
+def _workspace_version_errors(expected: str) -> list[str]:
+    declared: dict[str, str] = {}
+    root_project = tomllib.loads(ROOT_PYPROJECT.read_text(encoding="utf-8"))["project"]
+    declared[str(root_project["name"])] = str(root_project["version"])
+
+    manifest = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))
+    manifest_version = manifest.get(".") if isinstance(manifest, dict) else None
+    declared["release-please manifest"] = str(manifest_version)
+
+    citation_match = re.search(
+        r"^version:\s*['\"]?([^\s'\"]+)",
+        CITATION_FILE.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    declared["CITATION.cff"] = citation_match.group(1) if citation_match else "<missing>"
+
+    lock = tomllib.loads(LOCK_FILE.read_text(encoding="utf-8"))
+    locked_packages = lock.get("package", [])
+    for project_name in WORKSPACE_PROJECTS:
+        matches = [
+            str(item.get("version"))
+            for item in locked_packages
+            if isinstance(item, dict) and item.get("name") == project_name
+        ]
+        declared[f"uv.lock:{project_name}"] = matches[0] if len(matches) == 1 else "<missing>"
+
+    return [
+        f"{source} version {version!r} does not match package version {expected!r}"
+        for source, version in declared.items()
+        if version != expected
+    ]
 
 
 def _release_ref_errors(expected_version: str, environ: Mapping[str, str]) -> list[str]:
@@ -84,6 +125,28 @@ def _release_ref_errors(expected_version: str, environ: Mapping[str, str]) -> li
     if tag != expected_tag:
         return [f"release tag {tag!r} does not match package version {expected_tag}"]
     return []
+
+
+def _release_changelog_errors(
+    expected_version: str,
+    environ: Mapping[str, str],
+) -> list[str]:
+    is_tag_context, _ = _github_tag_context(environ)
+    if not is_tag_context:
+        return []
+    escaped = re.escape(expected_version)
+    plain_heading = re.compile(rf"^## {escaped} - \d{{4}}-\d{{2}}-\d{{2}}$", re.MULTILINE)
+    linked_heading = re.compile(
+        rf"^## \[{escaped}\]\([^\n)]+\) \(\d{{4}}-\d{{2}}-\d{{2}}\)$",
+        re.MULTILINE,
+    )
+    changelog = CHANGELOG_FILE.read_text(encoding="utf-8")
+    if plain_heading.search(changelog) or linked_heading.search(changelog):
+        return []
+    return [
+        f"CHANGELOG.md is missing a dated {expected_version} release heading; "
+        "move the release notes out of Unreleased before tagging"
+    ]
 
 
 def _github_tag_context(environ: Mapping[str, str]) -> tuple[bool, str | None]:

--- a/tests/test_pypi_version_check.py
+++ b/tests/test_pypi_version_check.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.qa import check_pypi_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.capture import CaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+
+EXPECTED_PACKAGE_COUNT = 2
+
+
+def _package(tmp_path: Path, *, name: str, version: str) -> Path:
+    path = tmp_path / f"{name}.toml"
+    path.write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_both_unused_versions_pass(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    packages = (
+        _package(tmp_path, name="ravage-schemas", version="0.6.0"),
+        _package(tmp_path, name="ravage", version="0.6.0"),
+    )
+    checked_urls: list[str] = []
+
+    def unused(url: str) -> int:
+        checked_urls.append(url)
+        return 404
+
+    monkeypatch.setattr(check_pypi_version, "PACKAGES", packages)
+    monkeypatch.setattr(check_pypi_version, "_release_status", unused)
+
+    assert check_pypi_version.main([]) == 0
+    assert len(checked_urls) == EXPECTED_PACKAGE_COUNT
+    output = capsys.readouterr().out
+    assert "ravage-schemas==0.6.0" in output
+    assert "ravage==0.6.0" in output
+
+
+def test_occupied_version_fails(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    packages = (_package(tmp_path, name="ravage", version="0.5.0"),)
+    monkeypatch.setattr(check_pypi_version, "PACKAGES", packages)
+    monkeypatch.setattr(check_pypi_version, "_release_status", lambda _url: 200)
+
+    assert check_pypi_version.main([]) == 1
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_registry_failure_fails_closed(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    packages = (_package(tmp_path, name="ravage", version="0.6.0"),)
+    monkeypatch.setattr(check_pypi_version, "PACKAGES", packages)
+
+    def fail(_url: str) -> int:
+        message = "offline"
+        raise check_pypi_version.RegistryCheckError(message)
+
+    monkeypatch.setattr(check_pypi_version, "_release_status", fail)
+
+    assert check_pypi_version.main([]) == 1
+    assert "offline" in capsys.readouterr().err
+
+
+def test_unexpected_registry_status_fails_closed(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    packages = (_package(tmp_path, name="ravage", version="0.6.0"),)
+    monkeypatch.setattr(check_pypi_version, "PACKAGES", packages)
+    monkeypatch.setattr(check_pypi_version, "_release_status", lambda _url: 503)
+
+    assert check_pypi_version.main([]) == 1
+    assert "HTTP 503" in capsys.readouterr().err
+
+
+def test_release_url_requires_absolute_https_and_quotes_components() -> None:
+    assert check_pypi_version._release_url(  # noqa: SLF001
+        "https://example.test/pypi/", "ravage schemas", "0.6.0+local"
+    ) == "https://example.test/pypi/ravage%20schemas/0.6.0%2Blocal/json"
+
+    for invalid in ("http://example.test/pypi", "https:///pypi"):
+        with pytest.raises(check_pypi_version.RegistryCheckError):
+            check_pypi_version._release_url(invalid, "ravage", "0.6.0")  # noqa: SLF001

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -45,12 +45,33 @@ def test_published_release_accepts_exact_package_tag(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    version = _expected_tag().removeprefix("v")
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(f"# Changelog\n\n## {version} - 2026-08-30\n", encoding="utf-8")
+    monkeypatch.setattr(check_release, "CHANGELOG_FILE", changelog)
     event_path = tmp_path / "event.json"
     _write_release_event(event_path, _expected_tag())
     monkeypatch.setenv("GITHUB_EVENT_NAME", "release")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
 
     assert check_release.main() == 0
+
+
+def test_published_release_rejects_unreleased_changelog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## Unreleased\n\n- Pending.\n", encoding="utf-8")
+    monkeypatch.setattr(check_release, "CHANGELOG_FILE", changelog)
+    event_path = tmp_path / "event.json"
+    _write_release_event(event_path, _expected_tag())
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "release")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+    assert check_release.main() == 1
+    assert "missing a dated" in capsys.readouterr().err
 
 
 def test_published_release_rejects_non_v_tag(
@@ -125,3 +146,41 @@ def test_tag_push_rejects_non_release_tag(
     assert f"release tag {tag!r} does not match package version {_expected_tag()}" in (
         capsys.readouterr().err
     )
+
+
+def test_workspace_version_check_rejects_stale_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        '[project]\nname = "pentest-agent"\nversion = "0.6.0"\n',
+        encoding="utf-8",
+    )
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text("version: 0.6.0\n", encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text('{".": "0.5.0"}\n', encoding="utf-8")
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        """
+[[package]]
+name = "pentest-agent"
+version = "0.6.0"
+[[package]]
+name = "ravage"
+version = "0.6.0"
+[[package]]
+name = "ravage-schemas"
+version = "0.6.0"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_release, "ROOT_PYPROJECT", root_pyproject)
+    monkeypatch.setattr(check_release, "CITATION_FILE", citation)
+    monkeypatch.setattr(check_release, "RELEASE_MANIFEST", manifest)
+    monkeypatch.setattr(check_release, "LOCK_FILE", lock)
+
+    assert check_release._workspace_version_errors("0.6.0") == [  # noqa: SLF001
+        "release-please manifest version '0.5.0' does not match package version '0.6.0'"
+    ]

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+FULL_COMMIT_SHA = re.compile(r"[0-9a-f]{40}")
+ACTION_USE = re.compile(r"^\s*uses:\s*([^\s#]+)", re.MULTILINE)
+RELEASE_WORKFLOWS = (
+    "publish-kali-image.yml",
+    "publish-pypi.yml",
+    "publish-testpypi.yml",
+    "release-please.yml",
+)
+PRODUCTION_PYPI_PUBLISH_JOB_COUNT = 2
+TEST_PYPI_PUBLISH_JOB_COUNT = 2
+RAVAGE_VERSION_MARKER_COUNT = 2
+PYPI_PUBLISH_ACTION = (
+    "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33"
+)
+
+
+def _workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def _job(workflow: str, name: str, *, next_name: str | None = None) -> str:
+    section = workflow.split(f"  {name}:\n", maxsplit=1)[1]
+    if next_name is not None:
+        section = section.split(f"  {next_name}:\n", maxsplit=1)[0]
+    return section
+
+
+def test_release_workflow_actions_are_pinned_to_full_commit_shas() -> None:
+    failures: list[str] = []
+    for name in RELEASE_WORKFLOWS:
+        for action in ACTION_USE.findall(_workflow(name)):
+            if action.startswith("./"):
+                continue
+            _, separator, ref = action.rpartition("@")
+            if not separator or FULL_COMMIT_SHA.fullmatch(ref) is None:
+                failures.append(f"{name}: {action}")
+
+    assert failures == []
+
+
+def test_production_publish_is_serialized_and_requires_exact_current_main() -> None:
+    workflow = _workflow("publish-pypi.yml")
+
+    assert "group: publish-pypi-${{ github.event.release.tag_name || github.ref }}" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert 'git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}"' in workflow
+    assert 'git rev-parse --verify "refs/remotes/origin/main^{commit}"' in workflow
+    assert 'git rev-parse --verify "${GITHUB_SHA}^{commit}"' in workflow
+    assert "git merge-base --is-ancestor" not in workflow
+    assert "python scripts/check_pypi_version.py" in workflow
+    preflight_position = workflow.index("python scripts/check_pypi_version.py")
+    assert preflight_position < workflow.index("  build-schemas:")
+    assert workflow.count(PYPI_PUBLISH_ACTION) == PRODUCTION_PYPI_PUBLISH_JOB_COUNT
+    assert workflow.count("environment: pypi") == PRODUCTION_PYPI_PUBLISH_JOB_COUNT
+    assert workflow.count("id-token: write") == PRODUCTION_PYPI_PUBLISH_JOB_COUNT
+
+    test_job = _job(workflow, "test", next_name="build-schemas")
+    assert "github.event.release.prerelease == false" in test_job
+    assert "github.event_name == 'workflow_dispatch'" in test_job
+    for build_name, next_name in (
+        ("build-schemas", "build-ravage"),
+        ("build-ravage", "publish-schemas"),
+    ):
+        assert "needs: test" in _job(workflow, build_name, next_name=next_name)
+
+    publish_schemas = _job(workflow, "publish-schemas", next_name="publish-ravage")
+    publish_ravage = _job(workflow, "publish-ravage")
+    for publish_job in (publish_schemas, publish_ravage):
+        assert "github.event_name == 'release'" in publish_job
+        assert "github.event.release.prerelease == false" in publish_job
+        assert publish_job.count(PYPI_PUBLISH_ACTION) == 1
+        assert "actions/checkout@" not in publish_job
+        assert "\n        run:" not in publish_job
+
+
+def test_testpypi_rehearsal_cannot_target_production() -> None:
+    workflow = _workflow("publish-testpypi.yml")
+
+    assert "workflow_dispatch:" in workflow
+    assert workflow.count("environment: testpypi") == TEST_PYPI_PUBLISH_JOB_COUNT
+    assert "environment: pypi" not in workflow
+    assert (
+        workflow.count("repository-url: https://test.pypi.org/legacy/")
+        == TEST_PYPI_PUBLISH_JOB_COUNT
+    )
+    assert (
+        "python scripts/check_pypi_version.py --index-base https://test.pypi.org/pypi"
+        in workflow
+    )
+    assert "--index-url https://test.pypi.org/simple/" in workflow
+    assert "--probe surface_map" in workflow
+    assert "--timeout-seconds 10" in workflow
+    assert workflow.count(PYPI_PUBLISH_ACTION) == TEST_PYPI_PUBLISH_JOB_COUNT
+
+    publish_schemas = _job(workflow, "publish-schemas", next_name="publish-ravage")
+    publish_ravage = _job(workflow, "publish-ravage", next_name="verify")
+    for publish_job in (publish_schemas, publish_ravage):
+        assert publish_job.count(PYPI_PUBLISH_ACTION) == 1
+        assert "actions/checkout@" not in publish_job
+        assert "\n        run:" not in publish_job
+
+
+def test_kali_publish_requires_exact_current_main_and_skips_prereleases() -> None:
+    workflow = _workflow("publish-kali-image.yml")
+    preflight = _job(workflow, "preflight", next_name="publish-platform")
+    publish_platform = _job(workflow, "publish-platform", next_name="publish-manifest")
+    publish_manifest = _job(workflow, "publish-manifest")
+
+    prerelease_guard = (
+        "github.event_name != 'release' || github.event.release.prerelease == false"
+    )
+    assert prerelease_guard in publish_platform
+    assert prerelease_guard in publish_manifest
+    assert "needs: preflight" in publish_platform
+    assert '"${GITHUB_REF}" != "refs/heads/main"' in preflight
+    assert 'git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}"' in preflight
+    assert 'git rev-parse --verify "refs/remotes/origin/main^{commit}"' in preflight
+    assert 'git rev-parse --verify "${GITHUB_SHA}^{commit}"' in preflight
+    assert "python scripts/check_release.py" in preflight
+    assert (
+        "type=semver,pattern={{version}},value=${{ github.event.release.tag_name }},"
+        "enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}"
+        in publish_manifest
+    )
+    assert (
+        "type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }},"
+        "enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}"
+        in publish_manifest
+    )
+
+
+def test_release_please_is_main_only_and_has_no_token_fallback() -> None:
+    workflow = _workflow("release-please.yml")
+
+    assert "group: release-please" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "if: github.ref == 'refs/heads/main'" in workflow
+    assert "RELEASE_PLEASE_TOKEN is required" in workflow
+    assert "secrets.GITHUB_TOKEN" not in workflow
+    assert "token: ${{ secrets.RELEASE_PLEASE_TOKEN }}" in workflow
+    assert "python -m pip install uv==0.12.5" in workflow
+    assert "uv lock" in workflow
+    assert "python scripts/check_release.py" in workflow
+    assert "git add uv.lock" in workflow
+    assert 'git push origin "HEAD:${RELEASE_PR_BRANCH}"' in workflow
+
+
+def test_release_please_updates_the_ravage_version_and_schema_pin_together() -> None:
+    config_path = ROOT / "tools/release/release-please-config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert re.fullmatch(r"[0-9a-f]{40}", config["bootstrap-sha"])
+    extra_files = config["packages"]["."]["extra-files"]
+    generic_paths = {
+        item["path"] for item in extra_files if item.get("type") == "generic"
+    }
+
+    assert "packages/ravage/pyproject.toml" in generic_paths
+    assert "packages/ravage/src/ravage/_version.py" in generic_paths
+    assert "packages/schemas/src/pentest_schemas/_version.py" in generic_paths
+    assert "CITATION.cff" in generic_paths
+    ravage_pyproject = (ROOT / "packages/ravage/pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        ravage_pyproject.count("# x-release-please-version")
+        == RAVAGE_VERSION_MARKER_COUNT
+    )
+    project_version = re.search(
+        r'^version = "([0-9]+\.[0-9]+\.[0-9]+)" # x-release-please-version$',
+        ravage_pyproject,
+        re.MULTILINE,
+    )
+    schema_pin = re.search(
+        r'^\s+"ravage-schemas==([0-9]+\.[0-9]+\.[0-9]+)", '
+        r'# x-release-please-version$',
+        ravage_pyproject,
+        re.MULTILINE,
+    )
+    assert project_version is not None
+    assert schema_pin is not None
+    assert project_version.group(1) == schema_pin.group(1)

--- a/tools/release/release-please-config.json
+++ b/tools/release/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "87cf3e2a12b843841036a04d805bd8b2a08fd19d",
   "release-type": "simple",
   "include-v-in-tag": true,
   "packages": {
@@ -21,13 +22,16 @@
           "path": "packages/schemas/src/pentest_schemas/_version.py"
         },
         {
-          "type": "toml",
-          "path": "packages/ravage/pyproject.toml",
-          "jsonpath": "$.project.version"
+          "type": "generic",
+          "path": "packages/ravage/pyproject.toml"
         },
         {
           "type": "generic",
           "path": "packages/ravage/src/ravage/_version.py"
+        },
+        {
+          "type": "generic",
+          "path": "CITATION.cff"
         }
       ]
     }


### PR DESCRIPTION
## Summary

  - Agent now keeps cookies and login sessions between requests.
  - When it finds an interesting request, it saves the method, path, fields, and body type.
  - It can replay that same request to confirm whether the vulnerability is real.
  - Replays must use the same target and route. The agent cannot and should not accidentally test a different service.
  - Each replay is linked to its traffic record, so reports can show where the evidence came from.
  - If login is required, the agent pauses the replay and continues after a session is available.
  - Base-agent and graph traffic can now be used together without duplicate request IDs breaking reports.
  - Reports reject missing, damaged, wrong-target, or wrong-scan traffic data.
  - Payloads sent by the agent cannot be echoed back and wrongly accepted as proof.
