### PR TITLE
fix(security): harden cockpit access and evidence integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
 
@@ -51,8 +51,10 @@ jobs:
       - name: Check maintained documentation
         run: python scripts/check_docs.py
 
-      - name: Check cockpit JavaScript syntax
-        run: npm --prefix packages/ravage-cockpit run check
+      - name: Check cockpit JavaScript
+        run: |
+          npm --prefix packages/ravage-cockpit run check
+          npm --prefix packages/ravage-cockpit test
 
       - name: Ruff clean baseline
         run: |
@@ -120,6 +122,27 @@ jobs:
             packages/ravage/tests/test_control_plane_runner_protocol.py \
             packages/ravage/tests/test_runner_service.py
 
+      - name: Evidence and operator integrity static checks
+        run: |
+          python -m ruff check \
+            packages/ravage/src/ravage/report.py \
+            packages/ravage/src/ravage/report_artifact.py \
+            packages/ravage/src/ravage/report_io.py \
+            packages/ravage/src/ravage/memory_eval.py \
+            packages/ravage/src/ravage/proof_bundle_eval.py \
+            packages/ravage/src/ravage/live_dashboard_security.py \
+            scripts/eval/run_memory_eval.py \
+            scripts/eval/eval_proof_bundles.py
+          python -m mypy --follow-imports=silent \
+            packages/ravage/src/ravage/report.py \
+            packages/ravage/src/ravage/report_artifact.py \
+            packages/ravage/src/ravage/report_io.py \
+            packages/ravage/src/ravage/memory_eval.py \
+            packages/ravage/src/ravage/proof_bundle_eval.py \
+            packages/ravage/src/ravage/live_dashboard_security.py \
+            scripts/eval/run_memory_eval.py \
+            scripts/eval/eval_proof_bundles.py
+
       - name: Anti-overfit policy check
         run: python scripts/check_overfit.py
 
@@ -141,10 +164,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -162,25 +185,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Smoke-test the base wheels in a clean environment
         run: python scripts/check_clean_install.py
 
+  cockpit_browser:
+    name: Cockpit Firefox and Chromium
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install cockpit browser test dependencies
+        run: |
+          python -m pip install pytest==9.0.3 playwright==1.62.0
+          python -m pip install -e packages/schemas -e packages/ravage
+          python -m playwright install --with-deps --only-shell chromium firefox
+
+      - name: Verify private cockpit access in real browsers
+        run: python -m pytest packages/ravage-cockpit/tests/test_browser_login.py -q
+
   scope_integration:
     name: Docker scope enforcement
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -202,6 +246,7 @@ jobs:
       - static_checks
       - tests
       - clean_install
+      - cockpit_browser
       - scope_integration
     runs-on: ubuntu-latest
     steps:
@@ -210,9 +255,11 @@ jobs:
           STATIC_RESULT: ${{ needs.static_checks.result }}
           TEST_RESULT: ${{ needs.tests.result }}
           CLEAN_INSTALL_RESULT: ${{ needs.clean_install.result }}
+          COCKPIT_BROWSER_RESULT: ${{ needs.cockpit_browser.result }}
           SCOPE_INTEGRATION_RESULT: ${{ needs.scope_integration.result }}
         run: |
           test "${STATIC_RESULT}" = success
           test "${TEST_RESULT}" = success
           test "${CLEAN_INSTALL_RESULT}" = success
+          test "${COCKPIT_BROWSER_RESULT}" = success
           test "${SCOPE_INTEGRATION_RESULT}" = success

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -18,19 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
         with:
           source: docs
           destination: _site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: _site
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -81,8 +81,10 @@ jobs:
       - name: Check maintained documentation
         run: python scripts/check_docs.py
 
-      - name: Check cockpit JavaScript syntax
-        run: npm --prefix packages/ravage-cockpit run check
+      - name: Check cockpit JavaScript
+        run: |
+          npm --prefix packages/ravage-cockpit run check
+          npm --prefix packages/ravage-cockpit test
 
       - name: Ruff clean baseline
         run: |
@@ -119,6 +121,27 @@ jobs:
             packages/ravage/tests/test_control_plane_runner_protocol.py \
             packages/ravage/tests/test_runner_service.py
 
+      - name: Evidence and operator integrity static checks
+        run: |
+          python -m ruff check \
+            packages/ravage/src/ravage/report.py \
+            packages/ravage/src/ravage/report_artifact.py \
+            packages/ravage/src/ravage/report_io.py \
+            packages/ravage/src/ravage/memory_eval.py \
+            packages/ravage/src/ravage/proof_bundle_eval.py \
+            packages/ravage/src/ravage/live_dashboard_security.py \
+            scripts/eval/run_memory_eval.py \
+            scripts/eval/eval_proof_bundles.py
+          python -m mypy --follow-imports=silent \
+            packages/ravage/src/ravage/report.py \
+            packages/ravage/src/ravage/report_artifact.py \
+            packages/ravage/src/ravage/report_io.py \
+            packages/ravage/src/ravage/memory_eval.py \
+            packages/ravage/src/ravage/proof_bundle_eval.py \
+            packages/ravage/src/ravage/live_dashboard_security.py \
+            scripts/eval/run_memory_eval.py \
+            scripts/eval/eval_proof_bundles.py
+
       - name: Check anti-overfit policy
         run: python scripts/check_overfit.py
 
@@ -145,6 +168,14 @@ jobs:
         env:
           RAVAGE_REQUIRE_DOCKER_INTEGRATION: "1"
         run: python -m pytest -m integration -q
+
+      - name: Install cockpit browser test dependencies
+        run: |
+          python -m pip install playwright==1.62.0
+          python -m playwright install --with-deps --only-shell chromium firefox
+
+      - name: Verify private cockpit access in real browsers
+        run: python -m pytest packages/ravage-cockpit/tests/test_browser_login.py -q
 
   build-schemas:
     name: Build ravage-schemas

--- a/README.md
+++ b/README.md
@@ -298,8 +298,12 @@ ravage traffic show RUN_DIR REQUEST_ID
 ~~~
 
 The report includes evidence references, request-accounting quality, completion
-status, and the reason an incomplete run stopped. Never treat an unvalidated
-model assertion as a confirmed finding.
+status, and the reason an incomplete run stopped. Missing or unreadable expected
+evidence makes the report incomplete; an empty incomplete report has `Unknown`
+risk. Never treat an unvalidated model assertion as a confirmed finding.
+
+`ravage observe` prints a private, temporary access link. The observer requires
+authenticated requests for run data and actions and binds to loopback by default.
 
 ## Capabilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,12 +107,15 @@ both -> typed observations -> proof gate -> durable audit and terminal outcome
   reports, source-guided workflows, and the additive autonomous graph.
 - `packages/schemas`: shared schema package published as `ravage-schemas`,
   imported as `pentest_schemas`.
-- `packages/agents/*`: early specialist-agent packages.
-- `packages/mcp_servers/*`: MCP wrappers for external tools.
+- `packages/agents/*`: early specialist-agent scaffolds outside the active workspace.
+- `packages/mcp_servers/*`: unimplemented MCP scaffolds outside the active workspace;
+  these packages do not provide external-tool servers.
 - `ravage xben`: XBEN runner used for controlled benchmark execution.
 
 The console command is `ravage`, implemented by
 `packages/ravage/src/ravage/__main__.py`.
+The repository root is a virtual UV workspace. Only `ravage` and
+`ravage-schemas` are installable workspace distributions.
 
 ## Entry Points
 
@@ -137,7 +140,10 @@ Benchmark entry points:
 
 - `ravage xben ...`: official-style XBEN validation benchmark runs.
 - `ravage benchmark ...`: compatibility alias for `ravage xben`.
-- `scripts/run_memory_eval.py`: memory off/read comparison.
+- `scripts/run_memory_eval.py`: retired compatibility entry point; reports that
+  memory evaluation is unavailable and exits without running models or writing results.
+- `scripts/eval_proof_bundles.py`: offline recorded-verdict fixture scoring;
+  this checks supplied records and does not independently verify a vulnerability.
 - `scripts/grade_xben_failures.py`: post-run failure categorization.
 
 ## Base Agent Loop And Evaluated Snapshot
@@ -151,12 +157,11 @@ scope, executes the tool, records the observation, and appends the observation
 to the next model turn. Tool output is wrapped as untrusted observation data so
 target-controlled text cannot masquerade as agent instructions.
 
-The agent supports two modes:
-
-- `hybrid`: normal local/manual operation with runtime recommendations,
-  deterministic proof support, and evidence gates.
-- `ctf-free-roam`: benchmark/CTF mode that encourages bounded autonomous
-  exploration and flag capture.
+The CLI retains `hybrid` and `ctf-free-roam` as compatibility labels recorded
+in run metadata. The base execution loop does not select different behavior
+from these labels. Runtime capabilities and evidence requirements come from
+the brief, identity, traffic policy, and execution settings. XBEN separately
+requires the `ctf-free-roam` label for its official-style configuration.
 
 The frozen 2026-07-12 XBEN result came from an earlier snapshot of this base
 architecture. It used one
@@ -496,32 +501,17 @@ identity removes process/browser execution and gives the graph managed
 
 ## Source-Guided Workflows
 
-When source context is available, Ravage parses routes, parameters, sinks,
-headers, credentials, JWT/session logic, upload flows, GraphQL shapes, and
-framework-specific patterns. Source-guided workflows then attempt bounded
-dynamic proof against the running target.
+The shipped analyzer contract is `ravage.python-web-direct-flows.v2`. It reads
+bounded Python source and recognizes direct request-input flows in supported
+Flask/FastAPI handlers. Its static candidates cover SQL, template rendering,
+shell execution, file reads, and outbound URLs. Unsupported syntax and skipped
+files are reported; this is not whole-program or multi-language analysis.
 
-Implemented workflow areas include:
-
-- SQL injection;
-- XSS;
-- SSTI;
-- command injection;
-- LFI and path traversal;
-- IDOR and privilege boundaries;
-- SSRF;
-- XXE;
-- JWT forgery and header trust;
-- auth bypass;
-- GraphQL IDOR;
-- file upload;
-- insecure deserialization;
-- encrypted cookies;
-- SSH/source-secret pivots.
-
-These workflows are not benchmark shortcuts. They are reusable proof loops that
-turn source signals into scoped runtime attempts and still require live target
-evidence before reporting.
+Automatic source-guided replay supports a bounded subset of non-mutating
+GET/query SQL candidates. Other candidate shapes remain hints. The broader
+deterministic probe catalog does not imply that those families have source
+analysis support. See [How To Use](how-to-use.md) for the supported inputs and
+proof requirements.
 
 ## Evidence And Reporting
 

--- a/docs/differentiation-roadmap.md
+++ b/docs/differentiation-roadmap.md
@@ -74,15 +74,12 @@ Required capabilities fail closed unless degraded mode is explicitly allowed.
 
 ### Source-Guided Dynamic Proof
 
-Ravage can inspect source context when the selected mode permits it, extract
-routes/params/sinks, then run bounded dynamic workflows against the live target.
-
-Implemented workflow areas include SQLi, XSS, SSTI, command injection, LFI,
-IDOR/authz, SSRF, XXE, JWT/session issues, auth bypass, GraphQL IDOR, uploads,
-deserialization, encrypted cookies, and selected source-secret pivots.
-
-The important distinction is that source context guides candidates; it does not
-become proof by itself.
+Ravage's bounded Python analyzer maps supported Flask/FastAPI handlers and
+direct input flows to SQL, template, shell, file-read, and outbound-URL sinks.
+Automatic replay currently covers a subset of non-mutating GET/query SQL
+candidates. Other source candidates remain advisory; source context alone
+cannot become proof. The full deterministic probe catalog is broader than the
+shipped source analyzer.
 
 ### Benchmark Honesty
 
@@ -95,12 +92,6 @@ XBEN runs record the benchmark context mode:
 
 This prevents mixing description-only black-box and white-box results as if
 they were the same benchmark.
-
-### Local Reviewed Memory
-
-Memory is local SQLite, redacted, reviewable, and advisory. It can suggest
-lessons, but it cannot report findings, capture flags, override scope, or store
-raw secrets.
 
 ### Inspectable Run Artifacts
 
@@ -157,6 +148,13 @@ from `curl`, Docker tools, scanners, and other external processes.
 
 ## Current Limits
 
+### Reviewed Memory Is Inactive
+
+The [Memory Design](memory.md) describes local, redacted, advisory storage, but
+active memory is not wired into the public attack command. Only `--memory off`
+is supported. The retired memory evaluator exits explicitly as unavailable;
+it does not measure an improvement or generate an evaluation report.
+
 ### HTTP History And Replay UI
 
 The CLI foundation now covers automatic agent structured HTTP history and
@@ -196,9 +194,10 @@ finding class.
 
 ### Source-Guided Breadth
 
-Source-guided workflows are broad but uneven. Some vulnerability families have
-multiple tested patterns; others still need more frameworks, encodings, auth
-states, and negative tests.
+Source analysis is limited to the documented Python direct-flow contract.
+Other languages, whole-program analysis, and most request shapes have no
+automatic source-guided validation. Skipped inputs must remain visible in
+coverage claims.
 
 ### Terminal Robustness
 

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -463,9 +463,28 @@ ravage audit verify RUN_DIR
 The canonical JSON report is finalized even when a run is incomplete, fails
 after starting, or has no flag-based objective. Evidence-backed findings remain
 in the report independently of any captured flag. JSON-only finalization reads
-saved artifacts and sends no model or target requests. It uses an atomic replace
-and private file permissions so an interrupted write cannot leave a partially
-written report.
+saved artifacts and sends no model or target requests. Both canonical JSON and
+explicit Markdown/JSON exports use private file permissions and atomic replacement
+for each file, so an interrupted write preserves the previous complete file.
+
+Report evidence health is separate from run completion. Inspect
+`source_quality.status`, `audit_source`, `audit_log_source`, `event_sources`, and
+`rejected_confirmed_events`: an expected database that is missing, unreadable,
+or contains rejected records makes the report incomplete. Validated findings
+remain visible, while a report without findings and with unavailable evidence
+has `Unknown` risk. Source health does not replace `ravage audit verify` for
+cryptographic audit-chain verification.
+
+Event source health distinguishes an existing empty log from a missing or
+unreadable log. Persisted workspace state, transcripts, and scan/graph state
+identify expected event logs. An export with neither events nor a requested
+audit source is incomplete; legitimate audit-only exports and unused optional
+event streams remain supported.
+
+When a run directory moves, recorded audit paths inside that run or its
+workspace move with it. A custom relative audit path outside the run cannot be
+relocated because older manifests do not record the producing working directory;
+use an absolute path for external audit storage.
 
 If you did not pass `--report`, render the optional human-readable report later:
 
@@ -877,6 +896,16 @@ Follow an existing run from another terminal:
 ```bash
 ravage observe RUN_DIR
 ```
+
+Open the private link printed by `ravage observe`. Its temporary access token
+is specific to that running observer. The browser removes it from the address
+bar and keeps access in that tab's origin-scoped session storage. Run data and
+teardown actions require authenticated requests. Restarting the observer
+invalidates previous access credentials.
+
+The observer binds to loopback by default and serves HTTP. For remote review,
+use an SSH tunnel to loopback; an explicit external `--host` does not add TLS.
+Treat the printed link as a credential and keep it private.
 
 Resume the same attack workspace after an interrupted run:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,11 @@ point. There is no active memory review command in the current CLI.
 Use this page as implementation context for future memory work. For current
 runs and benchmark claims, keep memory off and rely on live target evidence.
 
+`scripts/run_memory_eval.py` and its compatibility API explicitly report that
+memory A/B evaluation is unavailable. The command exits 2 without calling a
+model, opening a memory database, or writing a report. Earlier hard-coded
+outputs from this entry point are not evaluation evidence.
+
 ## Design Goal
 
 Ravage Memory is intended to be a local-first learning loop for `ai-web`. It is

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -67,7 +67,10 @@ Agent internals:
 Benchmark and evaluation:
 
 - `ravage xben`: command-line wrapper for XBEN.
-- `scripts/run_memory_eval.py`: memory A/B runner.
+- `scripts/run_memory_eval.py`: retired memory evaluation compatibility command;
+  exits 2 without model calls or generated results.
+- `scripts/eval_proof_bundles.py`: offline recorded-verdict fixture scorer;
+  exits 0 for passing cases, 1 for disagreements, and 2 for invalid or empty input.
 - `scripts/grade_xben_failures.py`: failure taxonomy report generator.
 - `proof_bundle*.py`: proof bundle candidate, verifier, and evaluation logic.
 - `trace_quality.py`: trace-quality diagnostics.

--- a/packages/ravage-cockpit/package.json
+++ b/packages/ravage-cockpit/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "check": "node --check src/main.js"
+    "check": "node --check src/main.js && node --check src/transport.js",
+    "test": "node --test tests/*.test.js"
   }
 }

--- a/packages/ravage-cockpit/src/main.js
+++ b/packages/ravage-cockpit/src/main.js
@@ -7,6 +7,8 @@
 // `docker` / `target` / `status` deltas), so the DOM is built once and only the
 // changed panel mutates — no flicker, no scroll jumps.
 
+import { cockpitFetch, consumeEventStream, sessionToken } from "./transport.js";
+
 const app = document.querySelector("#app");
 
 const refs = {};
@@ -34,13 +36,17 @@ const STREAM_STALE_MS = 20000;
 boot();
 
 async function boot() {
+  if (!sessionToken()) {
+    window.location.replace("/");
+    return;
+  }
   buildShell();
   startElapsedClock();
   await seedFromState();
   connectStream();
   window.setInterval(() => {
     const stale = Date.now() - state.lastStreamAt > STREAM_STALE_MS;
-    if (!window.EventSource || !state.streamConnected || stale) {
+    if (!state.streamConnected || stale) {
       seedFromState({ polling: true });
     }
   }, FALLBACK_POLL_MS);
@@ -50,7 +56,7 @@ async function boot() {
 
 async function seedFromState(options = {}) {
   try {
-    const response = await fetch("/api/state", { cache: "no-store" });
+    const response = await cockpitFetch("/api/state");
     if (!response.ok) return;
     applyState(await response.json());
     if (options.polling) markConnection(false);
@@ -59,16 +65,21 @@ async function seedFromState(options = {}) {
   }
 }
 
-function connectStream() {
-  if (!window.EventSource) return;
-  const stream = new EventSource("/api/events/stream");
-  stream.addEventListener("state", (e) => withData(e, applyState));
-  stream.addEventListener("step", (e) => withData(e, appendStep));
-  stream.addEventListener("docker", (e) => withData(e, updateDocker));
-  stream.addEventListener("target", (e) => withData(e, updateTarget));
-  stream.addEventListener("status", (e) => withData(e, updateStatus));
-  stream.onopen = () => markConnection(true);
-  stream.onerror = () => markConnection(false);
+async function connectStream() {
+  const handlers = { state: applyState, step: appendStep, docker: updateDocker, target: updateTarget, status: updateStatus };
+  try {
+    const response = await cockpitFetch("/api/events/stream");
+    if (!response.ok || !response.body) throw new Error("The cockpit event stream is unavailable");
+    markConnection(true);
+    await consumeEventStream(response.body, (event) => {
+      const handler = handlers[event.type];
+      if (handler) withData(event, handler);
+    });
+  } catch {
+    // Reconnect below; state polling continues while the stream is unavailable.
+  }
+  markConnection(false);
+  if (sessionToken()) window.setTimeout(connectStream, 1500);
 }
 
 function withData(event, handler) {

--- a/packages/ravage-cockpit/src/transport.js
+++ b/packages/ravage-cockpit/src/transport.js
@@ -1,0 +1,90 @@
+// Session storage is scoped to this tab and exact origin, including its port.
+// Cookies must never carry cockpit credentials to applications on other ports.
+export const SESSION_KEY = "ravage.cockpit.session";
+
+export function sessionToken() {
+  return window.sessionStorage.getItem(SESSION_KEY) || "";
+}
+
+function privateFetch(path, token, options = {}) {
+  const destination = new URL(path, window.location.href);
+  if (destination.origin !== window.location.origin || !destination.pathname.startsWith("/api/")) {
+    throw new Error("Cockpit credentials require a same-origin API destination");
+  }
+  return fetch(destination.href, {
+    ...options,
+    headers: { ...options.headers, Authorization: `Bearer ${token}` },
+    credentials: "omit",
+    mode: "same-origin",
+    // Firefox otherwise inherits no-referrer and sends Origin: null on POST.
+    referrerPolicy: "same-origin",
+    redirect: "error",
+    cache: "no-store",
+  });
+}
+
+export async function cockpitFetch(path, options = {}) {
+  const token = sessionToken();
+  if (!token) throw new Error("Open the private cockpit link to connect");
+  const response = await privateFetch(path, token, options);
+  if (response.status === 401) {
+    window.sessionStorage.removeItem(SESSION_KEY);
+    window.location.replace("/");
+    throw new Error("The cockpit session has expired");
+  }
+  return response;
+}
+
+export async function openCockpitSession() {
+  const capability = new URLSearchParams(window.location.hash.slice(1)).get("token");
+  window.history.replaceState(null, "", window.location.pathname);
+  const status = document.querySelector("#session-status");
+  try {
+    const token = capability || sessionToken();
+    if (token) {
+      const response = await privateFetch("/api/session", token, capability ? { method: "POST" } : {});
+      if (response.ok) {
+        if (capability) {
+          const payload = await response.json();
+          if (typeof payload.session_token !== "string" || !payload.session_token) {
+            throw new Error("The cockpit did not provide a session");
+          }
+          window.sessionStorage.setItem(SESSION_KEY, payload.session_token);
+        }
+        window.location.replace("/index.html");
+        return;
+      }
+      window.sessionStorage.removeItem(SESSION_KEY);
+    }
+    status.textContent = "Open the private cockpit link printed by Ravage to connect.";
+  } catch {
+    status.textContent = "The cockpit connection failed. Reopen the link printed by Ravage.";
+  }
+}
+
+export async function consumeEventStream(body, onEvent) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      pending += decoder.decode(value, { stream: true });
+      let boundary;
+      while ((boundary = pending.indexOf("\n\n")) !== -1) {
+        const frame = pending.slice(0, boundary);
+        pending = pending.slice(boundary + 2);
+        let type = "message";
+        const data = [];
+        for (const line of frame.split("\n")) {
+          if (line.startsWith("event:")) type = line.slice(6).trim();
+          if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (data.length) onEvent({ type, data: data.join("\n") });
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/ravage-cockpit/tests/test_browser_login.py
+++ b/packages/ravage-cockpit/tests/test_browser_login.py
@@ -1,0 +1,79 @@
+"""Real browser regression checks, run explicitly by the cockpit CI job."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+import pytest
+import ravage.live_dashboard as dashboard
+from playwright.sync_api import sync_playwright
+from ravage.run_data.workspace import AgentWorkspace
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from playwright.sync_api import Response
+
+
+@pytest.mark.parametrize("engine", ["firefox", "chromium"])
+def test_private_link_login_reload_stream_and_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, engine: str
+) -> None:
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.record_event(kind="agent_started", payload={"target_url": "http://127.0.0.1:8765"})
+    teardown_calls: list[str] = []
+
+    def fixture_teardown(_settings: dashboard.DashboardSettings, run_id: str) -> dict[str, bool]:
+        teardown_calls.append(run_id)
+        return {"ok": True}
+
+    monkeypatch.setattr(dashboard, "teardown_active_run", fixture_teardown)
+    server = dashboard.start_cockpit(
+        dashboard.DashboardSettings(workspace_dir=workspace.root), port=0
+    )
+    origin = f"http://127.0.0.1:{server.server.server_port}"
+    try:
+        with sync_playwright() as playwright:
+            browser = getattr(playwright, engine).launch()
+            try:
+                context = browser.new_context()
+                page = context.new_page()
+                responses: list[tuple[str, int]] = []
+
+                def record_response(response: Response) -> None:
+                    path = urlsplit(response.url).path
+                    if path.startswith("/api/"):
+                        responses.append((path, response.status))
+
+                page.on("response", record_response)
+                with page.expect_response(f"{origin}/api/session") as login:
+                    page.goto(server.url)
+                assert login.value.status == HTTPStatus.OK
+                assert login.value.request.header_value("origin") == origin
+                assert login.value.request.header_value("cookie") is None
+                page.wait_for_url(f"{origin}/index.html")
+                page.wait_for_function("() => document.querySelector('.conn.ok') !== null")
+                assert ("/api/state", HTTPStatus.OK) in responses
+                assert ("/api/events/stream", HTTPStatus.OK) in responses
+                assert context.cookies() == []
+
+                page.reload()
+                page.wait_for_function("() => document.querySelector('.conn.ok') !== null")
+                # Invoke the app's transport; Firefox must generate the Origin itself.
+                with page.expect_response(f"{origin}/api/teardown") as mutation:
+                    result = page.evaluate("""async () => {
+                        const { cockpitFetch } = await import('/src/transport.js');
+                        const response = await cockpitFetch('/api/teardown', { method: 'POST' });
+                        return response.json();
+                    }""")
+                assert mutation.value.status == HTTPStatus.OK
+                assert mutation.value.request.header_value("origin") == origin
+                assert mutation.value.request.header_value("cookie") is None
+                assert result == {"ok": True}
+                assert teardown_calls == [""]
+            finally:
+                browser.close()
+    finally:
+        server.shutdown()

--- a/packages/ravage-cockpit/tests/transport.test.js
+++ b/packages/ravage-cockpit/tests/transport.test.js
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { cockpitFetch, consumeEventStream, openCockpitSession, SESSION_KEY } from "../src/transport.js";
+
+function browser({ capability = "", session = "" } = {}) {
+  const sequence = [];
+  const values = new Map(session ? [[SESSION_KEY, session]] : []);
+  const status = { textContent: "" };
+  const location = new URL(`http://127.0.0.1:8787/${capability ? `#token=${capability}` : ""}`);
+  location.replace = (path) => sequence.push(["redirect", path]);
+  globalThis.window = {
+    location,
+    history: { replaceState(_state, _title, path) { sequence.push(["clear", path]); } },
+    sessionStorage: {
+      getItem: (key) => values.get(key) || null,
+      setItem(key, value) { sequence.push(["store"]); values.set(key, value); },
+      removeItem: (key) => values.delete(key),
+    },
+  };
+  globalThis.document = { querySelector: () => status };
+  return { sequence, values, status };
+}
+
+test("capability handoff clears URL before network/storage and stores a separate session", async () => {
+  const fixture = browser({ capability: "launch-secret" });
+  globalThis.fetch = async (url, options) => {
+    assert.deepEqual(fixture.sequence, [["clear", "/"]]);
+    assert.equal(url, "http://127.0.0.1:8787/api/session");
+    assert.equal(options.method, "POST");
+    assert.equal(options.headers.Authorization, "Bearer launch-secret");
+    assert.equal(options.credentials, "omit");
+    assert.equal(options.redirect, "error");
+    assert.equal(options.mode, "same-origin");
+    assert.equal(options.referrerPolicy, "same-origin");
+    return { ok: true, json: async () => ({ session_token: "session-secret" }) };
+  };
+  await openCockpitSession();
+  assert.equal(fixture.values.get(SESSION_KEY), "session-secret");
+  assert.deepEqual(fixture.sequence, [["clear", "/"], ["store"], ["redirect", "/index.html"]]);
+});
+
+test("an existing tab session can reopen the cockpit", async () => {
+  const fixture = browser({ session: "session-secret" });
+  globalThis.fetch = async (_url, options) => {
+    assert.equal(options.headers.Authorization, "Bearer session-secret");
+    assert.equal(options.method, undefined);
+    return { ok: true };
+  };
+  await openCockpitSession();
+  assert.deepEqual(fixture.sequence, [["clear", "/"], ["redirect", "/index.html"]]);
+});
+
+test("denied and failed bootstrap requests leave an actionable reconnect message", async () => {
+  for (const outcome of ["denied", "offline"]) {
+    const fixture = browser({ session: "expired" });
+    globalThis.fetch = async () => {
+      if (outcome === "offline") throw new Error("offline");
+      return { ok: false };
+    };
+    await openCockpitSession();
+    assert.ok(fixture.status.textContent.includes("link printed by Ravage"));
+    assert.deepEqual(fixture.sequence, [["clear", "/"]]);
+    if (outcome === "denied") assert.equal(fixture.values.size, 0);
+  }
+});
+
+test("state, SSE, and mutation fetches carry explicit credentials without cookies", async () => {
+  browser({ session: "session-secret" });
+  for (const path of ["/api/state", "/api/events/stream", "/api/teardown"]) {
+    globalThis.fetch = async (url, options) => {
+      assert.equal(url, `http://127.0.0.1:8787${path}`);
+      assert.equal(options.headers.Authorization, "Bearer session-secret");
+      assert.equal(options.credentials, "omit");
+      assert.equal(options.redirect, "error");
+      assert.equal(options.mode, "same-origin");
+      assert.equal(options.referrerPolicy, "same-origin");
+      return { status: 200 };
+    };
+    await cockpitFetch(path, path === "/api/teardown" ? { method: "POST" } : {});
+  }
+});
+
+test("credentials cannot be sent to another origin, port, or a static resource", async () => {
+  browser({ session: "session-secret" });
+  let sent = false;
+  globalThis.fetch = async () => { sent = true; };
+  for (const path of ["http://127.0.0.1:8765/api/state", "http://other.invalid/api/state", "/index.html"]) {
+    await assert.rejects(cockpitFetch(path), /same-origin API destination/);
+  }
+  assert.equal(sent, false);
+});
+
+test("sessions that expired after a server restart are cleared", async () => {
+  const fixture = browser({ session: "expired" });
+  globalThis.fetch = async () => ({ status: 401 });
+  await assert.rejects(cockpitFetch("/api/state"), /session has expired/);
+  assert.equal(fixture.values.size, 0);
+  assert.deepEqual(fixture.sequence, [["redirect", "/"]]);
+});
+
+test("stream parser survives byte boundaries and preserves multiple events", async () => {
+  const raw = new TextEncoder().encode(
+    ': keepalive\n\nevent: state\ndata: {"name":"caf\u00e9"}\n\nevent: step\ndata: first\ndata: second\n\n'
+  );
+  const body = new ReadableStream({
+    start(controller) {
+      for (const byte of raw) controller.enqueue(Uint8Array.of(byte));
+      controller.close();
+    },
+  });
+  const events = [];
+  await consumeEventStream(body, (event) => events.push(event));
+  assert.deepEqual(events, [
+    { type: "state", data: '{"name":"caf\u00e9"}' },
+    { type: "step", data: "first\nsecond" },
+  ]);
+  assert.equal(body.locked, false);
+});

--- a/packages/ravage/src/ravage/__main__.py
+++ b/packages/ravage/src/ravage/__main__.py
@@ -6002,13 +6002,40 @@ def _report(args: list[str]) -> None:
             output_path=output_path,
             status=parsed.status,
             completed=parsed.status == "completed",
-            audit_db_path=run_dir / "audit.db",
+            audit_db_path=_report_audit_path(
+                run_dir=run_dir, workspace_dir=workspace_dir, manifest=manifest
+            ),
         )
     except (OSError, sqlite3.Error, TypeError, ValueError, yaml.YAMLError) as exc:
         parser.error(f"could not generate report: {_concise_cli_error(exc)}")
     raw_artifacts = report.get("artifacts")
     artifacts = raw_artifacts if isinstance(raw_artifacts, dict) else {}
     _write_line(f"report written {artifacts.get('markdown_report_path') or output_path}")
+
+
+def _report_audit_path(
+    *, run_dir: Path, workspace_dir: Path, manifest: RunManifest | None
+) -> Path | None:
+    """Honor the recorded audit location, including an expected source that is missing."""
+    if manifest is not None and manifest.db_path:
+        declared = Path(manifest.db_path)
+        if manifest.workspace_dir:
+            recorded_workspace = Path(manifest.workspace_dir)
+            for recorded_root, actual_root in (
+                (recorded_workspace, workspace_dir),
+                (recorded_workspace.parent, run_dir),
+            ):
+                if declared.is_relative_to(recorded_root):
+                    relative = declared.relative_to(recorded_root)
+                    if ".." not in relative.parts:
+                        return actual_root / relative
+        # External relative paths cannot be relocated without the producer's cwd.
+        # Preserve that declared location; never substitute a healthy default DB.
+        return declared
+    for candidate in (run_dir / "audit.db", workspace_dir / "audit.db"):
+        if candidate.exists() or candidate.is_symlink():
+            return candidate
+    return None
 
 
 def _validate_report_output(parser: argparse.ArgumentParser, output_path: Path) -> None:
@@ -6081,13 +6108,13 @@ def _valid_run_directory(parser: argparse.ArgumentParser, path: Path) -> bool:
     if (workspace / "terminal").is_dir() or (workspace / "traffic").is_dir():
         return True
 
-    audit_path = run_dir / "audit.db"
-    if not audit_path.is_file():
-        return False
-    error = _audit_db_schema_error(audit_path)
-    if error:
-        parser.error(f"invalid Ravage audit database {audit_path}: {error}")
-    return True
+    for audit_path in (run_dir / "audit.db", workspace / "audit.db"):
+        if audit_path.is_file():
+            error = _audit_db_schema_error(audit_path)
+            if error:
+                parser.error(f"invalid Ravage audit database {audit_path}: {error}")
+            return True
+    return False
 
 
 def _observe_settings(run_dir: Path, *, lab_manifest_path: Path | None) -> DashboardSettings:

--- a/packages/ravage/src/ravage/live_dashboard.py
+++ b/packages/ravage/src/ravage/live_dashboard.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -18,6 +18,13 @@ from urllib.parse import unquote, urlparse
 
 import yaml
 
+from ravage.live_dashboard_security import (
+    BOOTSTRAP_HTML,
+    BOOTSTRAP_PATH,
+    BOOTSTRAP_SCRIPT,
+    CONTENT_SECURITY_POLICY,
+    CockpitAccess,
+)
 from ravage.live_dashboard_view import (
     _activity,
     _agents,
@@ -417,7 +424,7 @@ def serve_dashboard(
     port: int = 8787,
 ) -> None:
     cockpit = start_cockpit(settings, host=host, port=port)
-    sys.stdout.write(f"ravage cockpit listening on {cockpit.url}\n")
+    sys.stdout.write(f"ravage cockpit private link: {cockpit.url}\n")
     sys.stdout.flush()
     try:
         cockpit.wait_forever()
@@ -434,7 +441,7 @@ class CockpitServer:
 
     server: ThreadingHTTPServer
     thread: threading.Thread
-    url: str
+    url: str = field(repr=False)
     stop_event: threading.Event
 
     def wait_forever(self) -> None:
@@ -454,12 +461,11 @@ def start_cockpit(
     host: str = "127.0.0.1",
     port: int = 8787,
 ) -> CockpitServer:
-    handler = _handler(settings)
+    access = CockpitAccess(bind_host=host)
+    handler = _handler(settings, access)
     server = ThreadingHTTPServer((host, port), handler)
     stop_event = threading.Event()
-    thread = threading.Thread(
-        target=server.serve_forever, name="ravage-cockpit", daemon=True
-    )
+    thread = threading.Thread(target=server.serve_forever, name="ravage-cockpit", daemon=True)
     thread.start()
     if settings.run_root is not None:
         reaper = threading.Thread(
@@ -470,7 +476,10 @@ def start_cockpit(
         )
         reaper.start()
     return CockpitServer(
-        server=server, thread=thread, url=f"http://{host}:{port}", stop_event=stop_event
+        server=server,
+        thread=thread,
+        url=access.launch_url(server.server_port),
+        stop_event=stop_event,
     )
 
 
@@ -743,115 +752,180 @@ def _run_docker_json_lines(command: list[str], *, timeout: int) -> list[dict[str
 _RUN_TEARDOWN_RE = re.compile(r"/api/run/(?P<run_id>[^/]*)/teardown")
 
 
-def _handler(settings: DashboardSettings) -> type[BaseHTTPRequestHandler]:
-    class DashboardHandler(BaseHTTPRequestHandler):
-        def handle(self) -> None:
-            try:
-                super().handle()
-            except ConnectionResetError:
-                return
+class _DashboardHandler(BaseHTTPRequestHandler):
+    settings: DashboardSettings
+    access: CockpitAccess
+    server: ThreadingHTTPServer
 
-        def do_GET(self) -> None:
-            path = urlparse(self.path).path
-            self._route_get(path)
-
-        def do_POST(self) -> None:
-            path = urlparse(self.path).path
-            run_id = _teardown_run_id(path)
-            if run_id is not None:
-                self._send_json(teardown_active_run(settings, run_id))
-                return
-            self.send_error(HTTPStatus.NOT_FOUND)
-
-        def log_message(self, format: str, *args: object) -> None:  # noqa: A002, ARG002
+    def handle(self) -> None:
+        try:
+            super().handle()
+        except ConnectionResetError:
             return
 
-        def _route_get(self, path: str) -> None:
-            if path == "/api/state":
-                self._send_json(build_dashboard_state(settings))
-                return
-            if path == "/api/events/stream":
-                self._send_state_stream()
-                return
-            if path == "/assets/ravage_logo.png":
-                self._send_file(LOGO_PATH)
-                return
-            self._send_frontend_file(path)
-
-        def _send_json(self, payload: Mapping[str, Any]) -> None:
-            body = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
-            self._send_body(body, status=HTTPStatus.OK, content_type="application/json")
-
-        def _send_state_stream(self) -> None:
-            self._send_stream_headers()
-            cursor = _StreamCursor()
-            while True:
-                try:
-                    self._write_state_stream_tick(cursor)
-                    time.sleep(1.0)
-                except (BrokenPipeError, ConnectionResetError):
-                    return
-
-        def _send_stream_headers(self) -> None:
-            self.send_response(HTTPStatus.OK)
-            self.send_header("Content-Type", "text/event-stream")
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Connection", "keep-alive")
-            self.send_header("X-Accel-Buffering", "no")
-            self.end_headers()
-
-        def _write_state_stream_tick(self, cursor: _StreamCursor) -> None:
-            state = build_dashboard_state(settings)
-            for event_name, data in cursor.deltas(state):
-                self._write_sse(event_name, data)
-            self.wfile.write(b": keepalive\n\n")
-            self.wfile.flush()
-
-        def _write_sse(self, event_name: str, data: object) -> None:
-            body = json.dumps(data, sort_keys=True, default=str)
-            self.wfile.write(f"event: {event_name}\ndata: {body}\n\n".encode())
-
-        def _send_frontend_file(self, request_path: str) -> None:
-            path = _frontend_request_path(request_path)
-            resolved = _safe_static_path(FRONTEND_DIR, path)
-            if resolved is not None and _static_file_available(resolved):
-                self._send_file(resolved)
-                return
-            if path != "/index.html":
-                self.send_error(HTTPStatus.NOT_FOUND)
-                return
-            self._send_missing_frontend()
-
-        def _send_file(self, path: Path) -> None:
-            if not path.exists() or not path.is_file():
-                self.send_error(HTTPStatus.NOT_FOUND)
-                return
-            body = path.read_bytes()
-            content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-            self._send_body(body, status=HTTPStatus.OK, content_type=content_type)
-
-        def _send_missing_frontend(self) -> None:
-            body = _missing_frontend_body()
+    def do_GET(self) -> None:
+        if not self._valid_request():
+            return
+        path = urlparse(self.path).path
+        if path == "/":
             self._send_body(
-                body,
-                status=HTTPStatus.SERVICE_UNAVAILABLE,
-                content_type="text/plain; charset=utf-8",
+                BOOTSTRAP_HTML, status=HTTPStatus.OK, content_type="text/html; charset=utf-8"
             )
+            return
+        if path == BOOTSTRAP_PATH:
+            self._send_body(
+                BOOTSTRAP_SCRIPT,
+                status=HTTPStatus.OK,
+                content_type="text/javascript; charset=utf-8",
+            )
+            return
+        if path.startswith("/api/") and not self._authorized():
+            return
+        self._route_get(path)
 
-        def _send_body(
-            self,
-            body: bytes,
-            *,
-            status: HTTPStatus,
-            content_type: str,
-        ) -> None:
-            self.send_response(status)
-            self.send_header("Content-Type", content_type)
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+    def do_POST(self) -> None:
+        if not self._valid_request(mutation=True):
+            return
+        path = urlparse(self.path).path
+        if path == "/api/session":
+            if not self.access.bearer_authorized(self.headers):
+                self.send_error(HTTPStatus.UNAUTHORIZED)
+                return
+            self._send_json({"authenticated": True, "session_token": self.access.session})
+            return
+        if not self._authorized():
+            return
+        run_id = _teardown_run_id(path)
+        if run_id is not None:
+            self._send_json(teardown_active_run(self.settings, run_id))
+            return
+        self.send_error(HTTPStatus.NOT_FOUND)
 
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002, ARG002
+        return
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Content-Security-Policy", CONTENT_SECURITY_POLICY)
+        super().end_headers()
+
+    def _valid_request(self, *, mutation: bool = False) -> bool:
+        origin = self.access.request_origin(
+            self.headers,
+            local_host=str(self.connection.getsockname()[0]),
+            port=self.server.server_port,
+        )
+        if origin is None:
+            self.send_error(HTTPStatus.FORBIDDEN)
+            return False
+        if mutation and self.headers.get_all("Origin", []) != [origin]:
+            self.send_error(HTTPStatus.FORBIDDEN)
+            return False
+        return True
+
+    def _authorized(self) -> bool:
+        if self.access.authorized(self.headers):
+            return True
+        self.send_error(HTTPStatus.UNAUTHORIZED)
+        return False
+
+    def _route_get(self, path: str) -> None:
+        if path == "/api/session":
+            self._send_json({"authenticated": True})
+            return
+        if path == "/api/state":
+            self._send_json(build_dashboard_state(self.settings))
+            return
+        if path == "/api/events/stream":
+            self._send_state_stream()
+            return
+        if path == "/assets/ravage_logo.png":
+            self._send_file(LOGO_PATH)
+            return
+        self._send_frontend_file(path)
+
+    def _send_json(self, payload: Mapping[str, Any]) -> None:
+        body = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        self._send_body(body, status=HTTPStatus.OK, content_type="application/json")
+
+    def _send_state_stream(self) -> None:
+        self._send_stream_headers()
+        cursor = _StreamCursor()
+        while True:
+            try:
+                self._write_state_stream_tick(cursor)
+                time.sleep(1.0)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+    def _send_stream_headers(self) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Connection", "keep-alive")
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+
+    def _write_state_stream_tick(self, cursor: _StreamCursor) -> None:
+        state = build_dashboard_state(self.settings)
+        for event_name, data in cursor.deltas(state):
+            self._write_sse(event_name, data)
+        self.wfile.write(b": keepalive\n\n")
+        self.wfile.flush()
+
+    def _write_sse(self, event_name: str, data: object) -> None:
+        body = json.dumps(data, sort_keys=True, default=str)
+        self.wfile.write(f"event: {event_name}\ndata: {body}\n\n".encode())
+
+    def _send_frontend_file(self, request_path: str) -> None:
+        path = _frontend_request_path(request_path)
+        resolved = _safe_static_path(FRONTEND_DIR, path)
+        if resolved is not None and _static_file_available(resolved):
+            self._send_file(resolved)
+            return
+        if path != "/index.html":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        self._send_missing_frontend()
+
+    def _send_file(self, path: Path) -> None:
+        if not path.exists() or not path.is_file():
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        body = path.read_bytes()
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        self._send_body(body, status=HTTPStatus.OK, content_type=content_type)
+
+    def _send_missing_frontend(self) -> None:
+        body = _missing_frontend_body()
+        self._send_body(
+            body,
+            status=HTTPStatus.SERVICE_UNAVAILABLE,
+            content_type="text/plain; charset=utf-8",
+        )
+
+    def _send_body(
+        self,
+        body: bytes,
+        *,
+        status: HTTPStatus,
+        content_type: str,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _handler(settings: DashboardSettings, access: CockpitAccess) -> type[BaseHTTPRequestHandler]:
+    class DashboardHandler(_DashboardHandler):
+        pass
+
+    DashboardHandler.settings = settings
+    DashboardHandler.access = access
     return DashboardHandler
 
 
@@ -875,10 +949,7 @@ def _static_file_available(path: Path) -> bool:
 
 
 def _missing_frontend_body() -> bytes:
-    message = (
-        "Ravage cockpit frontend is missing. Expected files under "
-        f"{FRONTEND_DIR}."
-    )
+    message = f"Ravage cockpit frontend is missing. Expected files under {FRONTEND_DIR}."
     return message.encode()
 
 

--- a/packages/ravage/src/ravage/live_dashboard_security.py
+++ b/packages/ravage/src/ravage/live_dashboard_security.py
@@ -1,0 +1,78 @@
+"""Process-local cockpit capabilities and an origin-scoped browser handoff."""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from email.message import Message
+
+BOOTSTRAP_PATH = "/_cockpit/session.js"
+BOOTSTRAP_HTML = b"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ravage Cockpit</title></head><body>
+<p id="session-status">Opening Ravage Cockpit...</p>
+<script type="module" src="/_cockpit/session.js"></script>
+</body></html>
+"""
+BOOTSTRAP_SCRIPT = b"""import { openCockpitSession } from "/src/transport.js";
+openCockpitSession();
+"""
+CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; script-src 'self'; style-src 'self'; "
+    "img-src 'self'; connect-src 'self'; base-uri 'none'; "
+    "frame-ancestors 'none'; form-action 'none'"
+)
+_WILDCARD_HOSTS = frozenset({"", "0.0.0.0", "::"})  # noqa: S104
+
+
+def _authority(host: str, port: int) -> str:
+    rendered = f"[{host}]" if ":" in host else host.lower()
+    return f"{rendered}:{port}"
+
+
+def _matches(presented: str, expected: str) -> bool:
+    return secrets.compare_digest(presented.encode("utf-8"), expected.encode("ascii"))
+
+
+@dataclass(frozen=True)
+class CockpitAccess:
+    bind_host: str
+    capability: str = field(default_factory=lambda: secrets.token_urlsafe(32), repr=False)
+    session: str = field(default_factory=lambda: secrets.token_urlsafe(32), repr=False)
+
+    def launch_url(self, port: int) -> str:
+        host = "127.0.0.1" if self.bind_host in _WILDCARD_HOSTS else self.bind_host
+        return f"http://{_authority(host, port)}/#token={self.capability}"
+
+    def request_origin(self, headers: Message, *, local_host: str, port: int) -> str | None:
+        """Accept only the configured host or this connection's local interface."""
+        hosts = headers.get_all("Host", [])
+        if len(hosts) != 1:
+            return None
+        host = hosts[0].lower()
+        allowed_hosts = {local_host}
+        if self.bind_host not in _WILDCARD_HOSTS:
+            allowed_hosts.add(self.bind_host)
+        authorities = {_authority(value, port) for value in allowed_hosts}
+        if port == 80:  # noqa: PLR2004
+            authorities.update(value.lower() for value in allowed_hosts)
+        return f"http://{host}" if host in authorities else None
+
+    def bearer_authorized(self, headers: Message) -> bool:
+        values = headers.get_all("Authorization", [])
+        return (
+            len(values) == 1
+            and values[0].startswith("Bearer ")
+            and _matches(values[0][len("Bearer ") :], self.capability)
+        )
+
+    def authorized(self, headers: Message) -> bool:
+        values = headers.get_all("Authorization", [])
+        if len(values) != 1 or not values[0].startswith("Bearer "):
+            return False
+        token = values[0][len("Bearer ") :]
+        return _matches(token, self.capability) or _matches(token, self.session)

--- a/packages/ravage/src/ravage/memory_eval.py
+++ b/packages/ravage/src/ravage/memory_eval.py
@@ -1,99 +1,23 @@
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
-from dataclasses import dataclass
-from pathlib import Path
-
-from ravage.agent_core.ai_agent import ChatMessage
-from ravage.memory import MemoryStore
-from ravage.model_core.providers import DEFAULT_OUTPUT_TOKEN_LIMIT_PARAMETER, ResolvedModelRoute
+from typing import NoReturn
 
 
-@dataclass(frozen=True)
-class MemoryEvalSide:
-    false_negatives: int = 0
+class MemoryEvalUnavailableError(ValueError):
+    """Raised when the retired memory evaluation entry point is called."""
 
 
-@dataclass(frozen=True)
-class MemoryEvalReport:
-    report_path: Path
-    baseline: MemoryEvalSide
-    memory: MemoryEvalSide
-    passed: bool
+def run_memory_eval(*_args: object, **_kwargs: object) -> NoReturn:
+    """
+    Fail explicitly until memory A/B evaluation has a supported implementation.
 
-    def to_json(self) -> dict[str, object]:
-        return {
-            "report_path": str(self.report_path),
-            "baseline": {"false_negatives": self.baseline.false_negatives},
-            "memory": {"false_negatives": self.memory.false_negatives},
-            "delta": {
-                "false_negatives": self.memory.false_negatives - self.baseline.false_negatives
-            },
-            "passed": self.passed,
-        }
-
-
-def run_memory_eval(*args: object, **kwargs: object) -> MemoryEvalReport:
-    output_dir = Path(kwargs.get("output_dir") or "memory-eval")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    report_path = output_dir / "memory-eval-report.json"
-    _exercise_model_clients(kwargs.get("off_ai_model_clients"), memory_hints="")
-    _exercise_model_clients(
-        kwargs.get("read_ai_model_clients"),
-        memory_hints=_memory_hints_text(kwargs.get("memory_db_path")),
+    Retain the entry point so old callers receive an actionable error. In
+    particular, never call model clients or write invented benchmark results.
+    """
+    message = (
+        "Memory A/B evaluation is unavailable: active memory is not supported by the "
+        "CLI and this entry point has no benchmark evaluator. No evaluation was run "
+        "and no report was generated. Use --memory off for supported runs; compare "
+        "real, independently recorded results before claiming a memory improvement."
     )
-    report = MemoryEvalReport(
-        report_path=report_path,
-        baseline=MemoryEvalSide(false_negatives=1),
-        memory=MemoryEvalSide(false_negatives=0),
-        passed=True,
-    )
-    report_path.write_text(json.dumps(report.to_json(), sort_keys=True), encoding="utf-8")
-    _ = args
-    return report
-
-
-def _exercise_model_clients(raw_clients: object, *, memory_hints: str) -> None:
-    if not isinstance(raw_clients, Mapping):
-        return
-    route = _memory_eval_route()
-    for case_id, client in raw_clients.items():
-        complete = getattr(client, "complete", None)
-        if not callable(complete):
-            continue
-        prompt = f"MEMORY_EVAL_CASE {case_id}"
-        if memory_hints:
-            prompt = f"{prompt}\n\nMEMORY_HINTS\n{memory_hints}"
-        complete(messages=[ChatMessage(role="user", content=prompt)], route=route)
-
-
-def _memory_hints_text(raw_path: object) -> str:
-    if not isinstance(raw_path, str | Path):
-        return ""
-    store = MemoryStore(Path(raw_path))
-    try:
-        hints = store.retrieve_hints(target_fingerprint={}, min_confidence=0.0, limit=5)
-        return "\n".join(hint.item.summary for hint in hints)
-    finally:
-        store.close()
-
-
-def _memory_eval_route() -> ResolvedModelRoute:
-    return ResolvedModelRoute(
-        requested_tier="low",
-        selected_tier="low",
-        ordinal=0,
-        provider="openai",
-        model="memory-eval-test",
-        base_url=None,
-        api_key_env=None,
-        missing_env=(),
-        reasoning_effort=None,
-        max_output_tokens=256,
-        output_token_limit_parameter=DEFAULT_OUTPUT_TOKEN_LIMIT_PARAMETER,
-        input_cost_per_1m_tokens=None,
-        output_cost_per_1m_tokens=None,
-        timeout_seconds=30.0,
-        max_retries=0,
-    )
+    raise MemoryEvalUnavailableError(message)

--- a/packages/ravage/src/ravage/outcome_evidence.py
+++ b/packages/ravage/src/ravage/outcome_evidence.py
@@ -1259,8 +1259,10 @@ def _workspace_records(
     records: list[tuple[str, dict[str, object]]] = []
     for events_path in _workspace_event_paths(workspace_path):
         try:
+            if not events_path.is_file():
+                continue
             lines = events_path.read_text(encoding="utf-8").splitlines()
-        except OSError:
+        except (OSError, UnicodeError):
             continue
         for line in lines:
             value = _json_object(line)
@@ -1298,7 +1300,7 @@ def _audit_records(  # noqa: C901 - legacy schemas are read fail-closed per tabl
         return []
     records: list[tuple[str, dict[str, object]]] = []
     try:
-        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        connection = sqlite3.connect(db_path.resolve().as_uri() + "?mode=ro", uri=True)
         try:
             parameters: tuple[str, ...] = ()
             query = "SELECT action, payload_json FROM audit_log"
@@ -1309,7 +1311,7 @@ def _audit_records(  # noqa: C901 - legacy schemas are read fail-closed per tabl
             try:
                 audit_rows = connection.execute(query, parameters).fetchall()
             except sqlite3.Error:
-                audit_rows = ()
+                audit_rows = []
             for action, raw_payload in audit_rows:
                 payload = _json_object(str(raw_payload or ""))
                 if payload:
@@ -1325,7 +1327,7 @@ def _audit_records(  # noqa: C901 - legacy schemas are read fail-closed per tabl
                     finding_parameters,
                 ).fetchall()
             except sqlite3.Error:
-                finding_rows = ()
+                finding_rows = []
             for (raw_payload,) in finding_rows:
                 payload = _json_object(str(raw_payload or ""))
                 if payload:

--- a/packages/ravage/src/ravage/proof_bundle_eval.py
+++ b/packages/ravage/src/ravage/proof_bundle_eval.py
@@ -2,10 +2,19 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Literal
 
-from pentest_schemas.proof_bundle import ProofVerifierVerdict
+from pentest_schemas.proof_bundle import ProofBundle, ProofVerifierVerdict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+_VERDICTS = frozenset({"accepted", "rejected", "inconclusive"})
+
+
+class ProofBundleEvalInputError(ValueError):
+    """Raised when the supplied evaluation dataset is malformed."""
 
 
 @dataclass(frozen=True)
@@ -30,6 +39,7 @@ class ProofBundleEvalResult:
 @dataclass(frozen=True)
 class ProofBundleEvalReport:
     results: list[ProofBundleEvalResult] = field(default_factory=list)
+    evaluation_mode: Literal["recorded_verdicts", "provided_verifier"] = "recorded_verdicts"
 
     @property
     def total(self) -> int:
@@ -37,7 +47,10 @@ class ProofBundleEvalReport:
 
     @property
     def passed(self) -> int:
-        return sum(item.expected_verdict == item.actual_verdict and not item.gate_failures for item in self.results)
+        return sum(
+            item.expected_verdict == item.actual_verdict and not item.gate_failures
+            for item in self.results
+        )
 
     @property
     def failed(self) -> int:
@@ -45,11 +58,48 @@ class ProofBundleEvalReport:
 
     @property
     def false_positive(self) -> int:
-        return sum(item.expected_verdict != "accepted" and item.actual_verdict == "accepted" for item in self.results)
+        return sum(
+            item.expected_verdict != "accepted" and item.actual_verdict == "accepted"
+            for item in self.results
+        )
 
     @property
     def false_negative(self) -> int:
-        return sum(item.expected_verdict == "accepted" and item.actual_verdict != "accepted" for item in self.results)
+        return sum(
+            item.expected_verdict == "accepted" and item.actual_verdict != "accepted"
+            for item in self.results
+        )
+
+    @property
+    def status(self) -> Literal["empty", "failed", "passed"]:
+        if not self.total:
+            return "empty"
+        return "failed" if self.failed else "passed"
+
+    @property
+    def successful(self) -> bool:
+        return self.status == "passed"
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "evaluation_mode": self.evaluation_mode,
+            "status": self.status,
+            "successful": self.successful,
+            "total": self.total,
+            "passed": self.passed,
+            "failed": self.failed,
+            "false_positive": self.false_positive,
+            "false_negative": self.false_negative,
+            "results": [
+                {
+                    "case_id": item.case_id,
+                    "expected_verdict": item.expected_verdict,
+                    "actual_verdict": item.actual_verdict,
+                    "gate_failures": list(item.gate_failures),
+                }
+                for item in self.results
+            ],
+        }
 
 
 def evaluate_proof_bundle_cases(
@@ -58,66 +108,127 @@ def evaluate_proof_bundle_cases(
     verifier: Callable[[object], ProofVerifierVerdict] | None = None,
     semantic_verifier: Callable[[object], ProofVerifierVerdict] | None = None,
 ) -> ProofBundleEvalReport:
+    """Score supplied offline cases; recorded verdicts are not independent verification."""
     results: list[ProofBundleEvalResult] = []
     selected_verifier = semantic_verifier or verifier
-    for case in cases:
-        verdict = _actual_verdict(case.bundle, selected_verifier)
-        gate_failures = _gate_failures(case.bundle, verdict)
+    validated_bundles = _validate_cases(cases)
+    for case, bundle in zip(cases, validated_bundles, strict=True):
+        verdict = (
+            ProofVerifierVerdict.model_validate(selected_verifier(case.bundle))
+            if selected_verifier is not None
+            else bundle.verifier
+        )
+        gate_failures = _gate_failures(bundle, verdict)
         results.append(
             ProofBundleEvalResult(
                 case.case_id,
                 case.expected_verdict,
-                verdict,
+                verdict.verdict,
                 gate_failures=gate_failures,
             )
         )
-    return ProofBundleEvalReport(results)
+    return ProofBundleEvalReport(
+        results,
+        evaluation_mode="provided_verifier" if selected_verifier else "recorded_verdicts",
+    )
 
 
 def load_proof_bundle_eval_cases(path: Path) -> list[ProofBundleEvalCase]:
     cases: list[ProofBundleEvalCase] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         text = line.strip()
         if not text or text.startswith("#"):
             continue
-        raw = json.loads(text)
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            message = f"{path}:{line_number}: invalid JSON: {exc.msg}"
+            raise ProofBundleEvalInputError(message) from exc
+        if not isinstance(raw, dict):
+            message = f"{path}:{line_number}: case must be a JSON object"
+            raise ProofBundleEvalInputError(message)
         bundle = raw.get("proof_bundle")
-        if not isinstance(bundle, dict):
+        if "proof_bundle" not in raw:
             bundle = raw.get("bundle")
         if not isinstance(bundle, dict):
-            bundle = {}
+            message = f"{path}:{line_number}: proof_bundle must be an object"
+            raise ProofBundleEvalInputError(message)
+        case_id = raw.get("case_id")
+        expected_verdict = raw.get("expected_verdict")
+        if not isinstance(case_id, str) or not isinstance(expected_verdict, str):
+            message = f"{path}:{line_number}: case_id and expected_verdict must be strings"
+            raise ProofBundleEvalInputError(message)
         cases.append(
             ProofBundleEvalCase(
-                case_id=str(raw["case_id"]),
-                expected_verdict=str(raw["expected_verdict"]),
+                case_id=case_id,
+                expected_verdict=expected_verdict,
                 proof_bundle=bundle,
             )
         )
+    _validate_cases(cases)
     return cases
 
 
-def _actual_verdict(
-    bundle: dict[str, object],
-    verifier: Callable[[object], ProofVerifierVerdict] | None,
-) -> str:
-    if verifier is not None:
-        return verifier(bundle).verdict
-
-    raw_verifier = bundle.get("verifier")
-    if not isinstance(raw_verifier, dict):
-        return "rejected"
-    return str(raw_verifier.get("verdict") or "rejected")
+def write_proof_bundle_eval_report(report: ProofBundleEvalReport, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def _gate_failures(bundle: dict[str, object], verdict: str) -> tuple[str, ...]:
+def _validate_cases(cases: list[ProofBundleEvalCase]) -> list[ProofBundle]:
+    seen_ids: set[str] = set()
+    bundles: list[ProofBundle] = []
+    for case in cases:
+        if not case.case_id.strip() or case.case_id in seen_ids:
+            message = "proof-bundle evaluation case IDs must be nonempty and unique"
+            raise ProofBundleEvalInputError(message)
+        if case.expected_verdict not in _VERDICTS:
+            message = f"case {case.case_id!r}: invalid expected_verdict"
+            raise ProofBundleEvalInputError(message)
+        seen_ids.add(case.case_id)
+        try:
+            bundle = ProofBundle.model_validate(case.bundle)
+        except ValueError as exc:
+            message = f"case {case.case_id!r}: invalid proof_bundle: {exc}"
+            raise ProofBundleEvalInputError(message) from exc
+        reference_errors = _bundle_reference_errors(bundle)
+        if reference_errors:
+            message = f"case {case.case_id!r}: " + "; ".join(reference_errors)
+            raise ProofBundleEvalInputError(message)
+        bundles.append(bundle)
+    return bundles
+
+
+def _bundle_reference_errors(bundle: ProofBundle) -> list[str]:
+    errors: list[str] = []
+    step_ids = [step.step_id for step in bundle.steps]
+    if any(not step_id.strip() for step_id in step_ids) or len(set(step_ids)) != len(step_ids):
+        errors.append("proof step IDs must be nonempty and unique")
+    control_ids = [control.control_id for control in bundle.controls]
+    if any(not item.strip() for item in control_ids) or len(set(control_ids)) != len(control_ids):
+        errors.append("proof control IDs must be nonempty and unique")
+    known_steps = set(step_ids)
+    errors.extend(
+        f"control {control.control_id!r} refers to an unknown proof step"
+        for control in bundle.controls
+        if any(step_id not in known_steps for step_id in control.step_ids)
+    )
+    if any(
+        link.source_step_id not in known_steps or link.observed_step_id not in known_steps
+        for link in bundle.provenance
+    ):
+        errors.append("provenance refers to an unknown proof step")
+    return errors
+
+
+def _gate_failures(bundle: ProofBundle, verdict: ProofVerifierVerdict) -> tuple[str, ...]:
     failures: list[str] = []
-    if verdict != "accepted":
+    if verdict.verdict != "accepted":
         return ()
-
-    verifier = bundle.get("verifier")
-    impact = ""
-    if isinstance(verifier, dict):
-        impact = str(verifier.get("impact") or "").strip()
-    if not impact:
+    if not (verdict.impact or "").strip():
         failures.append("missing proof_bundle.verifier.impact")
+    failures.extend(
+        f"proof control {control.control_id!r} did not pass"
+        for control in bundle.controls
+        if not control.passed
+    )
     return tuple(failures)

--- a/packages/ravage/src/ravage/report.py
+++ b/packages/ravage/src/ravage/report.py
@@ -5,14 +5,17 @@ import os
 import re
 import sqlite3
 import stat
+from contextlib import closing
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from ravage.finding_evidence import confirmed_finding_evidence_failures
 from ravage.hosting_layer import HOSTING_LAYER_EVENT_KIND, run_configured_hosting_layer_agent
 from ravage.outcome_evidence import load_run_outcome, load_validated_captured_flags
+from ravage.report_io import atomic_write_private_report
 from ravage.run_data.brief import load_engagement_brief
 from ravage.run_data.run_manifest import read_manifest
 from ravage.traffic.manifest import (
@@ -34,12 +37,13 @@ if TYPE_CHECKING:
 
     from ravage.traffic.provenance import AgentHttpEvidenceLink
 
-REPORT_SCHEMA_VERSION = "2026-09-04"
+REPORT_SCHEMA_VERSION = "2026-09-05"
 PRO_REPORT_MODULE = "ravage_pro.report"
 PRO_REPORT_SUFFIXES = frozenset({".pdf", ".docx"})
 CORE_REPORT_SUFFIXES = frozenset({"", ".md", ".json"})
 
 _PROOF_RE = re.compile(r"\b(?:flag|FLAG|HTB|CTF)\{[^}\r\n]{1,512}\}")
+_PATH_SEPARATOR_RE = re.compile(r"([/\\\\]+)")
 _SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
     re.compile(
@@ -51,6 +55,13 @@ _SECRET_PATTERNS = (
 
 _MIN_SECRET_REPLACEMENT_GROUPS = 5
 _GRAPH_MARKER_MAX_BYTES = 262_144
+_EVENT_WORKSPACE_MARKERS = (
+    "working_state.json",
+    "transcript.jsonl",
+    "scan-summary.json",
+    "graph-state.json",
+    "remote-graph-state.json",
+)
 type _ExpectedTrafficBoundary = tuple[
     str,
     str | None,
@@ -136,6 +147,60 @@ _REMEDIATIONS = {
 }
 
 
+@dataclass(frozen=True)
+class _AuditSourceHealth:
+    status: Literal["not_requested", "available", "missing", "unreadable", "invalid_records"]
+    rows_loaded: int = 0
+    rejected_rows: int = 0
+
+    @property
+    def complete(self) -> bool:
+        return self.status in {"not_requested", "available"}
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "expected": self.status != "not_requested",
+            "status": self.status,
+            "rows_loaded": self.rows_loaded,
+            "rejected_rows": self.rejected_rows,
+        }
+
+
+@dataclass(frozen=True)
+class _AuditFindingsSource(_AuditSourceHealth):
+    findings: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "expected": self.status != "not_requested",
+            "status": self.status,
+            "confirmed_rows_loaded": self.rows_loaded,
+            "accepted_findings": len(self.findings),
+            "rejected_rows": self.rejected_rows,
+        }
+
+
+@dataclass(frozen=True)
+class _EventSourceHealth:
+    path: Path
+    status: Literal["not_requested", "available", "missing", "unreadable", "invalid_records"]
+    events: list[dict[str, Any]] = field(default_factory=list)
+    parse_errors: int = 0
+
+    @property
+    def complete(self) -> bool:
+        return self.status in {"not_requested", "available"}
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "events_path": str(self.path),
+            "expected": self.status != "not_requested",
+            "status": self.status,
+            "events_loaded": len(self.events),
+            "parse_errors": self.parse_errors,
+        }
+
+
 class ProFeatureRequiredError(RuntimeError):
     """Raised when a report output requires a separately licensed Pro package."""
 
@@ -193,8 +258,6 @@ def write_pentest_report(  # noqa: PLR0913
         audit_db_path=audit_db_path,
         error=error,
     )
-    markdown = render_markdown_report(report)
-
     output_path.parent.mkdir(parents=True, exist_ok=True)
     suffix = output_path.suffix.lower()
     json_path = output_path.with_suffix(".json")
@@ -213,13 +276,15 @@ def write_pentest_report(  # noqa: PLR0913
         "markdown_report_path": str(markdown_path),
         "professional_report_path": str(pro_path) if pro_path else "",
     }
-
-    markdown_path.write_text(markdown, encoding="utf-8")
+    report = redact_report_payload(report)
+    markdown = render_markdown_report(report)
+    atomic_write_private_report(markdown_path, markdown)
     if pro_path is not None:
         report["artifacts"].update(
             _write_professional_report(report=report, markdown=markdown, output_path=pro_path)
         )
-    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report = redact_report_payload(report)
+    atomic_write_private_report(json_path, json.dumps(report, indent=2, sort_keys=True) + "\n")
     return report
 
 
@@ -299,29 +364,31 @@ def build_pentest_report(  # noqa: PLR0913
     error: str | None = None,
 ) -> dict[str, Any]:
     brief = load_engagement_brief(brief_path)
-    events, parse_errors, event_paths = _load_run_events(workspace_dir)
+    event_sources = _load_run_events(workspace_dir, audit_requested=audit_db_path is not None)
+    events = [event for source in event_sources for event in source.events]
+    parse_errors = sum(source.parse_errors for source in event_sources)
+    event_paths = [
+        source.path for source in event_sources if source.status in {"available", "invalid_records"}
+    ]
     manifest = read_manifest(workspace_dir.parent)
     flags = load_validated_captured_flags(
         db_path=audit_db_path,
         workspace_path=workspace_dir,
         engagement_id=brief.engagement_id,
     )
-    findings = (
-        _audit_findings(
-            audit_db_path,
-            scope=brief.scope,
-            engagement_id=brief.engagement_id,
-        )
-        if audit_db_path is not None
-        else []
+    audit_source = _audit_findings(
+        audit_db_path,
+        scope=brief.scope,
+        engagement_id=brief.engagement_id,
     )
-    findings.extend(
-        _confirmed_findings(
-            events,
-            scope=brief.scope,
-            engagement_id=brief.engagement_id,
-        )
+    audit_log_source = _audit_log_health(audit_db_path, engagement_id=brief.engagement_id)
+    findings = list(audit_source.findings)
+    event_findings, rejected_confirmed_events = _confirmed_findings(
+        events,
+        scope=brief.scope,
+        engagement_id=brief.engagement_id,
     )
+    findings.extend(event_findings)
     findings = _dedupe_findings(findings)
     outcome = load_run_outcome(
         db_path=audit_db_path,
@@ -333,7 +400,15 @@ def build_pentest_report(  # noqa: PLR0913
     hosting_layer = _hosting_layer_summary(events)
     proof_observations = _proof_observations(events)
     severity_counts = _severity_counts(findings)
-    overall_risk = _overall_risk(findings=findings, flags=flags, status=status)
+    evidence_complete = (
+        audit_source.complete
+        and audit_log_source.complete
+        and all(source.complete for source in event_sources)
+        and rejected_confirmed_events == 0
+    )
+    overall_risk = _overall_risk(
+        findings=findings, flags=flags, status=status, evidence_complete=evidence_complete
+    )
     recommendations = _recommendations(findings=findings, flags=flags)
 
     generated_at = datetime.now(UTC).isoformat()
@@ -377,6 +452,7 @@ def build_pentest_report(  # noqa: PLR0913
                 finding_count=len(findings),
                 flag_count=len(flags),
                 error=error,
+                evidence_complete=evidence_complete,
             ),
         },
         "reconnaissance": recon,
@@ -405,20 +481,27 @@ def build_pentest_report(  # noqa: PLR0913
             "The report does not expand truncated artifacts into full response bodies.",
         ],
         "source_quality": {
+            "status": "complete" if evidence_complete else "incomplete",
+            "audit_source": audit_source.to_json(),
+            "audit_log_source": audit_log_source.to_json(),
+            "event_sources": [source.to_json() for source in event_sources],
             "events_path": str(workspace_dir / "events.jsonl"),
             "event_paths": [str(path) for path in event_paths],
             "events_loaded": len(events),
             "event_parse_errors": parse_errors,
+            "rejected_confirmed_events": rejected_confirmed_events,
             "audit_db_path": str(audit_db_path) if audit_db_path else "",
         },
     }
-    return cast("dict[str, Any]", _redact_recursive(report))
+    return redact_report_payload(report)
 
 
 def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
     engagement = _dict(report.get("engagement"))
     summary = _dict(report.get("executive_summary"))
     proofs = _dict(report.get("captured_proofs"))
+    source_quality = _dict(report.get("source_quality"))
+    evidence_complete = source_quality.get("status") != "incomplete"
     scope = _dict(engagement.get("scope"))
     rules = _dict(engagement.get("rules_of_engagement"))
     outcome = _dict(report.get("outcome"))
@@ -449,6 +532,7 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
         f"- Physical target requests: {traffic_count}",
         f"- Request accounting status: {traffic_status}",
         f"- Completion status: {report.get('status', '')}",
+        f"- Evidence completeness: {source_quality.get('status', 'unknown')}",
         "",
         "## Scope and Engagement",
         "",
@@ -474,7 +558,13 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
     if not findings:
         lines.extend(
             [
-                "No confirmed vulnerability findings were recorded in the run artifacts.",
+                (
+                    "No confirmed vulnerability findings were recorded in the run artifacts."
+                    if evidence_complete
+                    else "No confirmed findings could be recovered from the available evidence. "
+                    "Evidence is incomplete; this does not establish the absence "
+                    "of vulnerabilities."
+                ),
                 "",
             ]
         )
@@ -535,8 +625,34 @@ def render_markdown_report(report: dict[str, Any]) -> str:  # noqa: PLR0915
     lines.extend(f"- {item}" for item in _list(report.get("limitations")))
     lines.extend(["", "## Evidence Handling", ""])
     lines.extend(f"- {item}" for item in _list(report.get("evidence_handling")))
+    lines.extend(_source_quality_markdown(source_quality))
     lines.append("")
     return "\n".join(lines)
+
+
+def _source_quality_markdown(source_quality: dict[str, Any]) -> list[str]:
+    audit_source = _dict(source_quality.get("audit_source"))
+    audit_log_source = _dict(source_quality.get("audit_log_source"))
+    lines = [
+        "",
+        "## Source Quality",
+        "",
+        f"- Evidence completeness: {source_quality.get('status', 'unknown')}",
+        f"- Audit findings source: {audit_source.get('status', 'unknown')}",
+        f"- Rejected audit rows: {audit_source.get('rejected_rows', 0)}",
+        f"- Audit log source: {audit_log_source.get('status', 'unknown')}",
+        f"- Rejected audit log rows: {audit_log_source.get('rejected_rows', 0)}",
+        f"- Event parse errors: {source_quality.get('event_parse_errors', 0)}",
+        f"- Rejected confirmed events: {source_quality.get('rejected_confirmed_events', 0)}",
+    ]
+    for source in _list(source_quality.get("event_sources")):
+        event_source = _dict(source)
+        if event_source.get("expected"):
+            lines.append(
+                f"- Event source: {event_source.get('events_path', '')} "
+                f"({event_source.get('status', 'unknown')})"
+            )
+    return lines
 
 
 def _recon_markdown(recon: dict[str, Any]) -> list[str]:
@@ -894,8 +1010,7 @@ def _validated_agent_http_lane(
         message = "traffic artifacts are present but could not be validated"
         raise TrafficProvenanceError(message) from exc
     if any(
-        exchange.capture_session_id != traffic_manifest.capture_session_id
-        for exchange in exchanges
+        exchange.capture_session_id != traffic_manifest.capture_session_id for exchange in exchanges
     ) or any(
         receipt.capture_session_id != traffic_manifest.capture_session_id
         for receipt in replay_receipts
@@ -976,9 +1091,7 @@ def _expected_traffic_manifest_boundary(
     persisted_target = sanitize_url(raw_target)
     expected_identity = (
         None
-        if (
-            raw_target in (REDACTED_URL, persisted_target) or "[redacted" in decoded_target
-        )
+        if (raw_target in (REDACTED_URL, persisted_target) or "[redacted" in decoded_target)
         else expected.target_identity
     )
     return (
@@ -1116,12 +1229,23 @@ def _agent_http_evidence_markdown(summary: dict[str, Any]) -> list[str]:
     return lines
 
 
-def _load_events(path: Path) -> tuple[list[dict[str, Any]], int]:
-    if not path.exists():
-        return [], 0
+def _load_events(path: Path) -> _EventSourceHealth:
+    expected = False
+    try:
+        expected = path.is_symlink() or any(
+            (path.parent / marker).exists() for marker in _EVENT_WORKSPACE_MARKERS
+        )
+        if not stat.S_ISREG(path.stat().st_mode):
+            return _EventSourceHealth(path, status="unreadable")
+        expected = True
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _EventSourceHealth(path, status="missing" if expected else "not_requested")
+    except (OSError, UnicodeError):
+        return _EventSourceHealth(path, status="unreadable")
     events: list[dict[str, Any]] = []
     parse_errors = 0
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for line in content.splitlines():
         if not line.strip():
             continue
         try:
@@ -1131,28 +1255,32 @@ def _load_events(path: Path) -> tuple[list[dict[str, Any]], int]:
             continue
         if isinstance(event, dict):
             events.append(event)
-    return events, parse_errors
+        else:
+            parse_errors += 1
+    return _EventSourceHealth(
+        path,
+        status="invalid_records" if parse_errors else "available",
+        events=events,
+        parse_errors=parse_errors,
+    )
 
 
 def _load_run_events(
     workspace_dir: Path,
-) -> tuple[list[dict[str, Any]], int, tuple[Path, ...]]:
+    *,
+    audit_requested: bool,
+) -> tuple[_EventSourceHealth, ...]:
     candidates = (
         workspace_dir / "events.jsonl",
         workspace_dir / "autonomous-route" / "events.jsonl",
         workspace_dir / "autonomous-route" / "agent-graph" / "events.jsonl",
     )
-    events: list[dict[str, Any]] = []
-    parse_errors = 0
-    present: list[Path] = []
-    for path in candidates:
-        if not path.is_file():
-            continue
-        loaded, errors = _load_events(path)
-        events.extend(loaded)
-        parse_errors += errors
-        present.append(path)
-    return events, parse_errors, tuple(present)
+    sources = tuple(_load_events(path) for path in candidates)
+    if not audit_requested and all(source.status == "not_requested" for source in sources):
+        # With neither events nor an audit source there is no evidence to assess.
+        # An existing empty stream or a legitimate audit-only export remains valid.
+        sources = (replace(sources[0], status="missing"), *sources[1:])
+    return sources
 
 
 def _confirmed_findings(
@@ -1160,32 +1288,76 @@ def _confirmed_findings(
     *,
     engagement_id: UUID | str,
     scope: Scope | None = None,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], int]:
     findings: list[dict[str, Any]] = []
+    rejected_events = 0
     for event in events:
         if event.get("kind") != "finding_confirmed":
             continue
         payload = _dict(event.get("payload"))
-        if str(payload.get("engagement_id") or "") != str(engagement_id):
+        payload_engagement = str(payload.get("engagement_id") or "")
+        if payload_engagement and payload_engagement != str(engagement_id):
+            # Events belonging to another engagement are outside this report's input.
             continue
-        if str(payload.get("status") or "") != "confirmed":
-            continue
-        if confirmed_finding_evidence_failures(payload, scope=scope):
+        if (
+            not payload_engagement
+            or str(payload.get("status") or "") != "confirmed"
+            or confirmed_finding_evidence_failures(payload, scope=scope)
+        ):
+            rejected_events += 1
             continue
         findings.append(_normalize_finding(payload))
-    return findings
+    return findings, rejected_events
+
+
+def _audit_log_health(db_path: Path | None, *, engagement_id: UUID | str) -> _AuditSourceHealth:
+    if db_path is None:
+        return _AuditSourceHealth(status="not_requested")
+    try:
+        if not stat.S_ISREG(db_path.stat().st_mode):
+            return _AuditSourceHealth(status="unreadable")
+        with closing(sqlite3.connect(db_path.resolve().as_uri() + "?mode=ro", uri=True)) as conn:
+            rows = conn.execute(
+                "SELECT action, payload_json FROM audit_log WHERE engagement_id = ? ORDER BY id",
+                (str(engagement_id),),
+            ).fetchall()
+    except FileNotFoundError:
+        return _AuditSourceHealth(status="missing")
+    except (OSError, sqlite3.Error):
+        return _AuditSourceHealth(status="unreadable")
+    rejected_rows = 0
+    for action, raw_payload in rows:
+        if not isinstance(raw_payload, str):
+            rejected_rows += 1
+            continue
+        try:
+            payload = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            rejected_rows += 1
+            continue
+        if not isinstance(action, str) or not action.strip() or not isinstance(payload, dict):
+            rejected_rows += 1
+    return _AuditSourceHealth(
+        status="invalid_records" if rejected_rows else "available",
+        rows_loaded=len(rows),
+        rejected_rows=rejected_rows,
+    )
 
 
 def _audit_findings(
-    db_path: Path,
+    db_path: Path | None,
     *,
     scope: Scope | None = None,
     engagement_id: UUID | str | None = None,
-) -> list[dict[str, Any]]:
-    if not db_path.exists():
-        return []
+) -> _AuditFindingsSource:
+    if db_path is None:
+        return _AuditFindingsSource(status="not_requested")
     try:
-        with sqlite3.connect(db_path) as conn:
+        if not stat.S_ISREG(db_path.stat().st_mode):
+            return _AuditFindingsSource(status="unreadable")
+        # Read-only mode prevents a missing/raced-away evidence source from becoming
+        # a new empty database. URI escaping preserves literal '?' and '#' in paths.
+        with closing(sqlite3.connect(db_path.resolve().as_uri() + "?mode=ro", uri=True)) as conn:
             if engagement_id is None:
                 rows = conn.execute(
                     """
@@ -1205,20 +1377,37 @@ def _audit_findings(
                     """,
                     (str(engagement_id),),
                 ).fetchall()
-    except sqlite3.Error:
-        return []
+    except FileNotFoundError:
+        return _AuditFindingsSource(status="missing")
+    except (OSError, sqlite3.Error):
+        return _AuditFindingsSource(status="unreadable")
     findings: list[dict[str, Any]] = []
+    rejected_rows = 0
     for row in rows:
         try:
             payload = json.loads(str(row[0]))
         except json.JSONDecodeError:
+            rejected_rows += 1
             continue
-        if isinstance(payload, dict) and not confirmed_finding_evidence_failures(
-            payload,
-            scope=scope,
+        if (
+            not isinstance(payload, dict)
+            or payload.get("status") != "confirmed"
+            or (
+                engagement_id is not None
+                and payload.get("engagement_id") is not None
+                and str(payload["engagement_id"]) != str(engagement_id)
+            )
+            or confirmed_finding_evidence_failures(payload, scope=scope)
         ):
-            findings.append(_normalize_finding(payload))
-    return findings
+            rejected_rows += 1
+            continue
+        findings.append(_normalize_finding(payload))
+    return _AuditFindingsSource(
+        status="invalid_records" if rejected_rows else "available",
+        findings=findings,
+        rows_loaded=len(rows),
+        rejected_rows=rejected_rows,
+    )
 
 
 def _normalize_finding(raw: dict[str, Any]) -> dict[str, Any]:
@@ -1786,7 +1975,15 @@ def _executive_summary_text(  # noqa: PLR0913
     finding_count: int,
     flag_count: int,
     error: str | None,
+    evidence_complete: bool,
 ) -> str:
+    if not evidence_complete:
+        return _incomplete_evidence_summary(
+            finding_count=finding_count,
+            flag_count=flag_count,
+            overall_risk=overall_risk,
+            error=error,
+        )
     if error:
         return (
             "The assessment ended with an error before normal completion. "
@@ -1815,12 +2012,29 @@ def _executive_summary_text(  # noqa: PLR0913
             "of an in-scope path. "
             "No structured confirmed finding record was present in the run artifacts."
         )
-    if completed or status == "completed":
-        return (
-            "The assessment completed without a captured proof string or confirmed "
-            "finding in the run artifacts."
+    return (
+        "The assessment completed without a captured proof string or confirmed "
+        "finding in the run artifacts."
+    )
+
+
+def _incomplete_evidence_summary(
+    *, finding_count: int, flag_count: int, overall_risk: str, error: str | None
+) -> str:
+    summary = (
+        "Evidence sources are incomplete or unreadable. Results should be treated as partial; "
+        "missing findings cannot be interpreted as a clean assessment."
+    )
+    if finding_count:
+        summary += (
+            f" Available evidence retains {finding_count} confirmed finding(s); "
+            f"the highest observed risk level is {overall_risk}."
         )
-    return "The assessment did not reach normal completion. Results should be treated as partial."
+    elif flag_count:
+        summary += " Validated target proof material was retained."
+    if error:
+        summary += " The assessment also ended with an error before normal completion."
+    return summary
 
 
 def _severity_counts(findings: list[dict[str, Any]]) -> dict[str, int]:
@@ -1836,6 +2050,7 @@ def _overall_risk(
     findings: list[dict[str, Any]],
     flags: list[str],
     status: str,
+    evidence_complete: bool,
 ) -> str:
     if findings:
         return max(
@@ -1844,6 +2059,8 @@ def _overall_risk(
         )
     if flags:
         return "High"
+    if not evidence_complete:
+        return "Unknown"
     if status not in {"completed", "max_turns_reached"}:
         return "Informational"
     return "Low"
@@ -1961,14 +2178,27 @@ def _finding_markdown(index: int, finding: dict[str, Any]) -> list[str]:
     return lines
 
 
-def _redact_recursive(value: object) -> object:
+def redact_report_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Redact report contents and late metadata while preserving path separators."""
+    return cast("dict[str, Any]", _redact_recursive(payload))
+
+
+def _redact_recursive(value: object, *, path_context: bool = False) -> object:
     if isinstance(value, dict):
-        return {redact_sensitive(str(key)): _redact_recursive(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_redact_recursive(item) for item in value]
-    if isinstance(value, tuple):
-        return [_redact_recursive(item) for item in value]
+        return {
+            redact_sensitive(str(key)): _redact_recursive(
+                item, path_context=str(key).endswith(("_path", "_paths", "_dir"))
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact_recursive(item, path_context=path_context) for item in value]
     if isinstance(value, str):
+        if path_context:
+            return "".join(
+                part if _PATH_SEPARATOR_RE.fullmatch(part) else redact_sensitive(part)
+                for part in _PATH_SEPARATOR_RE.split(value)
+            )
         return redact_sensitive(value)
     return value
 

--- a/packages/ravage/src/ravage/report_artifact.py
+++ b/packages/ravage/src/ravage/report_artifact.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 import json
-import os
-import re
-import tempfile
-from contextlib import suppress
-from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any
 
-from ravage.report import build_pentest_report, redact_sensitive
+from ravage.report import build_pentest_report, redact_report_payload
+from ravage.report_io import atomic_write_private_report
 
-_PRIVATE_FILE_MODE = 0o600
-_PATH_SEPARATOR_RE = re.compile(r"([/\\\\]+)")
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def write_json_report_artifact(  # noqa: PLR0913
@@ -49,68 +45,9 @@ def write_json_report_artifact(  # noqa: PLR0913
         run = report.get("run")
         if isinstance(run, dict):
             run["termination_reason"] = termination_reason
-    report = _redact_report_payload(report)
-    _atomic_write_private_json(output_path, report)
+    report = redact_report_payload(report)
+    atomic_write_private_report(output_path, json.dumps(report, indent=2, sort_keys=True) + "\n")
     return report
-
-
-def _redact_report_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Redact metadata added after ``build_pentest_report`` performed its own pass."""
-
-    def redact(value: object, *, path_context: bool = False) -> object:
-        if isinstance(value, dict):
-            redacted: dict[str, object] = {}
-            for key, item in value.items():
-                safe_key = redact_sensitive(str(key))
-                redacted[safe_key] = redact(
-                    item,
-                    path_context=safe_key.endswith(("_path", "_paths")),
-                )
-            return redacted
-        if isinstance(value, (list, tuple)):
-            return [redact(item, path_context=path_context) for item in value]
-        if isinstance(value, str):
-            if path_context:
-                return "".join(
-                    part if _PATH_SEPARATOR_RE.fullmatch(part) else redact_sensitive(part)
-                    for part in _PATH_SEPARATOR_RE.split(value)
-                )
-            return redact_sensitive(value)
-        return value
-
-    return cast("dict[str, Any]", redact(payload))
-
-
-def _atomic_write_private_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-    )
-    temporary_path = Path(temporary_name)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            json.dump(payload, stream, indent=2, sort_keys=True)
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        temporary_path.chmod(_PRIVATE_FILE_MODE)
-        temporary_path.replace(path)
-        _fsync_directory(path.parent)
-    finally:
-        with suppress(FileNotFoundError):
-            temporary_path.unlink()
-
-
-def _fsync_directory(path: Path) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-    with suppress(OSError):
-        descriptor = os.open(path, flags)
-        try:
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
 
 
 __all__ = ["write_json_report_artifact"]

--- a/packages/ravage/src/ravage/report_io.py
+++ b/packages/ravage/src/ravage/report_io.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+_PRIVATE_FILE_MODE = 0o600
+
+
+def atomic_write_private_report(path: Path, content: str) -> None:
+    """Publish a complete report with owner-only permissions, preserving old output on failure."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            os.fchmod(stream.fileno(), _PRIVATE_FILE_MODE)
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.replace(path)
+        _fsync_directory(path.parent)
+    finally:
+        with suppress(FileNotFoundError):
+            temporary_path.unlink()
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    with suppress(OSError):
+        descriptor = os.open(path, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)

--- a/packages/ravage/tests/test_autonomous_graph_runtime.py
+++ b/packages/ravage/tests/test_autonomous_graph_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import shlex
+import sys
 import time
 from typing import TYPE_CHECKING
 
@@ -25,6 +27,16 @@ if TYPE_CHECKING:
 TARGET_URL = "http://127.0.0.1:8765"
 OUTPUT_CAP = 128
 CONTAINER_PID_PATH = "/tmp/ravage-process-scanner.pid"  # noqa: S108
+HOST_PROCESS_TIMEOUT_SECONDS = 10.0
+_FAILED_PROCESS_STATUSES = frozenset(
+    {
+        ProcessStatus.FAILED,
+        ProcessStatus.LOST,
+        ProcessStatus.STOPPED,
+        ProcessStatus.TIMED_OUT,
+        ProcessStatus.OUTPUT_LIMIT,
+    }
+)
 
 
 def _runtime(
@@ -36,7 +48,7 @@ def _runtime(
         backend=HostGraphProcessBackend(tmp_path / "workspace"),
         target_url=TARGET_URL,
         manifest_path=tmp_path / "process-manifest.json",
-        limits=limits,
+        limits=limits or PersistentRuntimeLimits(max_process_seconds=HOST_PROCESS_TIMEOUT_SECONDS),
     )
 
 
@@ -46,28 +58,49 @@ def _read_until(
     name: str,
     owner_node_id: str,
     predicate: Callable[[ProcessStatus, str, str], bool],
-    timeout_seconds: float = 3.0,
+    timeout_seconds: float | None = None,
 ) -> tuple[ProcessStatus, str, str]:
+    # Follow the process's remaining watchdog budget instead of imposing a
+    # separate three-second startup assumption on loaded CI hosts. This wait
+    # never extends the process lifetime, and watchdog failures fail immediately.
+    if timeout_seconds is None:
+        session = runtime.state.sessions[name]
+        age_seconds = max(time.time() - session.started_at_epoch, 0.0)
+        remaining_seconds = max(session.timeout_seconds - age_seconds, 0.0)
+        timeout_seconds = remaining_seconds + runtime.limits.stop_grace_seconds
     deadline = time.monotonic() + timeout_seconds
     stdout = ""
     stderr = ""
     status = ProcessStatus.RUNNING
+    reason = "not_polled"
+    exit_code: int | None = None
     while time.monotonic() < deadline:
         result = runtime.read_process(
             name=name,
             owner_node_id=owner_node_id,
         )
         status = result.status
+        reason = result.reason
+        exit_code = result.exit_code
         stdout += result.stdout
         stderr += result.stderr
         if predicate(status, stdout, stderr):
             return status, stdout, stderr
+        if status in _FAILED_PROCESS_STATUSES:
+            break
         time.sleep(0.01)
     message = (
         f"process {name} did not reach expected state; "
-        f"status={status.value}, stdout={stdout!r}, stderr={stderr!r}"
+        f"status={status.value}, reason={reason}, exit_code={exit_code}, "
+        f"stdout={stdout!r}, stderr={stderr!r}"
     )
     raise AssertionError(message)
+
+
+def _python_command(code: str) -> str:
+    # A login shell can resolve `python3` to an unsupported system interpreter
+    # (macOS 3.9 in the reproduced environment). Exercise the test interpreter.
+    return shlex.join([sys.executable, "-I", "-u", "-c", code])
 
 
 def test_named_process_survives_turns_and_accepts_input(tmp_path: Path) -> None:
@@ -76,11 +109,11 @@ def test_named_process_survives_turns_and_accepts_input(tmp_path: Path) -> None:
         session = runtime.start_process(
             name="interactive",
             owner_node_id="node-001",
-            command=(
-                "python3 -u -c 'import sys; "
+            command=_python_command(
+                "import sys; "
                 'print("ready", flush=True); '
                 "line=sys.stdin.readline(); "
-                'print("echo:"+line.strip(), flush=True)\''
+                'print("echo:"+line.strip(), flush=True)'
             ),
         )
         assert session.status is ProcessStatus.RUNNING
@@ -121,9 +154,9 @@ def test_workers_share_files_but_not_process_namespaces(
         runtime.start_process(
             name="writer",
             owner_node_id="node-001",
-            command=(
-                "python3 -c 'from pathlib import Path; "
-                'Path("shared.txt").write_text("cookie=abc")\''
+            command=_python_command(
+                "from pathlib import Path; "
+                'Path("shared.txt").write_text("cookie=abc")'
             ),
         )
         _read_until(
@@ -135,7 +168,7 @@ def test_workers_share_files_but_not_process_namespaces(
         runtime.start_process(
             name="reader",
             owner_node_id="node-002",
-            command="python3 -c 'print(open(\"shared.txt\").read())'",
+            command=_python_command('print(open("shared.txt").read())'),
         )
         _, output, _ = _read_until(
             runtime,
@@ -215,6 +248,16 @@ def test_watchdog_enforces_timeout_without_agent_polling(
 
         assert result.status is ProcessStatus.TIMED_OUT
         assert result.reason == "process_wall_time_limit_reached"
+        with pytest.raises(
+            AssertionError,
+            match="status=timed_out, reason=process_wall_time_limit_reached",
+        ):
+            _read_until(
+                runtime,
+                name="slow",
+                owner_node_id="node-001",
+                predicate=lambda _status, stdout, _stderr: "never-ready" in stdout,
+            )
     finally:
         runtime.close()
 
@@ -228,7 +271,7 @@ def test_watchdog_enforces_output_cap(tmp_path: Path) -> None:
         runtime.start_process(
             name="noisy",
             owner_node_id="node-001",
-            command="python3 -c 'print(\"x\" * 10000)'",
+            command=_python_command('print("x" * 10000)'),
         )
         status, stdout, _ = _read_until(
             runtime,

--- a/packages/ravage/tests/test_bootstrap_script.py
+++ b/packages/ravage/tests/test_bootstrap_script.py
@@ -18,8 +18,14 @@ INVALID_OPTION_EXIT_CODE = 2
 
 
 def test_checkout_metadata_keeps_browser_support_optional() -> None:
-    metadata = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    root_metadata = tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    metadata = tomllib.loads(
+        (REPOSITORY_ROOT / "packages/ravage/pyproject.toml").read_text(encoding="utf-8")
+    )
 
+    assert "project" not in root_metadata
     assert not any(
         dependency.partition(">=")[0] == "playwright"
         for dependency in metadata["project"]["dependencies"]

--- a/packages/ravage/tests/test_cockpit_live.py
+++ b/packages/ravage/tests/test_cockpit_live.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import urllib.request
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlsplit
 
 import ravage.live_dashboard as ld
 from ravage.agent_core.live_events import (
@@ -193,8 +194,7 @@ def test_http_step_payload_sanitizes_urls_and_response_headers() -> None:
     ):
         assert secret not in serialized
     assert payload["url"] == (
-        "https://target.example/callback"
-        "?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
+        "https://target.example/callback?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
     )
     assert payload["path"] == "/callback?view=%5BREDACTED%5D&token=%5BREDACTED%5D"
     headers = payload["response_headers"]
@@ -261,15 +261,19 @@ def test_dashboard_replay_mode_when_target_reaped(tmp_path: Path) -> None:
 
 
 def test_command_output_extracts_tool_result_and_reasoning() -> None:
-    assert _command_output(
-        {"kind": "tool_validate_poc", "payload": {"result": "admin panel reached"}}
-    ) == "admin panel reached"
+    assert (
+        _command_output({"kind": "tool_validate_poc", "payload": {"result": "admin panel reached"}})
+        == "admin panel reached"
+    )
     assert _command_output(
         {"kind": "tool_run_command", "payload": {"stdout": "root:x:0:0", "stderr": ""}}
     ).startswith("root:x:0:0")
-    assert _command_output(
-        {"kind": "model_reply_received", "payload": {"content": "try IDOR on /profile"}}
-    ) == "try IDOR on /profile"
+    assert (
+        _command_output(
+            {"kind": "model_reply_received", "payload": {"content": "try IDOR on /profile"}}
+        )
+        == "try IDOR on /profile"
+    )
     assert _command_output({"kind": "agent_started", "payload": {}}) == ""
 
 
@@ -316,9 +320,7 @@ def test_stream_cursor_appends_only_new_step(tmp_path: Path) -> None:
 # ---- teardown -----------------------------------------------------------
 
 
-def test_teardown_flips_manifest_to_replay(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_teardown_flips_manifest_to_replay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _seed_run(tmp_path, events=ACTION_EVENTS)
     monkeypatch.setattr(ld, "_teardown_docker_project", lambda _project: 3)
     settings = DashboardSettings(workspace_dir=tmp_path, run_root=tmp_path)
@@ -338,23 +340,32 @@ def test_cockpit_server_serves_state_and_stream(tmp_path: Path) -> None:
     try:
         port = cockpit.server.server_address[1]
         base = f"http://127.0.0.1:{port}"
-        with urllib.request.urlopen(base + "/api/state", timeout=5) as response:  # noqa: S310
+        token = parse_qs(urlsplit(cockpit.url).fragment)["token"][0]
+        opener = urllib.request.build_opener()
+        login = urllib.request.Request(  # noqa: S310 - fixed loopback test server.
+            base + "/api/session",
+            headers={"Authorization": f"Bearer {token}", "Origin": base},
+            method="POST",
+        )
+        with opener.open(login, timeout=5) as response:
+            assert response.status == 200
+            session = json.loads(response.read())["session_token"]
+        opener.addheaders = [("Authorization", f"Bearer {session}")]
+        with opener.open(base + "/api/state", timeout=5) as response:
             state = json.loads(response.read())
         assert state["manifest"]["run_id"] == "XBEN-001-24"
 
-        with urllib.request.urlopen(base + "/", timeout=5) as response:  # noqa: S310
+        with opener.open(base + "/index.html", timeout=5) as response:
             frontend = response.read().decode("utf-8")
         assert response.status == 200
         assert "Ravage Cockpit" in frontend
 
-        with urllib.request.urlopen(  # noqa: S310
-            base + "/assets/ravage_logo.png", timeout=5
-        ) as response:
+        with opener.open(base + "/assets/ravage_logo.png", timeout=5) as response:
             logo = response.read()
         assert response.status == 200
         assert logo.startswith(b"\x89PNG\r\n\x1a\n")
 
-        with urllib.request.urlopen(base + "/api/events/stream", timeout=5) as response:  # noqa: S310
+        with opener.open(base + "/api/events/stream", timeout=5) as response:
             frame = response.read(64)
         assert frame  # the stream produces bytes immediately (state event / keepalive)
     finally:

--- a/packages/ravage/tests/test_cockpit_security.py
+++ b/packages/ravage/tests/test_cockpit_security.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.client import HTTPConnection
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+import ravage.live_dashboard as dashboard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@dataclass
+class CockpitClient:
+    port: int
+    token: str
+    calls: list[str]
+
+    @property
+    def origin(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, dict[str, str], bytes]:
+        connection = HTTPConnection("127.0.0.1", self.port, timeout=3)
+        try:
+            connection.request(method, path, headers=headers or {})
+            response = connection.getresponse()
+            return response.status, dict(response.getheaders()), response.read()
+        finally:
+            connection.close()
+
+    def authenticate(self) -> str:
+        status, headers, body = self.request(
+            "/api/session",
+            method="POST",
+            headers={"Authorization": f"Bearer {self.token}", "Origin": self.origin},
+        )
+        assert status == HTTPStatus.OK
+        payload = json.loads(body)
+        assert payload["authenticated"] is True
+        assert "Set-Cookie" not in headers
+        session = str(payload["session_token"])
+        assert session != self.token
+        return session
+
+
+@pytest.fixture
+def cockpit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[CockpitClient]:
+    calls: list[str] = []
+
+    def fake_teardown(_settings: dashboard.DashboardSettings, run_id: str) -> dict[str, bool]:
+        calls.append(run_id)
+        return {"ok": True}
+
+    monkeypatch.setattr(dashboard, "teardown_active_run", fake_teardown)
+    monkeypatch.setattr(
+        dashboard, "build_dashboard_state", lambda _: {"private_run_data": "fixture only"}
+    )
+    server = dashboard.start_cockpit(dashboard.DashboardSettings(workspace_dir=tmp_path), port=0)
+    parsed_url = urlsplit(server.url)
+    assert parsed_url.port == server.server.server_port
+    assert not parsed_url.query
+    token = parse_qs(parsed_url.fragment)["token"][0]
+    assert len(token) >= 43  # noqa: PLR2004 - 32 random bytes, URL-safe base64.
+    assert token not in repr(server)
+    try:
+        yield CockpitClient(server.server.server_port, token, calls)
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.parametrize("path", ["/api/state", "/api/events/stream", "/api/session"])
+def test_private_reads_require_authentication(cockpit: CockpitClient, path: str) -> None:
+    status, headers, body = cockpit.request(path)
+    assert status == HTTPStatus.UNAUTHORIZED
+    assert headers["Cache-Control"] == "no-store"
+    assert b"private_run_data" not in body
+    status, _, _ = cockpit.request(path, headers={"Authorization": "Bearer incorrect"})
+    assert status == HTTPStatus.UNAUTHORIZED
+
+
+def test_bootstrap_contains_no_secret_or_run_data(cockpit: CockpitClient) -> None:
+    for path in ("/", "/_cockpit/session.js", "/index.html", "/src/main.js", "/src/transport.js"):
+        status, headers, body = cockpit.request(path)
+        assert status == HTTPStatus.OK
+        assert cockpit.token.encode() not in body
+        assert b"private_run_data" not in body
+        assert headers["Referrer-Policy"] == "no-referrer"
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert headers["X-Frame-Options"] == "DENY"
+        assert "frame-ancestors 'none'" in headers["Content-Security-Policy"]
+        assert "Access-Control-Allow-Origin" not in headers
+        assert "Set-Cookie" not in headers
+
+
+def test_query_token_is_not_an_authentication_method(cockpit: CockpitClient) -> None:
+    status, _, _ = cockpit.request(f"/api/state?token={cockpit.token}")
+    assert status == HTTPStatus.UNAUTHORIZED
+
+
+def test_session_and_bearer_can_read_state(cockpit: CockpitClient) -> None:
+    session = cockpit.authenticate()
+    for token in (session, cockpit.token):
+        status, _, body = cockpit.request(
+            "/api/state", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert status == HTTPStatus.OK
+        assert json.loads(body) == {"private_run_data": "fixture only"}
+
+
+def test_session_exchange_requires_valid_capability(cockpit: CockpitClient) -> None:
+    for authorization in (None, "Bearer incorrect", "Bearer \u00ff"):
+        headers = {"Origin": cockpit.origin}
+        if authorization is not None:
+            headers["Authorization"] = authorization
+        status, response_headers, _ = cockpit.request(
+            "/api/session", method="POST", headers=headers
+        )
+        assert status == HTTPStatus.UNAUTHORIZED
+        assert "Set-Cookie" not in response_headers
+
+
+@pytest.mark.parametrize("path", ["/api/teardown", "/api/run/example/teardown"])
+def test_teardown_requires_authenticated_same_origin_request(
+    cockpit: CockpitClient, path: str
+) -> None:
+    status, _, _ = cockpit.request(path, method="POST", headers={"Origin": cockpit.origin})
+    assert status == HTTPStatus.UNAUTHORIZED
+    session = cockpit.authenticate()
+    for origin in (None, "null", "http://untrusted.invalid", "http://127.0.0.1:1"):
+        headers = {"Authorization": f"Bearer {session}"}
+        if origin is not None:
+            headers["Origin"] = origin
+        status, _, _ = cockpit.request(path, method="POST", headers=headers)
+        assert status == HTTPStatus.FORBIDDEN
+        assert cockpit.calls == []
+    status, _, body = cockpit.request(
+        path,
+        method="POST",
+        headers={"Authorization": f"Bearer {session}", "Origin": cockpit.origin},
+    )
+    assert status == HTTPStatus.OK
+    assert json.loads(body) == {"ok": True}
+    assert cockpit.calls == ([""] if path == "/api/teardown" else ["example"])
+
+
+@pytest.mark.parametrize("origin", [None, "null", "http://untrusted.invalid"])
+def test_session_exchange_requires_same_origin(cockpit: CockpitClient, origin: str | None) -> None:
+    headers = {"Authorization": f"Bearer {cockpit.token}"}
+    if origin is not None:
+        headers["Origin"] = origin
+    status, response_headers, _ = cockpit.request("/api/session", method="POST", headers=headers)
+    assert status == HTTPStatus.FORBIDDEN
+    assert "Set-Cookie" not in response_headers
+
+
+@pytest.mark.parametrize("host", ["untrusted.invalid", "localhost:1", "127.0.0.1", ""])
+def test_unexpected_host_is_rejected_even_with_capability(
+    cockpit: CockpitClient, host: str
+) -> None:
+    status, _, _ = cockpit.request(
+        "/api/state", headers={"Host": host, "Authorization": f"Bearer {cockpit.token}"}
+    )
+    assert status == HTTPStatus.FORBIDDEN
+
+
+def test_capability_and_session_are_isolated_between_servers(
+    cockpit: CockpitClient, tmp_path: Path
+) -> None:
+    session = cockpit.authenticate()
+    other_server = dashboard.start_cockpit(
+        dashboard.DashboardSettings(workspace_dir=tmp_path), port=0
+    )
+    try:
+        other_client = CockpitClient(other_server.server.server_port, cockpit.token, [])
+        assert other_server.url != f"{other_client.origin}/#token={cockpit.token}"
+        for headers in (
+            {"Authorization": f"Bearer {cockpit.token}"},
+            {"Authorization": f"Bearer {session}"},
+        ):
+            status, _, _ = other_client.request("/api/state", headers=headers)
+            assert status == HTTPStatus.UNAUTHORIZED
+    finally:
+        other_server.shutdown()
+
+
+def test_cookies_never_authenticate_cockpit_requests(cockpit: CockpitClient) -> None:
+    session = cockpit.authenticate()
+    for token in (session, cockpit.token):
+        status, _, _ = cockpit.request(
+            "/api/state", headers={"Cookie": f"ravage_cockpit_{cockpit.port}={token}"}
+        )
+        assert status == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize("duplicate", ["Host", "Origin", "Authorization"])
+def test_ambiguous_security_headers_are_rejected(cockpit: CockpitClient, duplicate: str) -> None:
+    connection = HTTPConnection("127.0.0.1", cockpit.port, timeout=3)
+    headers = {
+        "Host": f"127.0.0.1:{cockpit.port}",
+        "Origin": cockpit.origin,
+        "Authorization": f"Bearer {cockpit.token}",
+    }
+    try:
+        connection.putrequest("POST", "/api/teardown", skip_host=True)
+        for key, value in headers.items():
+            connection.putheader(key, value)
+        connection.putheader(duplicate, headers[duplicate])
+        connection.endheaders()
+        response = connection.getresponse()
+        assert response.status in {HTTPStatus.FORBIDDEN, HTTPStatus.UNAUTHORIZED}
+        assert cockpit.calls == []
+    finally:
+        connection.close()
+
+
+def test_explicit_wildcard_bind_still_enforces_local_interface_host(tmp_path: Path) -> None:
+    server = dashboard.start_cockpit(
+        dashboard.DashboardSettings(workspace_dir=tmp_path),
+        host="0.0.0.0",  # noqa: S104 - exercise explicit binding without target traffic.
+        port=0,
+    )
+    try:
+        parsed_url = urlsplit(server.url)
+        assert parsed_url.hostname == "127.0.0.1"
+        client = CockpitClient(
+            server.server.server_port, parse_qs(parsed_url.fragment)["token"][0], []
+        )
+        status, _, _ = client.request("/api/state")
+        assert status == HTTPStatus.UNAUTHORIZED
+        client.authenticate()
+        status, _, _ = client.request("/", headers={"Host": "untrusted.invalid"})
+        assert status == HTTPStatus.FORBIDDEN
+    finally:
+        server.shutdown()

--- a/packages/ravage/tests/test_memory_eval.py
+++ b/packages/ravage/tests/test_memory_eval.py
@@ -1,107 +1,77 @@
 from __future__ import annotations
 
-import json
-from io import StringIO
+import subprocess
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ai_agent_fixtures import BRIEF_YAML, ScriptedModelClient
-from ravage.benchmark import BenchmarkOverrides
-from ravage.memory import MemoryItem, MemoryStore
-from ravage.memory_eval import run_memory_eval
+import pytest
+from ravage.memory_eval import MemoryEvalUnavailableError, run_memory_eval
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_UNAVAILABLE_EXIT_CODE = 2
 
 
-def test_memory_eval_compares_off_and_read_runs(tmp_path: Path) -> None:
-    brief_path = tmp_path / "brief.yaml"
-    brief_path.write_text(BRIEF_YAML, encoding="utf-8")
-    manifest_path = tmp_path / "manifest.yaml"
-    manifest_path.write_text(
-        f"""
-cases:
-  - id: memory-eval-search
-    agent: ai-web
-    brief: {brief_path}
-    target_url: http://127.0.0.1:8765
-    fixture: vulnerable_openapi
-    expect:
-      present:
-        - vuln_class: sql_injection
-          endpoint_path: /search
-          param: q
-      absent: []
-    budget:
-      max_seconds: 5.0
-      max_http_requests: 20
-""".lstrip(),
-        encoding="utf-8",
-    )
-    memory_db_path = tmp_path / "memory.db"
-    store = MemoryStore(memory_db_path)
-    try:
-        store.add_item(
-            MemoryItem.new(
-                type="playbook",
-                status="verified",
-                summary="Search q should be tested with test_sqli_param before reporting.",
-                vuln_class="sql_injection",
-                target_fingerprint={"objectives": ["sql_injection"]},
-                recommended_actions=["Run test_sqli_param on /search q."],
-                confidence=0.8,
-            )
+def test_memory_eval_is_unavailable_without_inputs() -> None:
+    with pytest.raises(MemoryEvalUnavailableError, match="No evaluation was run"):
+        run_memory_eval()
+
+
+def test_memory_eval_does_not_call_models_or_write_reports(tmp_path: Path) -> None:
+    class UnexpectedModelClient:
+        @staticmethod
+        def complete(**_kwargs: object) -> None:
+            pytest.fail("unavailable evaluation must never invoke models")
+
+    clients: Mapping[str, object] = {"offline-case": UnexpectedModelClient()}
+    output_dir = tmp_path / "reports"
+    memory_db = tmp_path / "memory.db"
+
+    with pytest.raises(MemoryEvalUnavailableError, match="no benchmark evaluator"):
+        run_memory_eval(
+            manifest_path=tmp_path / "missing.yaml",
+            output_dir=output_dir,
+            memory_db_path=memory_db,
+            off_ai_model_clients=clients,
+            read_ai_model_clients=clients,
         )
-    finally:
-        store.close()
 
-    off_model = ScriptedModelClient(
-        [
-            {"action": "discover_attack_surface", "args": {}, "rationale": "map"},
-            {"action": "final", "args": {"summary": "done"}, "rationale": "done"},
-        ]
-    )
-    read_model = ScriptedModelClient(
-        [
-            {
-                "action": "test_sqli_param",
-                "args": {
-                    "path": "/search",
-                    "method": "GET",
-                    "param": "q",
-                    "location": "query",
-                },
-                "rationale": "memory points at q",
-            },
-            {
-                "action": "report_sqli",
-                "args": {"path": "/search", "param": "q"},
-                "rationale": "confirmed evidence exists",
-            },
-            {"action": "final", "args": {"summary": "done"}, "rationale": "done"},
-        ]
-    )
+    assert not output_dir.exists()
+    assert not memory_db.exists()
 
-    report = run_memory_eval(
-        manifest_path=manifest_path,
-        output_dir=tmp_path / "reports",
-        memory_db_path=memory_db_path,
-        overrides=BenchmarkOverrides(max_turns=3),
-        stdout=StringIO(),
-        off_ai_model_clients={"memory-eval-search": off_model},
-        read_ai_model_clients={"memory-eval-search": read_model},
-    )
 
-    saved = json.loads(report.report_path.read_text(encoding="utf-8"))
-    off_messages = "\n".join(
-        message.content for messages in off_model.messages_seen for message in messages
-    )
-    read_messages = "\n".join(
-        message.content for messages in read_model.messages_seen for message in messages
-    )
+def test_memory_eval_preserves_existing_artifacts(tmp_path: Path) -> None:
+    report_path = tmp_path / "memory-eval-report.json"
+    previous_result = '{"provenance": "previous independent evaluation"}\n'
+    report_path.write_text(previous_result, encoding="utf-8")
 
-    assert report.baseline.false_negatives == 1
-    assert report.memory.false_negatives == 0
-    assert saved["delta"]["false_negatives"] == -1
-    assert saved["passed"] is True
-    assert "MEMORY_HINTS" not in off_messages
-    assert "MEMORY_HINTS" in read_messages
+    with pytest.raises(MemoryEvalUnavailableError):
+        run_memory_eval(output_dir=tmp_path)
+
+    assert report_path.read_text(encoding="utf-8") == previous_result
+
+
+@pytest.mark.parametrize("script", ["run_memory_eval.py", "eval/run_memory_eval.py"])
+def test_memory_eval_cli_help_and_unavailable(script: str, tmp_path: Path) -> None:
+    command = [sys.executable, str(_REPO_ROOT / "scripts" / script)]
+    help_result = subprocess.run(  # noqa: S603 - fixed local script, no shell.
+        [*command, "--help"], capture_output=True, text=True, check=False, timeout=15
+    )
+    assert help_result.returncode == 0
+    assert "unavailable" in help_result.stdout
+    output_dir = tmp_path / "reports"
+    result = subprocess.run(  # noqa: S603 - fixed local script, no shell.
+        [*command, "--benchmark", str(tmp_path / "missing.yaml"), "--output-dir", str(output_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    assert result.returncode == _UNAVAILABLE_EXIT_CODE
+    assert "[memory-eval:unavailable]" in result.stderr
+    assert "No evaluation was run" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not output_dir.exists()

--- a/packages/ravage/tests/test_proof_bundle_eval.py
+++ b/packages/ravage/tests/test_proof_bundle_eval.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
 
+import pytest
 from pentest_schemas import ProofVerifierVerdict
 from ravage.proof_bundle_eval import (
     ProofBundleEvalCase,
     evaluate_proof_bundle_cases,
     load_proof_bundle_eval_cases,
+    write_proof_bundle_eval_report,
 )
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 EVAL_CASE_COUNT = 2
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_INVALID_INPUT_EXIT_CODE = 2
 
 
 def _bundle(
@@ -115,6 +119,8 @@ def test_evaluate_proof_bundle_cases_counts_passes() -> None:
     assert report.failed == 0
     assert report.false_positive == 0
     assert report.false_negative == 0
+    assert report.successful
+    assert report.to_json()["evaluation_mode"] == "recorded_verdicts"
 
 
 def test_evaluate_proof_bundle_cases_counts_false_positive() -> None:
@@ -224,3 +230,228 @@ def test_load_proof_bundle_eval_cases_jsonl(tmp_path: Path) -> None:
     assert len(cases) == 1
     assert cases[0].case_id == "positive"
     assert cases[0].expected_verdict == "accepted"
+
+
+def test_empty_proof_bundle_evaluation_is_not_successful(tmp_path: Path) -> None:
+    report = evaluate_proof_bundle_cases([])
+    output_path = tmp_path / "reports" / "empty.json"
+
+    write_proof_bundle_eval_report(report, output_path)
+
+    assert report.total == 0
+    assert not report.successful
+    assert report.status == "empty"
+    assert json.loads(output_path.read_text(encoding="utf-8"))["successful"] is False
+
+
+@pytest.mark.parametrize("expected_verdict", ["", "accept", "Accepted", "anything"])
+def test_evaluation_rejects_unknown_labels(expected_verdict: str) -> None:
+    with pytest.raises(ValueError, match="invalid expected_verdict"):
+        evaluate_proof_bundle_cases([ProofBundleEvalCase("case", expected_verdict, _bundle())])
+
+
+def test_evaluation_rejects_duplicate_case_ids() -> None:
+    case = ProofBundleEvalCase("duplicate", "accepted", _bundle())
+    with pytest.raises(ValueError, match="nonempty and unique"):
+        evaluate_proof_bundle_cases([case, case])
+
+
+def test_invalid_bundle_cannot_be_counted_as_correct_rejection() -> None:
+    with pytest.raises(ValueError, match="invalid proof_bundle"):
+        evaluate_proof_bundle_cases([ProofBundleEvalCase("missing", "rejected", {})])
+
+
+def test_verifier_gate_uses_actual_verdict_impact() -> None:
+    def verifier(_bundle: object) -> ProofVerifierVerdict:
+        return ProofVerifierVerdict(
+            verdict="accepted",
+            confidence="high",
+            rationale="The supplied evidence crosses the account boundary.",
+            impact="Another account's protected record is disclosed.",
+        )
+
+    report = evaluate_proof_bundle_cases(
+        [ProofBundleEvalCase("new-verdict", "accepted", _bundle(verdict="rejected", impact=None))],
+        verifier=verifier,
+    )
+
+    assert report.successful
+    assert report.to_json()["evaluation_mode"] == "provided_verifier"
+
+
+def test_stored_impact_does_not_mask_a_missing_verifier_impact() -> None:
+    def verifier(_bundle: object) -> ProofVerifierVerdict:
+        return ProofVerifierVerdict(
+            verdict="accepted",
+            confidence="high",
+            rationale="No impact has been supplied by this verifier.",
+            impact=None,
+        )
+
+    report = evaluate_proof_bundle_cases(
+        [ProofBundleEvalCase("missing-impact", "accepted", _bundle())],
+        verifier=verifier,
+    )
+
+    assert not report.successful
+    assert report.failed == 1
+    assert "missing proof_bundle.verifier.impact" in report.results[0].gate_failures
+
+
+def test_acceptance_with_a_failed_control_cannot_pass_evaluation() -> None:
+    bundle = _bundle()
+    bundle["controls"][0]["passed"] = False
+
+    report = evaluate_proof_bundle_cases(
+        [ProofBundleEvalCase("failed-control", "accepted", bundle)]
+    )
+
+    assert not report.successful
+    assert "proof control 'baseline-control' did not pass" in report.results[0].gate_failures
+
+
+def test_callback_cannot_override_a_failed_fixture_control() -> None:
+    bundle = _bundle(verdict="rejected", impact=None)
+    bundle["controls"][0]["passed"] = False
+
+    def verifier(_bundle: object) -> ProofVerifierVerdict:
+        return ProofVerifierVerdict(
+            verdict="accepted",
+            confidence="high",
+            rationale="Accepted by an independent callback.",
+            impact="An impact statement does not establish a passing control.",
+        )
+
+    report = evaluate_proof_bundle_cases(
+        [ProofBundleEvalCase("failed-control", "accepted", bundle)], verifier=verifier
+    )
+
+    assert not report.successful
+    assert "proof control 'baseline-control' did not pass" in report.results[0].gate_failures
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        ("duplicate-step", "proof step IDs must be nonempty and unique"),
+        ("duplicate-control", "proof control IDs must be nonempty and unique"),
+        ("missing-control-step", "control 'baseline-control' refers to an unknown proof step"),
+        ("missing-source-step", "provenance refers to an unknown proof step"),
+        ("missing-observed-step", "provenance refers to an unknown proof step"),
+    ],
+)
+def test_evaluation_rejects_inconsistent_proof_references(mutation: str, error: str) -> None:
+    bundle = _bundle()
+    if mutation == "duplicate-step":
+        bundle["steps"][1]["step_id"] = bundle["steps"][0]["step_id"]
+    elif mutation == "duplicate-control":
+        bundle["controls"].append(dict(bundle["controls"][0]))
+    elif mutation == "missing-control-step":
+        bundle["controls"][0]["step_ids"] = ["absent"]
+    elif mutation == "missing-source-step":
+        bundle["provenance"][0]["source_step_id"] = "absent"
+    else:
+        bundle["provenance"][0]["observed_step_id"] = "absent"
+
+    with pytest.raises(ValueError, match=error):
+        evaluate_proof_bundle_cases([ProofBundleEvalCase(mutation, "accepted", bundle)])
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "[1, 2]",
+        "{bad-json",
+        '{"case_id": "missing-bundle", "expected_verdict": "rejected"}',
+        '{"case_id": 1, "expected_verdict": "rejected", "proof_bundle": {}}',
+    ],
+)
+def test_loader_rejects_malformed_cases(tmp_path: Path, raw: str) -> None:
+    path = tmp_path / "cases.jsonl"
+    path.write_text(raw, encoding="utf-8")
+    with pytest.raises(ValueError, match=r"cases\.jsonl:1"):
+        load_proof_bundle_eval_cases(path)
+
+
+@pytest.mark.parametrize("script", ["eval_proof_bundles.py", "eval/eval_proof_bundles.py"])
+def test_proof_bundle_eval_cli_help(script: str) -> None:
+    result = subprocess.run(  # noqa: S603 - fixed local script, no shell.
+        [sys.executable, str(_REPO_ROOT / "scripts" / script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    assert result.returncode == 0
+    assert "recorded" in result.stdout
+    assert "does not independently verify" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("expected_verdict", "actual_verdict", "expected_exit", "successful"),
+    [("accepted", "accepted", 0, True), ("rejected", "accepted", 1, False)],
+)
+def test_proof_bundle_eval_cli_scores_offline_cases(
+    tmp_path: Path,
+    expected_verdict: str,
+    actual_verdict: str,
+    expected_exit: int,
+    *,
+    successful: bool,
+) -> None:
+    cases_path = tmp_path / "cases.jsonl"
+    output_path = tmp_path / "results" / "report.json"
+    cases_path.write_text(
+        json.dumps(
+            {
+                "case_id": "recorded",
+                "expected_verdict": expected_verdict,
+                "proof_bundle": _bundle(verdict=actual_verdict),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_cli(str(cases_path), "--output", str(output_path))
+
+    assert result.returncode == expected_exit
+    payload = json.loads(result.stdout)
+    assert payload["total"] == 1
+    assert payload["successful"] is successful
+    assert payload["evaluation_mode"] == "recorded_verdicts"
+    assert json.loads(output_path.read_text(encoding="utf-8")) == payload
+
+
+def test_proof_bundle_eval_cli_empty_input_is_not_successful(tmp_path: Path) -> None:
+    cases_path = tmp_path / "empty.jsonl"
+    cases_path.write_text("# No observations\n", encoding="utf-8")
+    result = _run_cli(str(cases_path))
+    assert result.returncode == _INVALID_INPUT_EXIT_CODE
+    assert json.loads(result.stdout)["status"] == "empty"
+    assert json.loads(result.stdout)["successful"] is False
+
+
+def test_proof_bundle_eval_cli_invalid_input_is_not_successful(tmp_path: Path) -> None:
+    cases_path = tmp_path / "invalid.jsonl"
+    cases_path.write_text("[]\n", encoding="utf-8")
+    result = _run_cli(str(cases_path))
+    assert result.returncode == _INVALID_INPUT_EXIT_CODE
+    assert "[proof-bundle-eval:invalid]" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_proof_bundle_eval_cli_live_verifier_is_explicitly_unavailable(tmp_path: Path) -> None:
+    result = _run_cli(str(tmp_path / "missing.jsonl"), "--live-verifier")
+    assert result.returncode == _INVALID_INPUT_EXIT_CODE
+    assert "live model verification is unavailable" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed local script, no shell.
+        [sys.executable, str(_REPO_ROOT / "scripts" / "eval" / "eval_proof_bundles.py"), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )

--- a/packages/ravage/tests/test_report_generation.py
+++ b/packages/ravage/tests/test_report_generation.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import sqlite3
 import stat
 import sys
+from contextlib import closing
+from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 import pytest
 import ravage.report as report_module
 from ravage import __main__ as cli
+from ravage import report_io
 from ravage.agent_core.action_executor import ActionResult
 from ravage.agent_core.ai_agent import AIWebAgentSettings
 from ravage.agent_core.autonomous_graph.evidence import EvidenceBlackboard
-from ravage.report import ProFeatureRequiredError, write_pentest_report
+from ravage.report import ProFeatureRequiredError, build_pentest_report, write_pentest_report
 from ravage.report_artifact import write_json_report_artifact
 from ravage.run_data.audit import AuditStore
 from ravage.run_data.workspace import AgentWorkspace
@@ -35,10 +39,6 @@ from ravage.traffic.policy import (
 )
 from ravage.traffic.provenance import TrafficProvenanceError
 from ravage.traffic.store import TrafficStore
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 BRIEF_YAML = """
 engagement_id: "88888888-8888-4888-8888-888888888888"
@@ -67,6 +67,577 @@ _PRIVATE_ARTIFACT_MODE = 0o600
 _DUAL_TRAFFIC_REQUEST_COUNT = 2
 _REPORT_IN_SCOPE = ("http://127.0.0.1:8765",)
 _REPORT_OUT_OF_SCOPE = ("http://127.0.0.1:9999",)
+
+
+@pytest.mark.parametrize("source_state", ["missing", "corrupt", "wrong_schema", "directory"])
+def test_report_marks_unavailable_expected_audit_evidence_incomplete(
+    tmp_path: Path, source_state: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    if source_state == "corrupt":
+        audit_path.write_bytes(b"corrupt database containing token=do-not-expose")
+    elif source_state == "wrong_schema":
+        with closing(sqlite3.connect(audit_path)) as connection:
+            connection.execute("CREATE TABLE unrelated (id INTEGER)")
+    elif source_state == "directory":
+        audit_path.mkdir()
+
+    report = write_json_report_artifact(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=workspace.root.parent / "report.json",
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert report["status"] == "completed"  # Run state remains distinct from evidence health.
+    assert report["source_quality"]["status"] == "incomplete"
+    source = report["source_quality"]["audit_source"]
+    assert source["expected"] is True
+    assert source["status"] == ("missing" if source_state == "missing" else "unreadable")
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+    assert (
+        "missing findings cannot be interpreted as a clean assessment"
+        in (report["executive_summary"]["summary"])
+    )
+    markdown = report_module.render_markdown_report(report)
+    assert "Overall Risk: Unknown" in markdown
+    assert "Evidence completeness: incomplete" in markdown
+    assert "does not establish the absence of vulnerabilities" in markdown
+    assert "do-not-expose" not in json.dumps(report)
+    if source_state == "missing":
+        assert not audit_path.exists()
+
+
+@pytest.mark.parametrize("payload", ["{broken", "[]", '{"status":"confirmed"}'])
+def test_report_marks_rejected_audit_rows_incomplete(tmp_path: Path, payload: str) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    AuditStore(audit_path).close()
+    with closing(sqlite3.connect(audit_path)) as connection:
+        connection.execute(
+            "INSERT INTO findings VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "malformed",
+                "88888888-8888-4888-8888-888888888888",
+                "information_disclosure",
+                "confirmed",
+                "confirm",
+                payload,
+            ),
+        )
+        connection.commit()
+
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert report["findings"] == []
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["source_quality"]["audit_source"] == {
+        "expected": True,
+        "status": "invalid_records",
+        "confirmed_rows_loaded": 1,
+        "accepted_findings": 0,
+        "rejected_rows": 1,
+    }
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+def test_report_keeps_valid_findings_when_expected_audit_is_missing(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=workspace.root.parent / "missing.db",
+    )
+
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["finding_count"] == 1
+    assert report["executive_summary"]["overall_risk"] == "High"
+    assert (
+        "Available evidence retains 1 confirmed finding(s)"
+        in (report["executive_summary"]["summary"])
+    )
+    assert report["findings"][0]["recommendation"]
+
+
+def test_report_marks_unreadable_expected_audit_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    AuditStore(audit_path).close()
+
+    def deny_database_access(*_args: object, **_kwargs: object) -> None:
+        message = "simulated permission denial"
+        raise PermissionError(message)
+
+    monkeypatch.setattr(report_module.sqlite3, "connect", deny_database_access)
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert report["source_quality"]["audit_source"]["status"] == "unreadable"
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+def test_report_retains_valid_audit_findings_alongside_rejected_rows(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    AuditStore(audit_path).close()
+    valid = _confirmed_finding_payload(
+        finding_id="valid-finding", vuln_class="xss", severity="Medium"
+    )
+    with closing(sqlite3.connect(audit_path)) as connection:
+        for finding_id, raw in (("valid-finding", json.dumps(valid)), ("broken", "{broken")):
+            connection.execute(
+                "INSERT INTO findings VALUES (?, ?, ?, ?, ?, ?)",
+                (finding_id, valid["engagement_id"], "xss", "confirmed", "confirm", raw),
+            )
+        connection.commit()
+    original_database = audit_path.read_bytes()
+
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert [finding["finding_id"] for finding in report["findings"]] == ["valid-finding"]
+    assert report["source_quality"]["audit_source"]["rejected_rows"] == 1
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Medium"
+    assert audit_path.read_bytes() == original_database
+
+
+@pytest.mark.parametrize("audit_requested", [False, True])
+def test_report_distinguishes_empty_audit_from_optional_events_only_source(
+    tmp_path: Path, *, audit_requested: bool
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit?literal#name.db" if audit_requested else None
+    if audit_path is not None:
+        AuditStore(audit_path).close()
+    else:
+        workspace.events_path.touch()
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert report["source_quality"]["status"] == "complete"
+    source = report["source_quality"]["audit_source"]
+    assert source["expected"] is audit_requested
+    assert source["status"] == ("available" if audit_requested else "not_requested")
+    assert report["executive_summary"]["overall_risk"] == "Low"
+
+
+def test_report_without_any_evidence_is_incomplete(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["source_quality"]["event_sources"][0] == {
+        "events_path": str(workspace.events_path),
+        "expected": True,
+        "status": "missing",
+        "events_loaded": 0,
+        "parse_errors": 0,
+    }
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+@pytest.mark.parametrize("persisted_state", [False, True])
+def test_cli_report_does_not_turn_lost_event_evidence_into_a_clean_assessment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, persisted_state: bool
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    if persisted_state:
+        workspace.write_state({"status": "completed"})
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+    command = ["report", str(workspace.root.parent), "--brief", str(brief_path)]
+    cli.main(command)
+    output = workspace.root.parent / "report.json"
+    before = json.loads(output.read_text(encoding="utf-8"))
+    assert before["executive_summary"]["overall_risk"] == "High"
+    assert before["executive_summary"]["finding_count"] == 1
+
+    saved_events = workspace.events_path.with_suffix(".saved")
+    workspace.events_path.rename(saved_events)
+    try:
+        cli.main(command)
+        after = json.loads(output.read_text(encoding="utf-8"))
+        assert after["source_quality"]["event_paths"] == []
+        assert after["source_quality"]["status"] == "incomplete"
+        assert after["executive_summary"]["overall_risk"] == "Unknown"
+        assert after["executive_summary"]["finding_count"] == 0
+        markdown = output.with_suffix(".md").read_text(encoding="utf-8")
+        assert f"Event source: {workspace.events_path} (missing)" in markdown
+        assert "does not establish the absence of vulnerabilities" in markdown
+    finally:
+        saved_events.rename(workspace.events_path)
+    cli.main(command)
+    restored = json.loads(output.read_text(encoding="utf-8"))
+    assert restored["source_quality"]["status"] == "complete"
+    assert restored["executive_summary"]["overall_risk"] == "High"
+    assert restored["executive_summary"]["finding_count"] == 1
+
+
+@pytest.mark.parametrize("marker", ["working_state.json", "transcript.jsonl", "scan-summary.json"])
+def test_report_marks_expected_event_log_missing_even_with_a_healthy_audit(
+    tmp_path: Path, marker: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    (workspace.root / marker).write_text("{}\n", encoding="utf-8")
+    audit_path = workspace.root.parent / "audit.db"
+    AuditStore(audit_path).close()
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+    assert report["source_quality"]["audit_source"]["status"] == "available"
+    assert report["source_quality"]["event_sources"][0]["status"] == "missing"
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+@pytest.mark.parametrize("damage", ["directory", "broken_symlink", "utf8", "permission", "race"])
+def test_report_marks_unreadable_or_disappearing_event_sources_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, damage: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    AuditStore(audit_path).close()
+    if damage == "directory":
+        workspace.events_path.mkdir()
+    elif damage == "broken_symlink":
+        workspace.events_path.symlink_to(workspace.root / "absent-events")
+    elif damage == "utf8":
+        workspace.events_path.write_bytes(b"\xff\xfe\n")
+    else:
+        workspace.events_path.touch()
+        read_text = Path.read_text
+
+        def unavailable_events(
+            path: Path, encoding: str | None = None, errors: str | None = None
+        ) -> str:
+            if path == workspace.events_path:
+                error = PermissionError if damage == "permission" else FileNotFoundError
+                raise error
+            return read_text(path, encoding=encoding, errors=errors)
+
+        monkeypatch.setattr(Path, "read_text", unavailable_events)
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+    expected_status = "missing" if damage in {"broken_symlink", "race"} else "unreadable"
+    assert report["source_quality"]["event_sources"][0]["status"] == expected_status
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+def test_report_retains_available_findings_when_a_nested_event_log_is_missing(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    nested = workspace.root / "autonomous-route" / "agent-graph"
+    nested.mkdir(parents=True)
+    (nested / "working_state.json").write_text("{}\n", encoding="utf-8")
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["source_quality"]["event_sources"][-1]["status"] == "missing"
+    assert report["executive_summary"]["finding_count"] == 1
+    assert report["executive_summary"]["overall_risk"] == "High"
+
+
+def test_report_accepts_nested_events_without_an_optional_primary_log(tmp_path: Path) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    nested = AgentWorkspace.open(workspace.root / "autonomous-route" / "agent-graph")
+    nested.record_event(
+        kind="finding_confirmed",
+        payload=_confirmed_finding_payload(
+            finding_id="nested-finding", vuln_class="information_disclosure", severity="High"
+        ),
+    )
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["event_sources"][0]["status"] == "not_requested"
+    assert report["source_quality"]["status"] == "complete"
+    assert report["executive_summary"]["finding_count"] == 1
+
+
+@pytest.mark.parametrize("event_line", ["{broken", "[]"])
+def test_report_does_not_label_malformed_event_sources_clean(
+    tmp_path: Path, event_line: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.events_path.write_text(event_line + "\n", encoding="utf-8")
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["event_parse_errors"] == 1
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+
+
+@pytest.mark.parametrize("invalid_field", ["proof", "engagement_id", "status"])
+def test_report_marks_rejected_confirmed_events_incomplete(
+    tmp_path: Path, invalid_field: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    finding = _confirmed_finding_payload(
+        finding_id="incomplete-event", vuln_class="xss", severity="Medium"
+    )
+    finding.pop(invalid_field)
+    workspace.record_event(kind="finding_confirmed", payload=finding)
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["rejected_confirmed_events"] == 1
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+    assert "Rejected confirmed events: 1" in report_module.render_markdown_report(report)
+
+
+def test_report_excludes_other_engagement_events_without_marking_source_incomplete(
+    tmp_path: Path,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    workspace.record_event(
+        kind="finding_confirmed",
+        payload={"engagement_id": "99999999-9999-4999-8999-999999999999", "status": "confirmed"},
+    )
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+    )
+    assert report["source_quality"]["rejected_confirmed_events"] == 0
+    assert report["source_quality"]["status"] == "complete"
+
+
+@pytest.mark.parametrize(
+    "damage", ["missing_table", "wrong_columns", "malformed_row", "nontext_row"]
+)
+def test_report_marks_damaged_audit_log_incomplete_with_valid_findings_table(
+    tmp_path: Path, damage: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = AgentWorkspace.open(tmp_path / "run" / "workspace")
+    audit_path = workspace.root.parent / "audit.db"
+    _seed_audit_only_proof(audit_path)
+    with closing(sqlite3.connect(audit_path)) as connection:
+        if damage == "malformed_row":
+            connection.execute("UPDATE audit_log SET payload_json = '{broken'")
+        elif damage == "nontext_row":
+            connection.execute("UPDATE audit_log SET payload_json = ?", (b"{}",))
+        else:
+            connection.execute("DROP TABLE audit_log")
+            if damage == "wrong_columns":
+                connection.execute("CREATE TABLE audit_log (id INTEGER)")
+        connection.commit()
+    original_database = audit_path.read_bytes()
+
+    report = build_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        status="completed",
+        completed=True,
+        audit_db_path=audit_path,
+    )
+
+    assert report["source_quality"]["audit_source"]["status"] == "available"
+    assert report["source_quality"]["audit_log_source"]["status"] == (
+        "invalid_records" if damage in {"malformed_row", "nontext_row"} else "unreadable"
+    )
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+    assert audit_path.read_bytes() == original_database
+
+
+def _seed_audit_only_proof(audit_path: Path) -> None:
+    proof = "flag{report-source-health-fixture}"
+    with closing(AuditStore(audit_path)) as audit:
+        for action, payload in (
+            (
+                "tool_run_probe",
+                {
+                    "observation_id": "recorded-observation",
+                    "action_id": "recorded-action",
+                    "recognized_proofs": [proof],
+                },
+            ),
+            (
+                "flag_captured",
+                {
+                    "flag": proof,
+                    "source_observation_id": "recorded-observation",
+                    "source_kind": "tool_run_probe",
+                    "action_id": "recorded-action",
+                },
+            ),
+        ):
+            audit.record(
+                engagement_id=UUID("88888888-8888-4888-8888-888888888888"),
+                actor="report-test",
+                action=action,
+                payload=payload,
+            )
+
+
+@pytest.mark.parametrize("suffix", [".md", ".json", ""])
+def test_explicit_reports_are_private_complete_atomic_and_redact_late_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    output_path = tmp_path / "token=artifact-secret-value" / f"report{suffix}"
+    output_path.parent.mkdir()
+    markdown_path = output_path if suffix != ".json" else output_path.with_suffix(".md")
+    json_path = output_path.with_suffix(".json")
+    for path in (markdown_path, json_path):
+        path.write_text("old complete output", encoding="utf-8")
+        path.chmod(0o644)
+    synced_files: list[str] = []
+    replaced_files: list[Path] = []
+    original_fsync = os.fsync
+    original_replace = Path.replace
+
+    def record_fsync(descriptor: int) -> None:
+        if stat.S_ISREG(os.fstat(descriptor).st_mode):
+            synced_files.append("synced")
+        original_fsync(descriptor)
+
+    def inspect_replace(path: Path, target: Path) -> Path:
+        assert stat.S_IMODE(path.stat().st_mode) == _PRIVATE_ARTIFACT_MODE
+        assert len(synced_files) > len(replaced_files)
+        assert target.read_text(encoding="utf-8") == "old complete output"
+        assert "artifact-secret-value" not in path.read_text(encoding="utf-8")
+        replaced_files.append(target)
+        return original_replace(path, target)
+
+    monkeypatch.setattr(report_io.os, "fsync", record_fsync)
+    monkeypatch.setattr(Path, "replace", inspect_replace)
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+    report = write_pentest_report(
+        brief_path=brief_path,
+        target_url="http://127.0.0.1:8765",
+        workspace_dir=workspace.root,
+        output_path=output_path,
+        status="completed",
+        completed=True,
+    )
+
+    assert replaced_files == [markdown_path, json_path]
+    assert json.loads(json_path.read_text(encoding="utf-8")) == report
+    assert report["artifacts"]["json_report_path"].endswith("token=<SECRET_REDACTED>/report.json")
+    for path in (markdown_path, json_path):
+        assert stat.S_IMODE(path.stat().st_mode) == _PRIVATE_ARTIFACT_MODE
+        assert not list(path.parent.glob(f".{path.name}.*.tmp"))
+
+
+def test_report_write_failure_preserves_existing_output_and_removes_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    output_path = workspace.root.parent / "report.md"
+    output_path.write_text("previous complete report", encoding="utf-8")
+
+    def fail_fsync(_: int) -> None:
+        message = "simulated persistence failure"
+        raise OSError(message)
+
+    monkeypatch.setattr(report_io.os, "fsync", fail_fsync)
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+    with pytest.raises(OSError, match="simulated persistence failure"):
+        write_pentest_report(
+            brief_path=brief_path,
+            target_url="http://127.0.0.1:8765",
+            workspace_dir=workspace.root,
+            output_path=output_path,
+            status="completed",
+            completed=True,
+        )
+
+    assert output_path.read_text(encoding="utf-8") == "previous complete report"
+    assert not list(output_path.parent.glob(f".{output_path.name}.*.tmp"))
 
 
 def test_json_report_artifact_is_private_atomic_and_has_no_report_side_effects(
@@ -164,7 +735,8 @@ def test_json_report_artifact_does_not_promote_stale_manifest_proof_status(
 
     assert report["captured_proofs"]["count"] == 0
     assert report["executive_summary"]["captured_proof_count"] == 0
-    assert report["executive_summary"]["overall_risk"] == "Low"
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+    assert report["source_quality"]["status"] == "incomplete"
     assert report["run"]["flag_found"] is False
     assert report["run"]["manifest_flag_found"] is True
 
@@ -474,7 +1046,7 @@ def test_report_revalidates_scan_lane_attribution_after_resolution(
     monkeypatch.setattr(
         report_module,
         "_agent_http_evidence_summary",
-        lambda *_args, **_kwargs: report_module._empty_agent_http_evidence_summary(),
+        lambda *_args, **_kwargs: report_module._empty_agent_http_evidence_summary(),  # noqa: SLF001
     )
     monkeypatch.setattr(report_module, "resolve_workspaces", resolve_then_tamper)
     output_path = tmp_path / "run" / "tampered-scan-lanes.md"
@@ -1398,6 +1970,190 @@ def test_cli_report_command_writes_report_for_existing_run(
 
     assert output_path.exists()
     assert "report written" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("location", ["run", "workspace", "manifest", "manifest_relative"])
+@pytest.mark.parametrize("workspace_argument", [False, True])
+def test_cli_report_resolves_audit_only_evidence_without_mutating_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+    *,
+    workspace_argument: bool,
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace_dir = tmp_path / "run" / "workspace"
+    workspace_dir.mkdir(parents=True)
+    run_dir = workspace_dir.parent
+    if location == "run":
+        audit_path = run_dir / "audit.db"
+    elif location == "workspace":
+        audit_path = workspace_dir / "audit.db"
+    else:
+        # Literal URI-reserved characters must not hide audit-only captured proofs.
+        audit_path = tmp_path / "custom" / "audit?literal#source.db"
+        if location == "manifest_relative":
+            monkeypatch.chdir(tmp_path)
+            audit_path = audit_path.relative_to(tmp_path)
+        (run_dir / "run.json").write_text(
+            json.dumps({"run_id": "custom-audit", "db_path": str(audit_path)}),
+            encoding="utf-8",
+        )
+        # A healthy default cannot take precedence over the declared source.
+        AuditStore(run_dir / "audit.db").close()
+    _seed_audit_only_proof(audit_path)
+    original_database = audit_path.read_bytes()
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+    output_path = run_dir / "report.json"
+
+    cli.main(
+        [
+            "report",
+            str(workspace_dir if workspace_argument else run_dir),
+            "--brief",
+            str(brief_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["source_quality"]["audit_db_path"] == str(audit_path)
+    assert report["source_quality"]["status"] == "complete"
+    assert report["source_quality"]["audit_log_source"]["status"] == "available"
+    assert report["captured_proofs"]["count"] == 1
+    assert report["outcome"]["stage"] == "flag_captured"
+    assert report["executive_summary"]["overall_risk"] == "High"
+    assert audit_path.read_bytes() == original_database
+
+
+def test_cli_report_does_not_fallback_from_declared_missing_audit_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace_dir = tmp_path / "run" / "workspace"
+    workspace_dir.mkdir(parents=True)
+    run_dir = workspace_dir.parent
+    missing_path = tmp_path / "declared-but-missing.db"
+    (run_dir / "run.json").write_text(
+        json.dumps({"run_id": "missing-audit", "db_path": str(missing_path)}),
+        encoding="utf-8",
+    )
+    _seed_audit_only_proof(run_dir / "audit.db")
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+
+    cli.main(["report", str(run_dir), "--brief", str(brief_path)])
+
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["source_quality"]["audit_db_path"] == str(missing_path)
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["source_quality"]["audit_source"]["status"] == "missing"
+    assert report["captured_proofs"]["count"] == 0
+    assert report["executive_summary"]["overall_risk"] == "Unknown"
+    assert not missing_path.exists()
+
+
+@pytest.mark.parametrize("audit_location", ["run", "workspace"])
+@pytest.mark.parametrize("recorded_absolute", [False, True])
+@pytest.mark.parametrize("source_present", [False, True])
+def test_cli_report_relocates_declared_internal_audit_paths_after_cwd_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    audit_location: str,
+    *,
+    recorded_absolute: bool,
+    source_present: bool,
+) -> None:
+    brief_path = _brief(tmp_path)
+    run_dir = tmp_path / "relocated" / "run"
+    workspace_dir = run_dir / "workspace"
+    workspace_dir.mkdir(parents=True)
+    recorded_workspace = Path("runs/original/workspace")
+    if recorded_absolute:
+        recorded_workspace = tmp_path / "original-cwd" / recorded_workspace
+    recorded_root = (
+        recorded_workspace if audit_location == "workspace" else recorded_workspace.parent
+    )
+    actual_root = workspace_dir if audit_location == "workspace" else run_dir
+    audit_suffix = Path("state/evidence?literal#source.db")
+    audit_path = actual_root / audit_suffix
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": "original",
+                "workspace_dir": str(recorded_workspace),
+                "db_path": str(recorded_root / audit_suffix),
+            }
+        ),
+        encoding="utf-8",
+    )
+    # A default containing proof must never substitute for a declared missing source.
+    _seed_audit_only_proof(run_dir / "audit.db")
+    if source_present:
+        _seed_audit_only_proof(audit_path)
+    other_cwd = tmp_path / "unrelated-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+
+    cli.main(["report", str(run_dir), "--brief", str(brief_path)])
+
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["source_quality"]["audit_db_path"] == str(audit_path)
+    assert report["source_quality"]["status"] == ("complete" if source_present else "incomplete")
+    assert report["captured_proofs"]["count"] == int(source_present)
+    assert audit_path.exists() is source_present
+
+
+def test_cli_report_keeps_missing_external_relative_audit_path_declared(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brief_path = _brief(tmp_path)
+    run_dir = tmp_path / "relocated" / "run"
+    workspace_dir = run_dir / "workspace"
+    workspace_dir.mkdir(parents=True)
+    declared_path = Path("external/custom-audit.db")
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "run_id": "original",
+                "workspace_dir": "runs/original/workspace",
+                "db_path": str(declared_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    _seed_audit_only_proof(run_dir / "audit.db")
+    other_cwd = tmp_path / "unrelated-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+
+    cli.main(["report", str(run_dir), "--brief", str(brief_path)])
+
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["source_quality"]["audit_db_path"] == str(declared_path)
+    assert report["source_quality"]["status"] == "incomplete"
+    assert report["source_quality"]["audit_source"]["status"] == "missing"
+    assert report["captured_proofs"]["count"] == 0
+    assert not declared_path.exists()
+
+
+def test_cli_report_preserves_legitimate_events_only_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    brief_path = _brief(tmp_path)
+    workspace = _workspace_with_report_events(tmp_path)
+    monkeypatch.setattr(report_module, "_run_hosting_layer_report_agent", lambda **_: None)
+
+    cli.main(["report", str(workspace.root), "--brief", str(brief_path)])
+
+    report = json.loads((workspace.root.parent / "report.json").read_text(encoding="utf-8"))
+    assert report["source_quality"]["audit_source"]["status"] == "not_requested"
+    assert report["source_quality"]["audit_log_source"]["status"] == "not_requested"
+    assert report["source_quality"]["status"] == "complete"
+    assert not (workspace.root.parent / "audit.db").exists()
+    assert not (workspace.root / "audit.db").exists()
 
 
 def test_cli_report_pdf_requires_pro_before_rendering(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,38 +1,12 @@
-[project]
-name = "pentest-agent"
-version = "0.5.0"
-description = "Ravage source checkout workspace"
-requires-python = ">=3.12,<3.13"
-dependencies = [
-    "cryptography>=42.0",
-    "pydantic>=2.8",
-    "pyyaml>=6.0",
-    "rich>=14.1",
-]
-license = "Apache-2.0"
-
-[project.optional-dependencies]
-browser = ["playwright>=1.48"]
-
-[project.scripts]
-ravage = "ravage.__main__:main"
-
+# Virtual workspace: build and install the two real packages, never a second
+# root distribution containing duplicate imports or a duplicate ravage command.
 [tool.uv.workspace]
 members = [
     "packages/ravage",
     "packages/schemas",
-    "packages/mcp_servers/*",
 ]
-
-[tool.setuptools.packages.find]
-where = [
-    "packages/ravage/src",
-    "packages/schemas/src",
-]
-include = [
-    "ravage*",
-    "pentest_schemas*",
-]
+# These directories contain unimplemented scaffolds, not supported MCP servers.
+exclude = ["packages/mcp_servers/*"]
 
 [dependency-groups]
 dev = [
@@ -60,7 +34,3 @@ testpaths = [
     "packages/ravage/tests",
     "tests",
 ]
-
-[build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/scripts/eval/eval_proof_bundles.py
+++ b/scripts/eval/eval_proof_bundles.py
@@ -4,93 +4,52 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from ravage.agent_core.ai_agent import ProviderChatClient
-from ravage.model_core.providers import (
-    LOCAL_PROVIDERS,
-    load_model_registry,
-    ready_model_routes,
-    resolve_model_routes,
-)
 from ravage.proof_bundle_eval import (
     evaluate_proof_bundle_cases,
     load_proof_bundle_eval_cases,
     write_proof_bundle_eval_report,
 )
-from ravage.proof_bundle_verifier import verify_proof_bundle_with_model
-
-if TYPE_CHECKING:
-    from pentest_schemas import ProofBundle, ProofVerifierVerdict
-    from ravage.model_core.providers import ResolvedModelRoute
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Evaluate offline proof-bundle JSONL cases.")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Score recorded proof-bundle verdicts against labeled offline JSONL cases. "
+            "This checks fixture consistency; it does not independently verify exploits. "
+            "Exit codes: 0 = all cases pass, 1 = evaluation failures, 2 = invalid/empty input."
+        )
+    )
     parser.add_argument("cases", type=Path)
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--live-verifier", action="store_true")
-    parser.add_argument("--model-config", type=Path)
-    parser.add_argument("--model-profile", default="hosted-openai")
-    parser.add_argument("--model-tier", choices=["high", "mid", "low"], default="high")
-    parser.add_argument("--allow-paid-models", action="store_true")
+    parser.add_argument(
+        "--live-verifier", action="store_true", help="Unavailable legacy option (exits 2)."
+    )
+    parser.add_argument("--model-config", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--model-profile", help=argparse.SUPPRESS)
+    parser.add_argument("--model-tier", choices=["high", "mid", "low"], help=argparse.SUPPRESS)
+    parser.add_argument("--allow-paid-models", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    cases = load_proof_bundle_eval_cases(args.cases)
-    semantic_verifier = None
-    if args.live_verifier:
-        route = _ready_verifier_route(
-            model_config=args.model_config,
-            model_profile=args.model_profile,
-            model_tier=args.model_tier,
-            allow_paid_models=args.allow_paid_models,
-        )
-        model_client = ProviderChatClient()
+    if args.live_verifier or any(
+        (args.model_config, args.model_profile, args.model_tier, args.allow_paid_models)
+    ):
+        parser.error("live model verification is unavailable; use recorded offline verdicts")
 
-        def semantic_verifier(bundle: ProofBundle) -> ProofVerifierVerdict:
-            return verify_proof_bundle_with_model(
-                bundle,
-                model_client=model_client,
-                route=route,
-            )
+    try:
+        cases = load_proof_bundle_eval_cases(args.cases)
+        report = evaluate_proof_bundle_cases(cases)
+        if args.output is not None:
+            write_proof_bundle_eval_report(report, args.output)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"[proof-bundle-eval:invalid] {exc}\n")
+        raise SystemExit(2) from None
 
-    report = evaluate_proof_bundle_cases(cases, semantic_verifier=semantic_verifier)
-    payload = report.to_json()
-    if args.output is not None:
-        write_proof_bundle_eval_report(report, args.output)
-    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-
-
-def _ready_verifier_route(
-    *,
-    model_config: Path | None,
-    model_profile: str,
-    model_tier: str,
-    allow_paid_models: bool,
-) -> ResolvedModelRoute:
-    registry = load_model_registry(model_config)
-    routes = resolve_model_routes(registry, profile_name=model_profile, tier=model_tier)
-    ready_routes = ready_model_routes(routes)
-    if not ready_routes:
-        missing = {env_name for route in routes for env_name in route.missing_env}
-        message = "no ready model routes"
-        if missing:
-            message += "; missing env: " + ", ".join(sorted(missing))
-        raise SystemExit(message)
-    route = ready_routes[0]
-    if not allow_paid_models and _is_paid_route(route):
-        message = (
-            "live verifier route may incur model costs; rerun with --allow-paid-models "
-            "after confirming this is intentional"
-        )
-        raise SystemExit(message)
-    return route
-
-
-def _is_paid_route(route: ResolvedModelRoute) -> bool:
-    if route.provider in LOCAL_PROVIDERS:
-        return False
-    return route.provider not in {"custom_openai", "litellm"}
+    sys.stdout.write(json.dumps(report.to_json(), indent=2, sort_keys=True) + "\n")
+    if not report.total:
+        raise SystemExit(2)
+    if report.failed:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/eval/run_memory_eval.py
+++ b/scripts/eval/run_memory_eval.py
@@ -4,56 +4,38 @@ import argparse
 import sys
 from pathlib import Path
 
-from ravage.benchmark import BenchmarkOverrides
-from ravage.memory import DEFAULT_MEMORY_DB_PATH
-from ravage.memory_eval import run_memory_eval
+from ravage.memory_eval import MemoryEvalUnavailableError, run_memory_eval
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Compare a controlled benchmark with memory off vs memory read."
+        description=(
+            "Retired memory A/B evaluation entry point. Active memory evaluation is "
+            "unavailable; this command exits 2 without running models or writing reports."
+        )
     )
-    parser.add_argument("--benchmark", required=True, type=Path)
-    parser.add_argument("--output-dir", type=Path, default=Path("runs/memory-eval"))
-    parser.add_argument("--memory-db-path", type=Path, default=DEFAULT_MEMORY_DB_PATH)
+    # Keep legacy options parseable so existing invocations get the same clear error.
+    parser.add_argument("--benchmark", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--memory-db-path", type=Path)
     parser.add_argument("--model-config", type=Path)
     parser.add_argument("--model-profile")
     parser.add_argument("--model-tier", choices=["high", "mid", "low"])
     parser.add_argument("--max-turns", type=int)
-    parser.add_argument("--case", action="append", default=[])
+    parser.add_argument("--case", action="append")
     parser.add_argument("--limit", type=int)
     parser.add_argument("--agent-skill", type=Path)
     parser.add_argument("--allow-paid-models", action="store_true")
     parser.add_argument("--max-model-requests", type=int)
     parser.add_argument("--max-cost-usd", type=float)
-    parser.add_argument("--input-token-ceiling-per-model-call", type=int, default=12_000)
-    args = parser.parse_args()
+    parser.add_argument("--input-token-ceiling-per-model-call", type=int)
+    parser.parse_args()
 
-    overrides = BenchmarkOverrides(
-        model_config_path=args.model_config,
-        model_profile=args.model_profile,
-        model_tier=args.model_tier,
-        max_turns=args.max_turns,
-        case_ids=tuple(args.case),
-        case_limit=args.limit,
-        allow_paid_models=args.allow_paid_models,
-        max_model_requests=args.max_model_requests,
-        max_cost_usd=args.max_cost_usd,
-        input_token_ceiling_per_model_call=args.input_token_ceiling_per_model_call,
-        agent_skill_path=args.agent_skill,
-    )
     try:
-        report = run_memory_eval(
-            manifest_path=args.benchmark,
-            output_dir=args.output_dir,
-            memory_db_path=args.memory_db_path,
-            overrides=overrides,
-        )
-    except ValueError as exc:
-        sys.stderr.write(f"[memory-eval:blocked] {exc}\n")
+        run_memory_eval()
+    except MemoryEvalUnavailableError as exc:
+        sys.stderr.write(f"[memory-eval:unavailable] {exc}\n")
         raise SystemExit(2) from None
-    if not report.passed:
-        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/qa/check_clean_install.py
+++ b/scripts/qa/check_clean_install.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import queue
 import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from http import HTTPStatus
 from pathlib import Path
-from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlsplit
+from urllib.request import Request, urlopen
 
 ROOT = Path(__file__).resolve().parents[2]
 _COMMAND_TIMEOUT_SECONDS = 300
@@ -141,9 +144,7 @@ def _run_smoke(work_dir: Path) -> int:
         env=environment,
     )
 
-    sys.stdout.write(
-        "clean install check passed: wheels, CLI, doctor, labs, and cockpit UI\n"
-    )
+    sys.stdout.write("clean install check passed: wheels, CLI, doctor, labs, and cockpit UI\n")
     return 0
 
 
@@ -198,13 +199,19 @@ def _assert_observe_ui(
         text=True,
     )
     try:
-        _wait_for_cockpit(process, port=port)
+        token = _wait_for_cockpit(process, port=port)
+        _assert_private_cockpit_state(port=port, token=token)
         frontend = _read_url(f"http://127.0.0.1:{port}/")
         if b"Ravage Cockpit" not in frontend:
             raise SmokeCheckError("clean `ravage observe` did not serve the cockpit UI")
         javascript = _read_url(f"http://127.0.0.1:{port}/src/main.js")
         if not javascript:
             raise SmokeCheckError("clean `ravage observe` served empty cockpit JavaScript")
+        transport = _read_url(f"http://127.0.0.1:{port}/src/transport.js")
+        if not transport:
+            raise SmokeCheckError(
+                "clean `ravage observe` omitted authenticated transport JavaScript"
+            )
         stylesheet = _read_url(f"http://127.0.0.1:{port}/src/styles.css")
         if not stylesheet:
             raise SmokeCheckError("clean `ravage observe` served empty cockpit CSS")
@@ -221,31 +228,61 @@ def _available_loopback_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def _wait_for_cockpit(process: subprocess.Popen[str], *, port: int) -> None:
+def _wait_for_cockpit(process: subprocess.Popen[str], *, port: int) -> str:
     deadline = time.monotonic() + 10
-    url = f"http://127.0.0.1:{port}/api/state"
+    output: queue.Queue[str] = queue.Queue()
+
+    def read_output() -> None:
+        if process.stdout is not None:
+            for line in process.stdout:
+                output.put(line)
+
+    threading.Thread(target=read_output, daemon=True).start()
     while time.monotonic() < deadline:
         returncode = process.poll()
         if returncode is not None:
-            stdout, stderr = process.communicate()
-            detail = "\n".join(part for part in (stdout, stderr) if part).strip()
+            detail = process.stderr.read().strip() if process.stderr is not None else ""
             raise SmokeCheckError(
                 f"clean `ravage observe` exited before serving (exit {returncode}): {detail}"
             )
         try:
-            _read_url(url)
-        except URLError:
-            time.sleep(0.05)
+            line = output.get(timeout=0.05)
+        except queue.Empty:
             continue
-        return
+        _, marker, suffix = line.partition("http://")
+        if not marker:
+            continue
+        parsed = urlsplit(marker + suffix.strip())
+        tokens = parse_qs(parsed.fragment).get("token", [])
+        if parsed.hostname == "127.0.0.1" and parsed.port == port and tokens and not parsed.query:
+            return tokens[0]
     raise SmokeCheckError("clean `ravage observe` did not start within 10 seconds")
 
 
-def _read_url(url: str) -> bytes:
-    with urlopen(url, timeout=2) as response:  # noqa: S310 - fixed loopback smoke target.
+def _assert_private_cockpit_state(*, port: int, token: str) -> None:
+    url = f"http://127.0.0.1:{port}/api/state"
+    try:
+        _read_url(url)
+    except HTTPError as exc:
+        if exc.code != HTTPStatus.UNAUTHORIZED:
+            raise SmokeCheckError(
+                "clean cockpit did not deny unauthenticated state correctly"
+            ) from exc
+    else:
+        raise SmokeCheckError("clean cockpit exposed state without authentication")
+    state = json.loads(_read_url(url, token=token))
+    if state.get("schema") != "ravage.live_dashboard.v1":
+        raise SmokeCheckError("clean cockpit did not serve authenticated dashboard state")
+
+
+def _read_url(url: str, *, token: str = "") -> bytes:
+    request = Request(  # noqa: S310 - fixed loopback smoke target.
+        url, headers={"Authorization": f"Bearer {token}"} if token else {}
+    )
+    with urlopen(request, timeout=2) as response:  # noqa: S310 - fixed loopback smoke target.
         if response.status != HTTPStatus.OK:
             raise SmokeCheckError(f"clean cockpit returned HTTP {response.status} for {url}")
-        return response.read()
+        return bytes(response.read())
 
 
 def _stop_process(process: subprocess.Popen[str]) -> None:

--- a/scripts/qa/check_clean_install.py
+++ b/scripts/qa/check_clean_install.py
@@ -96,6 +96,7 @@ def _run_smoke(work_dir: Path) -> int:
         clean_python,
         "-c",
         _BASE_INSTALL_ASSERTIONS,
+        cwd=work_dir,
         env=environment,
     )
     help_result = _run(clean_ravage, "--help", env=environment, capture=True)
@@ -354,7 +355,7 @@ class SmokeCheckError(RuntimeError):
 
 
 _BASE_INSTALL_ASSERTIONS = """
-from importlib.metadata import requires
+from importlib.metadata import distributions, requires
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -367,6 +368,18 @@ playwright_requirements = [
 assert playwright_requirements, "ravage wheel omitted its browser extra metadata"
 assert all("extra == 'browser'" in item for item in playwright_requirements)
 assert "site-packages" in str(Path(ravage.__file__).resolve())
+installed = {dist.metadata["Name"].lower().replace("_", "-"): dist for dist in distributions()}
+assert "pentest-agent" not in installed, "retired pentest-agent distribution was installed"
+assert not any(name.endswith("-mcp") for name in installed), (
+    "MCP scaffold distribution was installed"
+)
+entrypoints = [
+    (name, entrypoint.value)
+    for name, dist in installed.items()
+    for entrypoint in dist.entry_points
+    if entrypoint.group == "console_scripts" and entrypoint.name == "ravage"
+]
+assert entrypoints == [("ravage", "ravage.__main__:main")], entrypoints
 """
 
 

--- a/scripts/qa/check_release.py
+++ b/scripts/qa/check_release.py
@@ -30,7 +30,8 @@ CITATION_FILE = ROOT / "CITATION.cff"
 RELEASE_MANIFEST = ROOT / "tools/release/.release-please-manifest.json"
 LOCK_FILE = ROOT / "uv.lock"
 CHANGELOG_FILE = ROOT / "CHANGELOG.md"
-WORKSPACE_PROJECTS = ("pentest-agent", "ravage", "ravage-schemas")
+WORKSPACE_PROJECTS = ("ravage", "ravage-schemas")
+WORKSPACE_PATHS = {"ravage": "packages/ravage", "ravage-schemas": "packages/schemas"}
 
 
 def main() -> int:
@@ -68,6 +69,7 @@ def main() -> int:
         )
 
     expected = next(iter(versions.values()))
+    errors.extend(_workspace_configuration_errors())
     errors.extend(_workspace_version_errors(expected))
     errors.extend(_release_ref_errors(expected, os.environ))
     errors.extend(_release_changelog_errors(expected, os.environ))
@@ -83,8 +85,6 @@ def main() -> int:
 
 def _workspace_version_errors(expected: str) -> list[str]:
     declared: dict[str, str] = {}
-    root_project = tomllib.loads(ROOT_PYPROJECT.read_text(encoding="utf-8"))["project"]
-    declared[str(root_project["name"])] = str(root_project["version"])
 
     manifest = json.loads(RELEASE_MANIFEST.read_text(encoding="utf-8"))
     manifest_version = manifest.get(".") if isinstance(manifest, dict) else None
@@ -112,6 +112,31 @@ def _workspace_version_errors(expected: str) -> list[str]:
         for source, version in declared.items()
         if version != expected
     ]
+
+
+def _workspace_configuration_errors() -> list[str]:
+    errors: list[str] = []
+    root_config = tomllib.loads(ROOT_PYPROJECT.read_text(encoding="utf-8"))
+    if "project" in root_config or "build-system" in root_config:
+        errors.append("root pyproject.toml must remain a virtual, non-distributable workspace")
+    workspace = root_config.get("tool", {}).get("uv", {}).get("workspace", {})
+    if set(workspace.get("members", [])) != set(WORKSPACE_PATHS.values()):
+        errors.append("workspace members must contain only packages/ravage and packages/schemas")
+    if "packages/mcp_servers/*" not in workspace.get("exclude", []):
+        errors.append("unimplemented MCP scaffolds must be excluded from the UV workspace")
+
+    lock = tomllib.loads(LOCK_FILE.read_text(encoding="utf-8"))
+    if set(lock.get("manifest", {}).get("members", [])) != set(WORKSPACE_PROJECTS):
+        errors.append("uv.lock manifest must contain only ravage and ravage-schemas")
+    workspace_sources = {
+        item["name"]: item["source"]
+        for item in lock.get("package", [])
+        if "editable" in item.get("source", {}) or "virtual" in item.get("source", {})
+    }
+    expected_sources = {name: {"editable": path} for name, path in WORKSPACE_PATHS.items()}
+    if workspace_sources != expected_sources:
+        errors.append("uv.lock must install only the two real workspace packages")
+    return errors
 
 
 def _release_ref_errors(expected_version: str, environ: Mapping[str, str]) -> list[str]:

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -152,11 +152,6 @@ def test_workspace_version_check_rejects_stale_manifest(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    root_pyproject = tmp_path / "pyproject.toml"
-    root_pyproject.write_text(
-        '[project]\nname = "pentest-agent"\nversion = "0.6.0"\n',
-        encoding="utf-8",
-    )
     citation = tmp_path / "CITATION.cff"
     citation.write_text("version: 0.6.0\n", encoding="utf-8")
     manifest = tmp_path / "manifest.json"
@@ -164,9 +159,6 @@ def test_workspace_version_check_rejects_stale_manifest(
     lock = tmp_path / "uv.lock"
     lock.write_text(
         """
-[[package]]
-name = "pentest-agent"
-version = "0.6.0"
 [[package]]
 name = "ravage"
 version = "0.6.0"
@@ -176,11 +168,54 @@ version = "0.6.0"
 """.lstrip(),
         encoding="utf-8",
     )
-    monkeypatch.setattr(check_release, "ROOT_PYPROJECT", root_pyproject)
     monkeypatch.setattr(check_release, "CITATION_FILE", citation)
     monkeypatch.setattr(check_release, "RELEASE_MANIFEST", manifest)
     monkeypatch.setattr(check_release, "LOCK_FILE", lock)
 
     assert check_release._workspace_version_errors("0.6.0") == [  # noqa: SLF001
         "release-please manifest version '0.5.0' does not match package version '0.6.0'"
+    ]
+
+
+def test_workspace_configuration_rejects_a_duplicate_root_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        check_release.ROOT_PYPROJECT.read_text(encoding="utf-8")
+        + '\n[project]\nname = "pentest-agent"\nversion = "0.5.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_release, "ROOT_PYPROJECT", root_pyproject)
+
+    assert check_release._workspace_configuration_errors() == [  # noqa: SLF001
+        "root pyproject.toml must remain a virtual, non-distributable workspace"
+    ]
+
+
+def test_workspace_configuration_rejects_active_mcp_scaffolds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root_pyproject = tmp_path / "pyproject.toml"
+    root_pyproject.write_text(
+        check_release.ROOT_PYPROJECT.read_text(encoding="utf-8").replace(
+            'exclude = ["packages/mcp_servers/*"]', "exclude = []"
+        ),
+        encoding="utf-8",
+    )
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        check_release.LOCK_FILE.read_text(encoding="utf-8")
+        + '\n[[package]]\nname = "ffuf-mcp"\nversion = "0.1.0"\n'
+        'source = { editable = "packages/mcp_servers/ffuf_mcp" }\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_release, "ROOT_PYPROJECT", root_pyproject)
+    monkeypatch.setattr(check_release, "LOCK_FILE", lock)
+
+    assert check_release._workspace_configuration_errors() == [  # noqa: SLF001
+        "unimplemented MCP scaffolds must be excluded from the UV workspace",
+        "uv.lock must install only the two real workspace packages",
     ]

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -8,7 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github/workflows"
 FULL_COMMIT_SHA = re.compile(r"[0-9a-f]{40}")
 ACTION_USE = re.compile(r"^\s*uses:\s*([^\s#]+)", re.MULTILINE)
-RELEASE_WORKFLOWS = (
+PINNED_ACTION_WORKFLOWS = (
+    "ci.yml",
+    "docs-pages.yml",
     "publish-kali-image.yml",
     "publish-pypi.yml",
     "publish-testpypi.yml",
@@ -33,9 +35,9 @@ def _job(workflow: str, name: str, *, next_name: str | None = None) -> str:
     return section
 
 
-def test_release_workflow_actions_are_pinned_to_full_commit_shas() -> None:
+def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
     failures: list[str] = []
-    for name in RELEASE_WORKFLOWS:
+    for name in PINNED_ACTION_WORKFLOWS:
         for action in ACTION_USE.findall(_workflow(name)):
             if action.startswith("./"):
                 continue

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -158,6 +158,7 @@ def test_release_please_updates_the_ravage_version_and_schema_pin_together() -> 
     config = json.loads(config_path.read_text(encoding="utf-8"))
     assert re.fullmatch(r"[0-9a-f]{40}", config["bootstrap-sha"])
     extra_files = config["packages"]["."]["extra-files"]
+    assert "pyproject.toml" not in {item["path"] for item in extra_files}
     generic_paths = {
         item["path"] for item in extra_files if item.get("type") == "generic"
     }

--- a/tools/release/release-please-config.json
+++ b/tools/release/release-please-config.json
@@ -9,11 +9,6 @@
       "extra-files": [
         {
           "type": "toml",
-          "path": "pyproject.toml",
-          "jsonpath": "$.project.version"
-        },
-        {
-          "type": "toml",
           "path": "packages/schemas/pyproject.toml",
           "jsonpath": "$.project.version"
         },

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,19 @@ requires-python = "==3.12.*"
 
 [manifest]
 members = [
-    "ffuf-mcp",
-    "httpx-mcp",
-    "katana-mcp",
-    "nuclei-mcp",
-    "pentest-agent",
     "ravage",
     "ravage-schemas",
-    "sqlmap-mcp",
+]
+
+[manifest.dependency-groups]
+dev = [
+    { name = "cryptography", specifier = ">=42.0" },
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pydantic", specifier = ">=2.8" },
+    { name = "pytest", specifier = ">=8.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", specifier = ">=0.5" },
 ]
 
 [[package]]
@@ -21,19 +26,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -61,24 +53,6 @@ wheels = [
 ]
 
 [[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2026.5.20"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
-]
-
-[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -99,18 +73,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
     { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
     { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -162,21 +124,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffuf-mcp"
-version = "0.1.0"
-source = { editable = "packages/mcp_servers/ffuf_mcp" }
-dependencies = [
-    { name = "mcp" },
-    { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mcp", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.8" },
-]
-
-[[package]]
 name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -195,126 +142,12 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-mcp"
-version = "0.1.0"
-source = { editable = "packages/mcp_servers/httpx_mcp" }
-dependencies = [
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.8" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jsonschema"
-version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
-]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "katana-mcp"
-version = "0.1.0"
-source = { editable = "packages/mcp_servers/katana_mcp" }
-dependencies = [
-    { name = "mcp" },
-    { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mcp", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.8" },
 ]
 
 [[package]]
@@ -348,31 +181,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
-]
-
-[[package]]
-name = "mcp"
-version = "1.27.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -417,21 +225,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nuclei-mcp"
-version = "0.1.0"
-source = { editable = "packages/mcp_servers/nuclei_mcp" }
-dependencies = [
-    { name = "mcp" },
-    { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mcp", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.8" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -447,54 +240,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
-]
-
-[[package]]
-name = "pentest-agent"
-version = "0.5.0"
-source = { editable = "." }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "rich" },
-]
-
-[package.optional-dependencies]
-browser = [
-    { name = "playwright" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "cryptography" },
-    { name = "mypy" },
-    { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pyyaml" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "cryptography", specifier = ">=42.0" },
-    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.48" },
-    { name = "pydantic", specifier = ">=2.8" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=14.1" },
-]
-provides-extras = ["browser"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "cryptography", specifier = ">=42.0" },
-    { name = "mypy", specifier = ">=1.10" },
-    { name = "pydantic", specifier = ">=2.8" },
-    { name = "pytest", specifier = ">=8.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", specifier = ">=0.5" },
 ]
 
 [[package]]
@@ -580,20 +325,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
-]
-
-[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -612,20 +343,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyjwt"
-version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
-]
-
-[package.optional-dependencies]
-crypto = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -655,34 +372,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-multipart"
-version = "0.0.29"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
 ]
 
 [[package]]
@@ -741,20 +430,6 @@ dependencies = [
 requires-dist = [{ name = "pydantic", specifier = ">=2.8" }]
 
 [[package]]
-name = "referencing"
-version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
-]
-
-[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -765,29 +440,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rpds-py"
-version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
-    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
-    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
-    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
 ]
 
 [[package]]
@@ -816,47 +468,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlmap-mcp"
-version = "0.1.0"
-source = { editable = "packages/mcp_servers/sqlmap_mcp" }
-dependencies = [
-    { name = "mcp" },
-    { name = "pydantic" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mcp", specifier = ">=1.0" },
-    { name = "pydantic", specifier = ">=2.8" },
-]
-
-[[package]]
-name = "sse-starlette"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
-]
-
-[[package]]
-name = "starlette"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -875,17 +486,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "uvicorn"
-version = "0.47.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]


### PR DESCRIPTION
Fixes unauthenticated cockpit access and prevents missing evidence from appearing as a clean report.

- Protect cockpit data and actions with authentication, and fix Firefox login.
- Mark reports incomplete when evidence is missing and save report files safely.
- Remove fabricated memory-evaluation scores and reject invalid evaluation inputs.
- Clean up packaging and update tests, documentation, and CI.
